### PR TITLE
Adding setup.py for local pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+from setuptools import setup, find_packages
+
+setup(
+    name="mephisto",
+    version="0.1",
+    packages=find_packages(),
+    # package_dir={'': 'mephisto'},
+)


### PR DESCRIPTION
This simple setup.py allows us to use `pip install -e .` to install a local version of mephisto for use by anyone who wants to be using the most up-to-date git version of Mephisto (which is _everyone_ while this is still private).