### PR TITLE
Implementing static tasks, loading directly from MTurk HTML!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ data/*
 mephisto.egg-info/*
 .DS_Store
 tmp/*
+**/node_modules/*
+mephisto/server/**/package-lock.json
+mephisto/server/blueprints/**/build/*
+
+# temporary files for inspiration from ParlAI-MTurk
+old_code/*
+mephisto/server/architects/router_old/*

--- a/mephisto/core/utils.py
+++ b/mephisto/core/utils.py
@@ -112,6 +112,10 @@ def get_blueprint_from_type(task_type: str) -> Type["TaskRunner"]:
         from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprint
 
         return MockBlueprint
+    if task_type == "static":
+        from mephisto.server.blueprints.static_task.static_blueprint import StaticBlueprint
+
+        return StaticBlueprint
     raise NotImplementedError()
 
 

--- a/mephisto/server/architects/heroku_architect.py
+++ b/mephisto/server/architects/heroku_architect.py
@@ -65,9 +65,6 @@ class HerokuArchitect(Architect):
         self.tmp_dir = os.path.join(get_mephisto_tmp_dir(), 'heroku')
         if not os.path.exists(self.tmp_dir):
             os.makedirs(self.tmp_dir)
-        TaskBuilderClass = task_run.get_blueprint().TaskBuilderClass
-        # TODO pull options from the current set options for this run?
-        self.task_builder = TaskBuilderClass(self.task_run, {})
 
         # Cache-able parameters
         self.__heroku_app_name: Optional[str] = None
@@ -215,7 +212,6 @@ class HerokuArchitect(Architect):
         heroku_server_development_root = self.__get_build_directory()
         os.makedirs(heroku_server_development_root)
         heroku_server_development_path = build_router(heroku_server_development_root, self.task_run)
-        self.task_builder.build_in_dir(heroku_server_development_path)
         return heroku_server_development_path
 
     def __setup_heroku_server(self) -> str:
@@ -227,7 +223,6 @@ class HerokuArchitect(Architect):
         server_dir = self.__get_build_directory()
 
         print("Heroku: Starting server...")
-
 
         heroku_server_directory_path = os.path.join(server_dir, "router")
         sh.git(shlex.split(f"-C {heroku_server_directory_path} init"))

--- a/mephisto/server/architects/local_architect.py
+++ b/mephisto/server/architects/local_architect.py
@@ -71,17 +71,11 @@ class LocalArchitect(Architect):
 
         shutil.copytree(self.server_dir, self.running_dir)
 
+        return_dir = os.getcwd()
         os.chdir(self.running_dir)
-
-        packages_installed = subprocess.call(['npm', 'install'])
-        if packages_installed != 0:
-            raise Exception(
-                'please make sure npm is installed, otherwise view '
-                'the above error for more info.'
-            )
-
         self.server_process = subprocess.Popen(['node', 'server.js'], preexec_fn=os.setpgrp)
         self.server_process_pid = self.server_process.pid
+        os.chdir(return_dir)
 
         time.sleep(1)
         print('Server running locally with pid {}.'.format(self.server_process_pid))

--- a/mephisto/server/architects/router/deploy/server.js
+++ b/mephisto/server/architects/router/deploy/server.js
@@ -7,7 +7,7 @@
 const bodyParser = require('body-parser');
 const express = require('express');
 const http = require('http');
-const nunjucks = require('nunjucks');
+const fs = require('fs');
 
 const task_directory_name = 'static';
 
@@ -23,15 +23,26 @@ app.use(
 );
 app.use(bodyParser.json());
 
-nunjucks.configure(task_directory_name, {
-  autoescape: true,
-  express: app,
-});
-
 const server = http.createServer(app);
 
 server.listen(PORT, function() {
   console.log('Listening on %d', server.address().port);
+});
+
+// ===================== <Routing> ========================
+app.get('/initial_task_data', function(req, res) {
+  var params = req.query;
+  var worker_id = params['worker_id']
+  var assignment_id = params['assignment_id']
+  var html_content = fs.readFileSync(task_directory_name + '/task.html', "utf8");
+  // TODO hit the backend to get the actual assignment and worker
+  // as registered
+  var response_data = {
+    worker_id: worker_id,
+    assignment_id: assignment_id,
+    html: html_content,
+  }
+  res.json(response_data)
 });
 
 // Quick status check for this server
@@ -42,6 +53,11 @@ app.get('/is_alive', function(req, res) {
 // Returns server time for now
 app.get('/get_timestamp', function(req, res) {
   res.json({ timestamp: Date.now() }); // in milliseconds
+});
+
+app.get('/task_index', function(req, res) {
+  // TODO how do we pass the task config to the frontend?
+  res.render('index.html');
 });
 
 app.use(express.static('static'));

--- a/mephisto/server/architects/router/deploy/static/index.html
+++ b/mephisto/server/architects/router/deploy/static/index.html
@@ -1,0 +1,25 @@
+<!--
+
+Copyright 2017-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the license found in the
+LICENSE file in the root directory of this source tree.
+
+-->
+
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Crowdsourcing Task</title>
+    <script src="wrap_crowd_source.js"></script>
+  </head>
+
+  <body>
+    <noscript>JS is required</noscript>
+    <div id="app" style="overflow: hidden"></div>
+    <script src="bundle.js"></script>
+  </body>
+</html>

--- a/mephisto/server/architects/router/deploy/static/wrap_crowd_source.js
+++ b/mephisto/server/architects/router/deploy/static/wrap_crowd_source.js
@@ -1,0 +1,46 @@
+/* Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+/* -------- wrap_crowd_source.js ---------\
+This file comprises the functions required to interface between
+a crowd provider's frontend and the crowd provider backend.
+
+At a high level this involves getting the worker identifier and
+assignment identifiers, and packaging any required information
+for both to be able to register them with the backend database.
+
+Returning None for the assignment_id means that the task is being
+previewed by the given worker.
+\------------------------------------------*/
+
+// TODO standardize this file, make one for every crowd provider
+
+function getWorkerId() {
+    // Mock worker id is passed via url params
+    urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('worker_id');
+}
+
+function getAssignmentId() {
+    // mock assignment id is passed via url params
+    urlParams = new URLSearchParams(window.location.search);
+    return urlParams.get('assignment_id');
+}
+
+function getWorkerRegistrationInfo() {
+    // mock workers have no special registration
+    return {};
+}
+
+function getAgentRegistration() {
+    // Mock agents are created just using worker_id and assignment_id
+    return {};
+}
+
+function handleSubmitToProvider(worker_id, assignment_id, task_data) {
+    // Mock agents won't ever submit to a real provider
+    return True;
+}

--- a/mephisto/server/blueprints/static_task/__init__.py
+++ b/mephisto/server/blueprints/static_task/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/mephisto/server/blueprints/static_task/html_sources/task.html
+++ b/mephisto/server/blueprints/static_task/html_sources/task.html
@@ -1,0 +1,80 @@
+<!-- Bootstrap v3.0.3 -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script><!-- Modal --><!-- MODAL -->
+<div aria-hidden="true" aria-labelledby="exampleModalLabel" class="modal fade in" id="exampleModal" role="dialog" tabindex="-1">
+<div class="modal-dialog" role="document">
+<div class="modal-content">
+<div class="modal-header"><button aria-label="Close" class="close" data-dismiss="modal" type="button"><span aria-hidden="true">&times;</span></button></div>
+
+<div class="modal-body" id="modal">&nbsp;</div>
+
+<div class="modal-footer"><button class="btn btn-secondary" data-dismiss="modal" type="button">Close</button></div>
+</div>
+</div>
+</div>
+<!-- Content -->
+
+<section class="container" id="Other" style="margin-bottom: 15px; padding: 10px; font-family: Verdana, Geneva, sans-serif; font-size: 0.9em;">
+<div class="row col-xs-12 col-md-12" style=""><!-- Instructions -->
+<div class="panel panel-primary" style="">
+<div class="panel-heading"><strong>Instructions</strong></div>
+
+<div class="panel-body" id="instructions">
+<p>Below you are given a character name and description for someone from a fantasy story. Please label what gender the character is. <br/> Below are some examples: </p>
+
+<ul>
+	<li>brave soldier - I fight to defend my honor. I will keep my village safe from any threat. It is my duty to protect my beloved wife. &nbsp; -<em> either </em> (the character doesn't explicitly state they are a man or a woman)</li>
+	<li>noble - I am the daughter of a great warrior. My family name carries a lot of weight where I live, so I'm accepted amongst nobility.  &nbsp; - <em>female</em> (the character is the daughter of someone, and thus a female)</li>
+	<li>prince - I cannot stand being part of royalty. I long to adventure at sea. My father would never allow it though. &nbsp;- <em>male</em> (the character is a prince, thus a male)</li>
+	<li>farmer - I heave hay around all day. Men like me don't have many other opportunities here. Still, I'd like to be a painter. &nbsp;- <em>male</em> (the character describes themself as a male)</li>
+</ul>
+
+</div>
+</div>
+<!-- End Instructions --><!-- Content Body -->
+
+<div class="input_location">
+<p><strong>Character name:</strong> <span id="char">${worker_id}</span></p>
+<p><strong>Description:</strong> <span id="persona">${assignment_id}</span></p>
+</div>
+
+<section>
+<fieldset>
+<div class="input-group">
+    <label>1. What gender is this character?</label>
+    <select class="form-control" name="gender">
+        <option selected="selected" value="">(select one)</option>
+        <option value="female">Female</option>
+        <option value="male">Male</option>
+        <option value="either">Either</option></select>
+</div>
+</fieldset>
+
+</section>
+<!-- End Content Body --></div>
+</section>
+<script>
+
+$(function()
+{
+    modal_body = $("#modal");
+    $("#instructions").clone().appendTo(modal_body);
+    $('.modal').modal('show');
+});
+</script>
+
+
+</script><!-- close container -->
+<style type="text/css">fieldset {
+    padding: 10px;
+    background:#fbfbfb;
+    border-radius:5px;
+    margin-bottom:5px;
+}
+
+.input_location {
+  background-color: blanchedalmond;
+  padding: 10px;
+}
+</style>

--- a/mephisto/server/blueprints/static_task/source/.babelrc
+++ b/mephisto/server/blueprints/static_task/source/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["@babel/env", "@babel/preset-react"],
+  "plugins": ["@babel/plugin-proposal-class-properties"]
+}

--- a/mephisto/server/blueprints/static_task/source/dev/app.jsx
+++ b/mephisto/server/blueprints/static_task/source/dev/app.jsx
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Bowser from 'bowser';
+import {Button} from 'react-bootstrap';
+
+/* global
+  getWorkerId, getAssignmentId, getWorkerRegistrationInfo,
+  getAgentRegistration, handleSubmitToProvider
+*/
+
+/* ================= Utility functions ================= */
+
+// Determine if the browser is a mobile phone
+function isMobile() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+}
+
+function clickDone(worker_id, assignment_id, task_data) {
+  // At the moment this function simply calls the submit method,
+  // will later also have to talk to the server and maybe do validation
+  // TODO validate entry
+  // TODO talk to the server
+  handleSubmitToProvider(worker_id, assignment_id, task_data);
+}
+
+// Sends a request to get the initial task data
+function getInitTaskData(worker_id, assignment_id, callback_function) {
+  var url = new URL(window.location.origin + '/initial_task_data')
+  var params = {'worker_id': worker_id, 'assignment_id': assignment_id};
+  Object.keys(params).forEach(key => url.searchParams.append(key, params[key]))
+  fetch(url)
+    .then(res => res.json())
+    .then(function(data) {
+    if (callback_function) {
+      callback_function(data);
+    }
+  });
+}
+
+/* ================= Application Components ================= */
+
+class MainApp extends React.Component {
+  constructor(props) {
+    super(props);
+
+    let worker_id = getWorkerId();
+    let assignment_id = getAssignmentId();
+    let render_html = "<h1>Display Preview Here</h1>";
+    if (worker_id !== null && assignment_id !== null) {
+      render_html =  "<h1>Loading...</h1>";
+    }
+
+    this.state = {
+      base_html: null,
+      render_html: render_html,
+      worker_id: worker_id,
+      assignment_id: assignment_id,
+      task_data: null,
+    };
+
+    this.raw_html_elem = null;
+  }
+
+  handleIncomingTaskData(data) {
+    let base_html = data['html'];
+    let fin_html = base_html;
+    delete data['html'];
+    let task_data = data;
+
+    for (let [key, value] of Object.entries(task_data)) {
+      let find_string = "${" + key + "}";
+      fin_html = fin_html.replace(find_string, value);
+    }
+
+    this.setState({
+      base_html: base_html,
+      render_html: fin_html,
+      task_data: task_data,
+    });
+  }
+
+  componentDidMount() {
+    let worker_id = this.state.worker_id;
+    let assignment_id = this.state.assignment_id;
+    if (assignment_id != null && worker_id != null) {
+      getInitTaskData(worker_id, assignment_id, data => this.handleIncomingTaskData(data));
+    }
+  }
+
+  render() {
+    let worker_id = this.state.worker_id;
+    let assignment_id = this.state.assignment_id;
+    let task_data = this.state.task_data;
+    let dangerous_html = <div
+      ref={elem => {this.raw_html_elem = elem}}
+      dangerouslySetInnerHTML={{__html: this.state.render_html}}
+    />;
+    return (
+      <div>
+        {dangerous_html}
+        <Button onClick={() => clickDone(worker_id, assignment_id, task_data)}>
+          <span
+            style={{ marginRight: 5 }}
+            className="glyphicon glyphicon-ok"
+          />
+          Submit
+        </Button>
+      </div>
+    );
+  }
+
+  handleUpdatingRemainingScripts(curr_counter, scripts_left) {
+    if (scripts_left.length == 0) {
+      return;
+    }
+    let curr_script_name = "POST_LOADED_SCRIPT_" + curr_counter;
+    let script_to_load = scripts_left.shift()
+    if (script_to_load.text == '') {
+      var head= document.getElementsByTagName('head')[0];
+      var script= document.createElement('script');
+      script.onload = () => {
+        this.handleUpdatingRemainingScripts(curr_counter+1, scripts_left)
+      };
+      script.async = 1;
+      script.src = script_to_load.src;
+      head.appendChild(script);
+    } else {
+      const script_text = script_to_load.text;
+      // This magic lets us evaluate a script from the global context
+      (1, eval)(script_text);
+      this.handleUpdatingRemainingScripts(curr_counter+1, scripts_left);
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    // When the inner html has changed, we need to execute scripts!
+    if (this.state.render_html != prevState.render_html) {
+      let children = this.raw_html_elem.children;
+      let scripts_to_load = [];
+      for (let child of children) {
+        let post_load_script_count = 0
+        if (child.tagName == "SCRIPT") {
+          scripts_to_load.push(child);
+        }
+      }
+      if (scripts_to_load.length > 0) {
+        this.handleUpdatingRemainingScripts(0, scripts_to_load);
+      }
+    }
+  }
+}
+
+ReactDOM.render(<MainApp />, document.getElementById('app'));

--- a/mephisto/server/blueprints/static_task/source/dev/main.js
+++ b/mephisto/server/blueprints/static_task/source/dev/main.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import './app.jsx';

--- a/mephisto/server/blueprints/static_task/source/package.json
+++ b/mephisto/server/blueprints/static_task/source/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "mephisto-task-compiler",
+  "version": "1.0.0",
+  "description": "",
+  "main": "webpack.config.js",
+  "scripts": {
+    "dev": "webpack --mode development -q"
+  },
+  "keywords": [],
+  "author": "",
+  "dependencies": {
+    "bootstrap": "^4.3.1",
+    "bowser": "^2.0",
+    "fetch": "^1.1.0",
+    "popper.js": "^1.14.4",
+    "rc-slider": "^8.6.3",
+    "react": "^16.5.2",
+    "react-bootstrap": "^0.32.4",
+    "react-dom": "^16.5.2",
+    "react-table": "^6.8.6"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.1.0",
+    "@babel/core": "^7.1.0",
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/preset-env": "^7.1.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.2",
+    "css-loader": "^1.0.0",
+    "style-loader": "^0.23.0",
+    "url-loader": "^2.0.1",
+    "webpack": "^4.19.1",
+    "webpack-cli": "^3.1.1"
+  }
+}

--- a/mephisto/server/blueprints/static_task/source/webpack.config.js
+++ b/mephisto/server/blueprints/static_task/source/webpack.config.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: './dev/main.js',
+  output: {
+    path: __dirname,
+    filename: 'build/bundle.js',
+  },
+  node: {
+    net: 'empty',
+    dns: 'empty',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: { presets: ['@babel/env'] },
+      },
+      {
+        test: /\.css$/,
+        loader: 'style-loader!css-loader',
+      },
+      {
+        test: /\.(svg|png|jpe?g|ttf)$/,
+        loader: 'url-loader?limit=100000',
+      },
+      {
+        test: /\.jpg$/,
+        loader: 'file-loader',
+      },
+    ],
+  },
+};

--- a/mephisto/server/blueprints/static_task/static_agent_state.py
+++ b/mephisto/server/blueprints/static_task/static_agent_state.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Dict, Any, TYPE_CHECKING
+from mephisto.data_model.blueprint import AgentState
+import os
+import json
+
+if TYPE_CHECKING:
+    from mephisto.data_model.agent import Agent
+
+
+class StaticAgentState(AgentState):
+    """
+    Agent state for static tasks
+    """
+
+    # TODO implement. Going to get frontend working first
+
+    def __init__(self, agent: "Agent"):
+        """Mock agent states keep everything in local memory"""
+        self.agent = agent
+        self.state: Dict[str, Any] = {}
+
+    def load_data(self) -> None:
+        """Mock agent states have no data stored"""
+        pass
+
+    def get_data(self) -> Dict[str, Any]:
+        """Return dict of this agent's state"""
+        return self.state
+
+    def save_data(self) -> None:
+        """Mock agents don't save data (yet)"""
+        pass
+
+    def update_data(self, state) -> None:
+        """Put new data into this mock state"""
+        # TODO this should actually take in packets instead
+        # update once we use packets
+        self.state = state

--- a/mephisto/server/blueprints/static_task/static_blueprint.py
+++ b/mephisto/server/blueprints/static_task/static_blueprint.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.data_model.blueprint import Blueprint
+from mephisto.server.blueprints.static_task.static_agent_state import StaticAgentState
+from mephisto.server.blueprints.static_task.static_task_runner import StaticTaskRunner
+from mephisto.server.blueprints.static_task.static_task_builder import StaticTaskBuilder
+
+import os
+import time
+
+from typing import ClassVar, List, Type, Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mephisto.data_model.task import TaskRun
+    from mephisto.data_model.blueprint import AgentState, TaskRunner, TaskBuilder
+    from mephisto.data_model.assignment import Assignment
+
+
+class StaticBlueprint(Blueprint):
+    """Blueprint for a task that runs off of templated static HTML"""
+
+    AgentStateClass: ClassVar[Type["AgentState"]] = StaticAgentState
+    TaskBuilderClass: ClassVar[Type["TaskBuilder"]] = StaticTaskBuilder
+    TaskRunnerClass: ClassVar[Type["TaskRunner"]] = StaticTaskRunner
+    supported_architects: ClassVar[List[str]] = ["mock"]
+
+    @staticmethod
+    def get_extra_options() -> Dict[str, str]:
+        """Will need to specify the HTML file!"""
+        # TODO fill in eventually
+        return {}

--- a/mephisto/server/blueprints/static_task/static_task_builder.py
+++ b/mephisto/server/blueprints/static_task/static_task_builder.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.data_model.blueprint import TaskBuilder
+
+from distutils.dir_util import copy_tree
+import os
+import time
+import sh
+import shutil
+import subprocess
+
+from typing import ClassVar, List, Type, Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mephisto.data_model.task import TaskRun
+    from mephisto.data_model.assignment import Assignment
+
+STATIC_TASK_DIR = os.path.dirname(__file__)
+FRONTEND_SOURCE_DIR = os.path.join(STATIC_TASK_DIR, 'source')
+FRONTEND_BUILD_DIR = os.path.join(FRONTEND_SOURCE_DIR, 'build')
+
+class StaticTaskBuilder(TaskBuilder):
+    """
+    Builder for a static task, pulls the appropriate html,
+    builds the frontend (if a build doesn't already exist),
+    then puts the file into the server directory
+    """
+
+    BUILT_FILE = "done.built"
+    BUILT_MESSAGE = "built!"
+
+    def rebuild_core(self):
+        """Rebuild the frontend for this task"""
+        return_dir = os.getcwd()
+        os.chdir(FRONTEND_SOURCE_DIR)
+        if os.path.exists(FRONTEND_BUILD_DIR):
+            shutil.rmtree(FRONTEND_BUILD_DIR)
+        packages_installed = subprocess.call(['npm', 'install'])
+        if packages_installed != 0:
+            raise Exception(
+                'please make sure npm is installed, otherwise view '
+                'the above error for more info.'
+            )
+
+        webpack_complete = subprocess.call(['npm', 'run', 'dev'])
+        if webpack_complete != 0:
+            raise Exception(
+                'Webpack appears to have failed to build your '
+                'frontend. See the above error for more information.'
+            )
+        os.chdir(return_dir)
+
+
+    def build_in_dir(self, build_dir: str):
+        """Build the frontend if it doesn't exist, then copy into the server directory"""
+
+        if True: #not os.path.exists(FRONTEND_BUILD_DIR):
+            self.rebuild_core()
+
+        # TODO Copy html into static
+        use_html_file = "/Users/jju/mephisto/mephisto/server/blueprints/static_task/html_sources/task.html"
+
+        # all the important files should've been moved to bundle.js in
+        # server/static, now copy the rest into static
+        target_resource_dir = os.path.join(
+            build_dir, 'static'
+        )
+        file_name = os.path.basename(use_html_file)
+        target_path = os.path.join(target_resource_dir, file_name)
+        shutil.copy2(use_html_file, target_path)
+
+        bundle_js_file = os.path.join(FRONTEND_BUILD_DIR, 'bundle.js')
+        target_path = os.path.join(target_resource_dir, 'bundle.js')
+        shutil.copy2(bundle_js_file, target_path)
+
+        with open(os.path.join(build_dir, self.BUILT_FILE), "w+") as built_file:
+            built_file.write(self.BUILT_MESSAGE)
+
+    # TODO update test validation
+    @staticmethod
+    def task_dir_is_valid(task_dir: str) -> bool:
+        """Mocks are always valid, we don't have any special resources"""
+        return True
+
+    @staticmethod
+    def get_extra_options() -> Dict[str, str]:
+        """Mock task types don't have extra options"""
+        return {}
+
+    def cleanup_assignment(self, assignment: "Assignment"):
+        """No cleanup required yet for ending mock runs"""
+        pass

--- a/mephisto/server/blueprints/static_task/static_task_runner.py
+++ b/mephisto/server/blueprints/static_task/static_task_runner.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.data_model.blueprint import TaskRunner
+
+import os
+import time
+
+from typing import ClassVar, List, Type, Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mephisto.data_model.task import TaskRun
+    from mephisto.data_model.assignment import Assignment
+
+
+class StaticTaskRunner(TaskRunner):
+    """Task runner for a static task"""
+
+    # TODO implement. Going to get frontend working first
+
+    def __init__(self, task_run: "TaskRun", opts: Any):
+        super().__init__(task_run, opts)
+        self.tracked_tasks: Dict[str, "Assignment"] = {}
+
+    def run_assignment(self, assignment: "Assignment"):
+        """
+        Mock runners will pass the agents for the given assignment
+        all of the required messages to finish a task.
+        """
+        self.tracked_tasks[assignment.db_id] = assignment
+        time.sleep(0.3)
+        for unit in assignment.get_units():
+            agent = unit.get_assigned_agent()
+            assert agent is not None, "Task was not fully assigned"
+            # TODO add some observations?
+            # TODO add some acts?
+            # TODO improve when MockAgents are more capable
+            agent.mark_done()
+        del self.tracked_tasks[assignment.db_id]
+
+    @staticmethod
+    def get_extra_options() -> Dict[str, str]:
+        """Mock task types don't have extra options"""
+        return {}
+
+    def cleanup_assignment(self, assignment: "Assignment"):
+        """No cleanup required yet for ending mock runs"""
+        pass


### PR DESCRIPTION
This loads a direct copy-paste of an MTurk template into a webpage loaded locally and pulling the task data from the server. To do this, it directly injects the html associated with the task. Unfortunately, react doesn't execute scripts injected in this way, so we have to query for these scripts, re-append them, and then force them to load. 

It's hairy, but it works:
<img width="1119" alt="Screen Shot 2019-12-11 at 10 26 00 PM" src="https://user-images.githubusercontent.com/1276867/70680365-0b4c1980-1c66-11ea-8cc9-ee88641ffe1f.png">
test code:
```
import os
from mephisto.core.local_database import LocalMephistoDB

db = LocalMephistoDB()
try:
    static_task_id = db.new_task("test_static", 'static')
except:
    static_task_id = db.find_tasks('test_static')[0].db_id

static_run_id = db.new_task_run(static_task_id, db.find_requesters()[-1].db_id, '--test --params')
from mephisto.server.architects.local_architect import LocalArchitect
from mephisto.data_model.task import TaskRun
from mephisto.core.utils import get_mephisto_tmp_dir

temp_path = os.path.join(get_mephisto_tmp_dir(), 'test_server')
os.makedirs(temp_path, exist_ok=True)

arch = LocalArchitect(db, {}, TaskRun(db, static_run_id), temp_path)
print(arch.prepare())
# input('check if prepare worked')
print(arch.deploy())
input('check if deploy worked')
arch.cleanup()
arch.shutdown()

```

I made inline comments to point to how this works.

This definitely isn't the complete feature, but I think this is in a reviewable state as anything else would make the review really bulky.