### PR TITLE
Small ParlAI Blueprint fixes

### DIFF
--- a/mephisto/server/blueprints/parlai_chat/webapp/src/app.jsx
+++ b/mephisto/server/blueprints/parlai_chat/webapp/src/app.jsx
@@ -51,7 +51,17 @@ function MainApp() {
     (allMessages, newMessage) => {
         // we clear messages by sending false
         if (newMessage === false) {
-          return []
+          return [];
+        }
+        // We skip empty messages
+        if (newMessage.text == "") {
+          return allMessages;
+        }
+        // We skip repeat messages
+        for (let m_idx in allMessages) {
+          if (allMessages[m_idx].message_id == newMessage.message_id) {
+            return allMessages;
+          }
         }
         return [...allMessages, newMessage]
       },


### PR DESCRIPTION
# Overview
I had forgotten to add message deduplication and ignoring empty messages to the ParlAI chat frontend, though these features have been present in the old interface. This adds them into `addMessage`.

Tested by running the ParlAI chat task locally, and ensuring that the empty confirmation message at the end of the chat doesn't render.