### PR TITLE
Getting all available requesters

### DIFF
--- a/mephisto/client/api.py
+++ b/mephisto/client/api.py
@@ -4,6 +4,13 @@ from mephisto.core.local_database import LocalMephistoDB
 from mephisto.data_model.database import EntryAlreadyExistsException
 
 api = Blueprint("api", __name__)
+db = LocalMephistoDB()
+
+@api.route("/requesters/")
+def get_available_requesters():
+    requesters = db.find_requesters()
+    dict_requesters = [r.to_dict() for r in requesters]
+    return jsonify({'requesters': dict_requesters})
 
 
 @api.route("/requester/<type>")
@@ -19,7 +26,6 @@ def register(type):
     options = request.form.to_dict()
     crowd_provider = get_crowd_provider_from_type(type)
     RequesterClass = crowd_provider.RequesterClass
-    db = LocalMephistoDB()
 
     if 'name' not in options:
         return jsonify({'success': False, 'msg': 'No name was specified for the requester.'})
@@ -41,7 +47,6 @@ def register(type):
 
 @api.route("/<string:requester_name>/get_balance")
 def get_balance(requester_name):
-    db = LocalMephistoDB()
     requesters = db.find_requesters(requester_name=requester_name)
 
     if len(requesters) == 0:

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod, abstractstaticmethod
 from mephisto.core.utils import get_crowd_provider_from_type
 
-from typing import List, Optional, Dict, TYPE_CHECKING
+from typing import List, Optional, Dict, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mephisto.data_model.database import MephistoDB
@@ -87,6 +87,10 @@ class Requester(ABC):
         """
         raise NotImplementedError()
 
+    def is_registered(self) -> bool:
+        """Check to see if this requester has already been registered"""
+        raise NotImplementedError()
+
     @staticmethod
     def get_register_args() -> Dict[str, str]:
         """
@@ -106,6 +110,17 @@ class Requester(ABC):
         its crowdsourcing vendor
         """
         raise NotImplementedError()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Produce a dict of this requester and important features for json serialization
+        """
+        return {
+            'requester_id': self.db_id,
+            'provider_type': self.provider_type,
+            'requester_name': self.requester_name,
+            'registered': self.is_registered(),
+        }
 
     # TODO add a way to manage creation and validation of qualifications
     # for a given requester?

--- a/mephisto/data_model/test/crowd_provider_tester.py
+++ b/mephisto/data_model/test/crowd_provider_tester.py
@@ -126,8 +126,13 @@ class CrowdProviderTests(unittest.TestCase):
             test_requester_2.requester_name,
             "Requester gotten from db not same as first init",
         )
+
         # Ensure credential registration works
+        # TODO ensure registration fails when we programatically login to an account
+        # in the future
+        # self.assertFalse(test_requester.is_registered())
         test_requester.register()
+        self.assertTrue(test_requester.is_registered())
 
         # Ensure requester methods work
         avail_budget = test_requester.get_available_budget()

--- a/mephisto/providers/mock/mock_requester.py
+++ b/mephisto/providers/mock/mock_requester.py
@@ -27,10 +27,15 @@ class MockRequester(Requester):
         super().__init__(db, db_id)
         # TODO any additional init as is necessary once
         # a mock DB exists
+        registered = False
 
     def register_credentials(self) -> None:
         """Mock requesters don't actually register credentials"""
-        pass
+        self.registered = True
+
+    def is_registered(self) -> bool:
+        """Return the registration status"""
+        return self.registered
 
     def get_available_budget(self) -> float:
         """MockRequesters have $100000 to spend"""

--- a/mephisto/providers/mturk/mturk_requester.py
+++ b/mephisto/providers/mturk/mturk_requester.py
@@ -8,6 +8,7 @@ from mephisto.data_model.requester import Requester
 from mephisto.providers.mturk.mturk_utils import (
     setup_aws_credentials,
     get_requester_balance,
+    check_aws_credentials,
 )
 from mephisto.providers.mturk.provider_type import PROVIDER_TYPE
 
@@ -56,6 +57,10 @@ class MTurkRequester(Requester):
         to assert it as such.
         """
         setup_aws_credentials(self._requester_name, args)
+
+    def is_registered(self) -> bool:
+        """Return whether or not this requester has registered yet"""
+        return check_aws_credentials(self._requester_name)
 
     @staticmethod
     def get_register_args() -> Dict[str, str]:

--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -36,6 +36,15 @@ def client_is_sandbox(client: MTurkClient) -> bool:
     return client.endpoint_url == SANDBOX_ENDPOINT
 
 
+def check_aws_credentials(profile_name: str) -> bool:
+    try:
+        # Check existing credentials
+        boto3.Session(profile_name=profile_name)
+        return True
+    except ProfileNotFound:
+        return False
+
+
 def setup_aws_credentials(
     profile_name: str, register_args: Optional[Dict[str, str]] = None
 ) -> bool:


### PR DESCRIPTION
For usage in wiring the first step of the process, ensuring that the user has at least one MTurk account setup. 

Testing:
```
>> {{ base_url  }}/requesters/
{
  "requesters": [
    {
      "provider_type": "mturk",
      "registered": true,
      "requester_id": "1",
      "requester_name": "<accountName>"
    },
    {
      "provider_type": "mturk",
      "registered": true,
      "requester_id": "2",
      "requester_name": '<otherAccountName>"
    },
    {
      "provider_type": "mturk_sandbox",
      "registered": true,
      "requester_id": "3",
      "requester_name": "<accountName>_sandbox"
    }
  ]
}
```

As an aside, I should probably tie the creation of an MTurk sandbox profile to the creation of an MTurk account, will do in another PR.