### PR TITLE
Small acute eval fixes

### DIFF
--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -603,7 +603,7 @@ class Supervisor:
 
         self.message_queue.append(agent_data_packet)
 
-        if unit_data.get("raw_messages") is not None:
+        if isinstance(unit_data, dict) and unit_data.get("raw_messages") is not None:
             # TODO bring these into constants somehow
             for message in unit_data.get("raw_messages"):
                 packet = Packet.from_dict(message)

--- a/mephisto/server/blueprints/acute_eval/webapp/package.json
+++ b/mephisto/server/blueprints/acute_eval/webapp/package.json
@@ -13,6 +13,7 @@
     "fetch": "^1.1.0",
     "jquery": "^3.0.0",
     "popper.js": "^1.14.4",
+    "mephisto-task": "^1.0.3",
     "react": "16.13.1",
     "react-bootstrap": "^0.32.4",
     "react-dom": "16.13.1",


### PR DESCRIPTION
Small fixes to operator and the acute eval blueprint.

Not all instances of `unit_data` will be a dict, so we can't just index it.
Needed to update the dependencies of the js now that the package doesn't need to be linked.