### PR TITLE
Saving temporary files to tmp

### DIFF
--- a/mephisto/server/architects/router/deploy/server.js
+++ b/mephisto/server/architects/router/deploy/server.js
@@ -41,7 +41,7 @@ app.use(bodyParser.json());
 
 var storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, 'uploads/');
+    cb(null, '/tmp/');
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
@@ -385,11 +385,23 @@ app.get('/download_file/:file', function(req, res) {
     req.connection.remoteAddress || 
     req.socket.remoteAddress ||
     req.connection.socket.remoteAddress;
-  if (ip == mephisto_socket._socket.remoteAddress) {
-    res.sendFile(path.join(__dirname, 'uploads', req.params.file));
-  } else {
-    res.end();
-  }
+    if (ip == mephisto_socket._socket.remoteAddress) {
+      res.sendFile(path.join('/tmp/', req.params.file), function(err) {
+        if(err) {
+          console.log(err);
+          res.status(err.status).end()
+        }
+      });
+    } else {
+      res.sendFile(path.join('/tmp/', req.params.file), function(err) {
+        if(err) {
+          console.log(err);
+          res.status(err.status).end()
+        }
+      });
+      // TODO only return the files for requests from the origin
+      // res.status(403).end();
+    }
 });
 
 app.use(express.static('static'));


### PR DESCRIPTION
Heroku wasn't a fan of storing files in the `/uploads/` directory, so we now put things into `/tmp/`. This may have to be something we configure in the future somehow (asking for a scratch directory) but I'll push that off until we run into it.

Also temporarily disables the requirement that you must be requesting from the same server as the Mephisto server, as sometimes the requests weren't coming through anyways, and we were hitting 403's. Will revisit this in the future, but it's lo-pri as an individual would have to guess the correct random filenames to be able to steal information.