### PR TITLE
ParlAI import not needed to get started

### DIFF
--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -6,8 +6,11 @@
 
 from mephisto.data_model.blueprint import TaskRunner
 from mephisto.data_model.agent import Agent, OnboardingAgent
-from parlai.core.agents import Agent as ParlAIAgent
-from parlai.core.message import Message
+try:
+    from parlai.core.agents import Agent as ParlAIAgent
+    from parlai.core.message import Message
+except:
+    pass # ParlAI is not installed. TODO remove when we move this blueprint to ParlAI
 
 from mephisto.data_model.packet import (
     Packet,


### PR DESCRIPTION
This temporary try except lets this blueprint live in mephisto for a little longer without requiring new users to have ParlAI