### PR TITLE
Agent Bugfix - Ok to set final status to same status

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -157,6 +157,8 @@ class Agent(ABC):
         """Update the database status of this agent, and
         possibly send a message to the frontend agent informing
         them of this update"""
+        if self.db_status == new_status:
+            return  # Noop, this is already the case
         assert (
             self.db_status not in AgentState.complete()
         ), f"Cannot update a final status, was {self.db_status} and want to set to {new_status}"


### PR DESCRIPTION
We were hard crashing when the system was setting an agent to the complete status that it already was. This shouldn't totally break things, and should instead pass as a noop.