### PR TITLE
Fixing non-unique agent registration IDs

### DIFF
--- a/mephisto/providers/mock/wrap_crowd_source.js
+++ b/mephisto/providers/mock/wrap_crowd_source.js
@@ -42,7 +42,7 @@ function getAgentRegistration(mephisto_worker_id) {
     // and the supplied assignment id
     return {
         worker_id: mephisto_worker_id,
-        agent_registration_id: getAssignmentId(),
+        agent_registration_id: getAssignmentId() + "-" + mephisto_worker_id,
         assignment_id: getAssignmentId(),
         provider_type: 'mock',
     };

--- a/mephisto/providers/mturk/wrap_crowd_source.js
+++ b/mephisto/providers/mturk/wrap_crowd_source.js
@@ -48,7 +48,7 @@ function getAgentRegistration(mephisto_worker_id) {
     // and the supplied assignment id
     return {
         worker_id: mephisto_worker_id,
-        agent_registration_id: getAssignmentId(),
+        agent_registration_id: getAssignmentId() + "-" + mephisto_worker_id,
         assignment_id: getAssignmentId(),
         hit_id: getHITId(),
         provider_type: 'mturk',

--- a/mephisto/providers/mturk_sandbox/wrap_crowd_source.js
+++ b/mephisto/providers/mturk_sandbox/wrap_crowd_source.js
@@ -48,7 +48,7 @@ function getAgentRegistration(mephisto_worker_id) {
     // and the supplied assignment id
     return {
         worker_id: mephisto_worker_id,
-        agent_registration_id: getAssignmentId(),
+        agent_registration_id: getAssignmentId() + "-" + mephisto_worker_id,
         assignment_id: getAssignmentId(),
         hit_id: getHITId(),
         provider_type: 'mturk_sandbox',


### PR DESCRIPTION
As noted by @bottler, it was possible that an agent would be mismatched from the worker that was completing the work. This was caused by not ensuring that the agent registration id would be unique to both the worker and assignment in `wrap_crowd_source.js`. It was initially overlooked as testing on live tasks wouldn't run into the issue because returned tasks would dispose of agents that were incomplete.

Tested manually, connecting with worker `y` on a static task returned by worker `x` on localhost would locally mark the work as completed by `x` before the fix, but by `y` after the fix.