### PR TITLE
Forgot to add port env for local architect

### DIFF
--- a/mephisto/server/architects/local_architect.py
+++ b/mephisto/server/architects/local_architect.py
@@ -123,7 +123,9 @@ class LocalArchitect(Architect):
         return_dir = os.getcwd()
         os.chdir(self.running_dir)
         self.server_process = subprocess.Popen(
-            ["node", "server.js"], preexec_fn=os.setpgrp
+            ["node", "server.js"], 
+            preexec_fn=os.setpgrp,
+            env=dict(os.environ, PORT=f"{self.port}"),
         )
         self.server_process_pid = self.server_process.pid
         os.chdir(return_dir)


### PR DESCRIPTION
Turns out I dropped the env line that was supposed to pass the port on to the server, so the port was locked at 3000 even with a `--port` arg.

# Testing
Launched and successfully ran a parlai_chat task on port 3500