### PR TITLE
Updating HIT lifetime for MTurk from 1 year to 1 month

### DIFF
--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -374,7 +374,7 @@ def create_hit_with_hit_type(
     response = client.create_hit_with_hit_type(
         HITTypeId=hit_type_id,
         MaxAssignments=num_assignments,
-        LifetimeInSeconds=31536000,
+        LifetimeInSeconds=60 * 60 * 24 * 31,
         Question=question_data_struture,
     )
 


### PR DESCRIPTION
Title. I think it's a bit silly to have tasks up and running for a full year, as it's likely everything is finished on the order of days from the initial launch. This updates the lifetime to be 1 month instead, which should help with the process of killing and cleaning dead tasks that Mephisto somehow misses.