### PR TITLE
TaskRunner control of valid units

### DIFF
--- a/mephisto/client/api.py
+++ b/mephisto/client/api.py
@@ -285,15 +285,18 @@ def accept_unit(unit_id):
     return jsonify({"success": True})
     pass
 
+
 @api.route("/unit/<string:unit_id>/reject", methods=["POST"])
 def reject_unit(unit_id):
     return jsonify({"success": True})
     pass
 
+
 @api.route("/unit/<string:unit_id>/softBlock", methods=["POST"])
 def soft_block_unit(unit_id):
     return jsonify({"success": True})
     pass
+
 
 @api.route("/unit/<string:unit_id>/hardBlock", methods=["POST"])
 def hard_block_unit(unit_id):

--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -478,7 +478,10 @@ class Supervisor:
 
         # get the list of tentatively valid units
         units = task_run.get_valid_units_for_worker(worker)
-        self._assign_unit_to_agent(packet, socket_info, units)
+        usable_units = socket_info.job.task_runner.filter_units_for_worker(
+            units, worker
+        )
+        self._assign_unit_to_agent(packet, socket_info, usable_units)
 
     def _register_agent(self, packet: Packet, socket_info: SocketInfo):
         """Process an agent registration packet to register an agent"""

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -264,6 +264,16 @@ class TaskRunner(ABC):
         """
         raise NotImplementedError()
 
+    def filter_units_for_worker(self, units: List["Unit"], worker: "Worker"):
+        """
+        Returns the list of Units that the given worker is eligible to work on.
+
+        Some tasks may want more direct control of what units a worker is 
+        allowed to work on, so this method should be overridden by children
+        classes.
+        """
+        return units
+
     # TaskRunners must implement either the unit or assignment versions of the
     # run and cleanup functions, depending on if the task is run at the assignment
     # level rather than on the the unit level.


### PR DESCRIPTION
In order to make ACUTE-eval work, blueprints need some ability to be able to control the units that a worker is allowed to work on.

This PR introduces that capability.

Tested with `pytest` and `mypy`, and ran `black`.