### PR TITLE
Tooling to improve MTurk cleanup experience

### DIFF
--- a/mephisto/data_model/qualification.py
+++ b/mephisto/data_model/qualification.py
@@ -57,7 +57,6 @@ COMPARATOR_OPERATIONS = {
 def worker_is_qualified(worker: "Worker", qualifications: List[Dict[str, Any]]):
     db = worker.db
     for qualification in qualifications:
-        print(f"Checking qualification {qualification}")
         qual_name = qualification["qualification_name"]
         qual_objs = db.find_qualifications(qual_name)
         if len(qual_objs) == 0:


### PR DESCRIPTION
Recently launched a LIGHT task that died, and had to clean up the HITs off from MTurk. Made some helper functions that ease the process of cleanup.

Tested by deleting that job, and even better it discovered some accidentally launched hits from when you were initially testing @pringshia - deleted those as well with:
```
outstanding_hits = get_outstanding_hits(client)
for hit_type in outstanding_hits:
    expire_and_dispose_hits(client, outstanding_hits[hit_type])
```

In the future using these I can create a script that will walk through your existing MTurk tasks and ask if you want to delete them, giving context on what's inside.