### PR TITLE
Fixing caching issue with unit assignments

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -204,7 +204,9 @@ class Agent(ABC):
         Wrapper around the new method that allows registering additional
         bookkeeping information from a crowd provider for this agent
         """
-        return cls.new(db, worker, unit)
+        agent = cls.new(db, worker, unit)
+        unit.worker_id = worker.db_id
+        return agent
 
     def observe(self, packet: "Packet") -> None:
         """


### PR DESCRIPTION
When an agent is created, we need to set the unit to have the correct worker_id associated.

This had broken when `__unit_cache` was added, as the unit cache wasn't being updated when agents were created.