### PR TITLE
Agent not always complete

### DIFF
--- a/mephisto/providers/mturk/mturk_agent.py
+++ b/mephisto/providers/mturk/mturk_agent.py
@@ -98,7 +98,6 @@ class MTurkAgent(Agent):
         is marked as done there's nothing else we need to do as the task has been
         submitted.
         """
-        # TODO more cases than just DISCONNECT to address
         if self.get_status() != AgentState.STATUS_DISCONNECT:
             self.db.update_agent(
                 agent_id=self.db_id, status=AgentState.STATUS_COMPLETED


### PR DESCRIPTION
# Overview
We were marking agents as being "completed" even if they were already marked as one of a number of complete states. This made it hard to have bookkeeping for the state an agent was in when they stopped interacting with a task. As such it was hard to find #161 before it was too late. This fixes the bookkeeping.

# Testing
Ran pytest and linting. Did a manual test of the parlai_chat with one agent disconnecting and checked the agent status.
```
> [a.get_status() for a in [u.get_assigned_agent() for u in run.get_units()]]
['completed', 'disconnect']
```