### PR TITLE
Have mock provider tasks alert a message on successful submission

### DIFF
--- a/mephisto/providers/mock/wrap_crowd_source.js
+++ b/mephisto/providers/mock/wrap_crowd_source.js
@@ -50,5 +50,6 @@ function getAgentRegistration(mephisto_worker_id) {
 
 function handleSubmitToProvider(task_data) {
     // Mock agents won't ever submit to a real provider
+    alert("The task has been submitted! Data: " + JSON.stringify(task_data))
     return true;
 }


### PR DESCRIPTION
Adds an alert to `handleSubmitToProvider`