### PR TITLE
Fix order of launching tasks from operator

### DIFF
--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -242,16 +242,16 @@ class Operator:
                 "Non-list initialization data is not yet supported"
             )
 
-        launcher = TaskLauncher(self.db, task_run, initialization_data_array)
-        launcher.create_assignments()
-        launcher.launch_units(task_url)
-
         # Link the job together
         job = self.supervisor.register_job(
             architect, task_runner, provider, existing_qualifications
         )
         if self.supervisor.sending_thread is None:
             self.supervisor.launch_sending_thread()
+
+        launcher = TaskLauncher(self.db, task_run, initialization_data_array)
+        launcher.create_assignments()
+        launcher.launch_units(task_url)
 
         self._task_runs_tracked[task_run.db_id] = TrackedRun(
             task_run=task_run,


### PR DESCRIPTION
By only registering the supervisor _after_ launching all the jobs (as we did in the past, if a job was launching a lot of tasks, they would not be able to communicate to the Mephisto backend until every task was launched. By registering the supervisor before launching tasks, people can get started working on tasks before all the tasks are launched.