### PR TITLE
Example script for MephistoDataBrowser usage

### DIFF
--- a/examples/simple_static_task/examine_results.py
+++ b/examples/simple_static_task/examine_results.py
@@ -11,35 +11,35 @@ DO_REVIEW = True
 units = mephisto_data_browser.get_units_for_task_name(input("Input task name: "))
 
 tasks_to_show = input("Tasks to see? (a)ll/(u)nreviewed: ")
-if (tasks_to_show in ['all', 'a']):
+if tasks_to_show in ["all", "a"]:
     DO_REVIEW = False
 else:
-    units = [u for u in units if u.get_status() == 'completed']
+    units = [u for u in units if u.get_status() == "completed"]
+
 
 def format_for_printing_data(data):
     # Custom tasks can define methods for how to display their data in a relevant way
-    worker_name = Worker(db, data['worker_id']).worker_name
-    contents = data['data']
-    duration = contents['times']['task_end'] - contents['times']['task_start']
-    metadata_string = f"Worker: {worker_name}\nUnit: {data['unit_id']}\nDuration: {int(duration)}\n"
-
-    inputs = contents['inputs']
-    inputs_string = (
-        f"Character: {inputs['character_name']}\nDescription: {inputs['character_description']}\n"
+    worker_name = Worker(db, data["worker_id"]).worker_name
+    contents = data["data"]
+    duration = contents["times"]["task_end"] - contents["times"]["task_start"]
+    metadata_string = (
+        f"Worker: {worker_name}\nUnit: {data['unit_id']}\nDuration: {int(duration)}\n"
     )
 
-    outputs = contents['outputs']
-    output_string = (
-        f"   Rating: {outputs['rating']}\n"
-    )
-    found_files = outputs.get('files')
+    inputs = contents["inputs"]
+    inputs_string = f"Character: {inputs['character_name']}\nDescription: {inputs['character_description']}\n"
+
+    outputs = contents["outputs"]
+    output_string = f"   Rating: {outputs['rating']}\n"
+    found_files = outputs.get("files")
     if found_files is not None:
-        file_dir = Unit(db, data['unit_id']).get_assigned_agent().get_data_dir()
+        file_dir = Unit(db, data["unit_id"]).get_assigned_agent().get_data_dir()
         output_string += f"   Files: {found_files}\n"
         output_string += f"   File directory {file_dir}\n"
     else:
         output_string += f"   Files: No files attached\n"
     return f"-------------------\n{metadata_string}{inputs_string}{output_string}"
+
 
 disqualification_name = None
 for unit in units:
@@ -65,4 +65,3 @@ for unit in units:
             agent.approve_work()
             worker = agent.get_worker()
             worker.grant_qualification(disqualification_name, 1)
-

--- a/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
@@ -105,6 +105,6 @@ class StaticAgentState(AgentState):
         if packet.data.get("files") != None:
             print("Got files:", str(packet.data["files"])[:500])
             self.state["outputs"]["files"] = [
-                f['filename'] for f in packet.data["files"]
+                f["filename"] for f in packet.data["files"]
             ]
         self.save_data()

--- a/mephisto/server/blueprints/static_task/static_agent_state.py
+++ b/mephisto/server/blueprints/static_task/static_agent_state.py
@@ -100,6 +100,6 @@ class StaticAgentState(AgentState):
         if packet.data.get("files") != None:
             print("Got files:", str(packet.data["files"])[:500])
             self.state["outputs"]["files"] = [
-                f['filename'] for f in packet.data["files"]
+                f["filename"] for f in packet.data["files"]
             ]
         self.save_data()


### PR DESCRIPTION
Creates an example script to pair with the static task script that demonstrates how someone can write code using the `MephistoDataBrowser` to both examine their data and also review the contents of it.

```
> python examples/simple_static_task/examine_results.py 
Input task name: static_task
Tasks to see? (a)ll/(u)nreviewed: a
-------------------
Worker: 10
Unit: 1804
Duration: 3
Character: Loaded Character 1
Description: I'm a character loaded from Mephisto!
   Rating: good
   Files: No files attached

-------------------
Worker: 11
Unit: 1805
Duration: 2
Character: Loaded Character 1
Description: I'm a character loaded from Mephisto!
   Rating: good
   Files: No files attached

-------------------
Worker: 12
Unit: 1806
Duration: 3
Character: Loaded Character 2
Description: I'm another character loaded from Mephisto!
   Rating: passable
   Files: No files attached

-------------------
Worker: 13
Unit: 1807
Duration: 3
Character: Loaded Character 2
Description: I'm another character loaded from Mephisto!
   Rating: good
   Files: No files attached

-------------------
Worker: 13
Unit: 2612
Duration: 9
Character: Loaded Character 1
Description: I'm a character loaded from Mephisto!
   Rating: passable
   Files: No files attached

-------------------
Worker: 13
Unit: 2616
Duration: 67
Character: Loaded Character 1
Description: I'm a character loaded from Mephisto!
   Rating: good
   Files: No files attached

-------------------
Worker: 13
Unit: 2620
Duration: 12
Character: Loaded Character 1
Description: I'm a character loaded from Mephisto!
   Rating: good
   Files: ['1589418048498-706402439-file1-dungeon_master.png']
   File directory /Users/jju/mephisto/data/data/runs/NO_PROJECT/648/1861/722
```