### PR TITLE
Updating examples to pull the blueprint type from the constant

### DIFF
--- a/examples/acute_eval_demo/example_script.py
+++ b/examples/acute_eval_demo/example_script.py
@@ -9,7 +9,7 @@ import shlex
 from mephisto.core.local_database import LocalMephistoDB
 from mephisto.core.operator import Operator
 from mephisto.core.utils import get_root_dir
-
+from mephisto.server.blueprints.acute_eval.acute_eval_blueprint import BLUEPRINT_TYPE
 
 """
 Example script for running ACUTE-EVAL.
@@ -60,7 +60,7 @@ assert USE_LOCAL or requester_name.endswith(
 # requester.register()
 
 ARG_STRING = (
-    "--blueprint-type acute_eval "
+    f"--blueprint-type {BLUEPRINT_TYPE} "
     f"--architect-type {architect_type} "
     f"--requester-name {requester_name} "
     f'--task-title "\\"{task_title}\\"" '

--- a/examples/parlai_chat_task_demo/parlai_test_script.py
+++ b/examples/parlai_chat_task_demo/parlai_test_script.py
@@ -4,6 +4,7 @@ import shlex
 from mephisto.core.local_database import LocalMephistoDB
 from mephisto.core.operator import Operator
 from mephisto.core.utils import get_root_dir
+from mephisto.server.blueprints.parlai_chat.parlai_chat_blueprint import BLUEPRINT_TYPE
 
 USE_LOCAL = True
 DEMO_CUSTOM_BUNDLE = True
@@ -45,7 +46,7 @@ assert USE_LOCAL or requester_name.endswith(
 # requester.register()
 
 ARG_STRING = (
-    "--blueprint-type parlai_chat "
+    f"--blueprint-type {BLUEPRINT_TYPE} "
     f"--architect-type {architect_type} "
     f"--requester-name {requester_name} "
     f'--task-title "\\"{task_title}\\"" '

--- a/examples/simple_static_task/static_test_script.py
+++ b/examples/simple_static_task/static_test_script.py
@@ -4,6 +4,7 @@ import shlex
 from mephisto.core.local_database import LocalMephistoDB
 from mephisto.core.operator import Operator
 from mephisto.core.utils import get_root_dir
+from mephisto.server.blueprints.static_task.static_blueprint import BLUEPRINT_TYPE
 
 USE_LOCAL = True
 
@@ -41,7 +42,7 @@ assert USE_LOCAL or requester_name.endswith(
 # requester.register()
 
 ARG_STRING = (
-    "--blueprint-type static "
+    f"--blueprint-type {BLUEPRINT_TYPE} "
     f"--architect-type {architect_type} "
     f"--requester-name {requester_name} "
     f'--task-title "\\"{task_title}\\"" '


### PR DESCRIPTION
In the past, the example files were using a hardcoded string for the blueprint type, which caused a bug when we updated one of these strings. This PR updates the examples to pull the `BLUEPRINT_TYPE` constant, which should prevent the issue on our examples and hopefully lead others to adapt a similar style (to prevent their own bugs as well).