### PR TITLE
Proper saving in parlai 'prep_save_data'

### DIFF
--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -171,7 +171,7 @@ class ParlAIChatTaskRunner(TaskRunner):
                     receiver_id=agent.db_id,
                     data={
                         "id": "SUBMIT_WORLD_DATA",
-                        "WORLD_DATA": world.prep_save_data(parlai_agent),
+                        "WORLD_DATA": world.prep_save_data([parlai_agent]),
                         "text": "",
                     },
                 )
@@ -211,7 +211,7 @@ class ParlAIChatTaskRunner(TaskRunner):
                         receiver_id=agent.db_id,
                         data={
                             "id": "SUBMIT_WORLD_DATA",
-                            "WORLD_DATA": world.prep_save_data(parlai_agents[idx]),
+                            "WORLD_DATA": world.prep_save_data([parlai_agents[idx]]),
                             "text": "",
                         },
                     )


### PR DESCRIPTION
Fairly straightforward bug. Thanks @jxmsML for tracing the source of it. `prep_save_data` expects a list of `Agent`s, and while it's configured to differentiate between `MTurkAgent`s and others, it must be a list.