### PR TITLE
Static tasks now replace all templated variables

### DIFF
--- a/mephisto/server/blueprints/static_task/source/dev/app.jsx
+++ b/mephisto/server/blueprints/static_task/source/dev/app.jsx
@@ -125,7 +125,8 @@ class MainApp extends React.Component {
     if (this.state.task_data !== null) {
       for (let [key, value] of Object.entries(this.state.task_data)) {
         let find_string = "${" + key + "}";
-        fin_html = fin_html.replace(find_string, value);
+        // Could be better done with a regex for performant code
+        fin_html = fin_html.split(find_string).join(value);
       }
     }
 

--- a/mephisto/server/blueprints/static_task/static_task_builder.py
+++ b/mephisto/server/blueprints/static_task/static_task_builder.py
@@ -58,7 +58,7 @@ class StaticTaskBuilder(TaskBuilder):
     def build_in_dir(self, build_dir: str):
         """Build the frontend if it doesn't exist, then copy into the server directory"""
         # Only build this task if it hasn't already been built
-        if not os.path.exists(FRONTEND_BUILD_DIR):
+        if True:  # not os.path.exists(FRONTEND_BUILD_DIR):
             self.rebuild_core()
 
         # Copy the built core and the given task file to the target path


### PR DESCRIPTION
I misunderstood how string replace worked in javascript, so I wasn't replacing all instances of the template string with the desired value. This fixes that problem, albeit in the laziest way (not using regex). I don't think the quantity of replacements that need to be done warrants the more efficient approach.