### PR TITLE
[WIP] dynamic launch_units with an issue of non-updating status

### DIFF
--- a/mephisto/core/local_database.py
+++ b/mephisto/core/local_database.py
@@ -228,7 +228,7 @@ class LocalMephistoDB(MephistoDB):
     """
 
     def __init__(self, database_path=None):
-        logger.info(f"database path: {database_path}")
+        logger.debug(f"database path: {database_path}")
         self.conn: Dict[int, Connection] = {}
         self.table_access_condition = threading.Condition()
         super().__init__(database_path)

--- a/mephisto/core/local_database.py
+++ b/mephisto/core/local_database.py
@@ -228,6 +228,7 @@ class LocalMephistoDB(MephistoDB):
     """
 
     def __init__(self, database_path=None):
+        logger.info(f"database path: {database_path}")
         self.conn: Dict[int, Connection] = {}
         self.table_access_condition = threading.Condition()
         super().__init__(database_path)

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -348,7 +348,6 @@ class Operator:
             return self.parse_and_launch_run(arg_list=arg_list, extra_args=extra_args)
         except (KeyboardInterrupt, Exception) as e:
             logger.error("Ran into error while launching run: ", exc_info=True)
-            traceback.print_exc()
             return None
 
     def print_run_details(self):

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -46,7 +46,7 @@ class TaskLauncher:
         db: "MephistoDB",
         task_run: "TaskRun",
         assignment_data_list: List[InitializationData],
-        max_num_concurrent_units: int = 2,
+        max_num_concurrent_units: int = 0,
     ):
         """Prepare the task launcher to get it ready to launch the assignments"""
         self.db = db

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -58,7 +58,7 @@ class TaskLauncher:
         self.provider_type = task_run.get_provider().PROVIDER_TYPE
         self.max_num_concurrent_units = max_num_concurrent_units
         self.launched_units: Dict[str, Unit] = {}
-        self.unlaunched_units: List[Unit] = []
+        self.unlaunched_units: Dict[str, Unit] = {}
 
         run_dir = task_run.get_run_dir()
         os.makedirs(run_dir, exist_ok=True)
@@ -96,7 +96,7 @@ class TaskLauncher:
                     task_run.sandbox,
                 )
                 self.units.append(Unit(self.db, unit_id))
-                self.unlaunched_units.append(Unit(self.db, unit_id))
+                self.unlaunched_units[unit_id] = Unit(self.db, unit_id)
 
     def generate_units(self):
         """ units generator which checks that only 'max_num_concurrent_units' running at the same time,
@@ -114,14 +114,18 @@ class TaskLauncher:
                 self.launched_units.pop(db_id)
 
             num_avail_units = self.max_num_concurrent_units - len(self.launched_units)
-            for i in range(len(self.unlaunched_units)):
+            units_id_to_remove = []
+            for i, item in enumerate(self.unlaunched_units.items()):
+                db_id, unit = item
                 if i < num_avail_units:
-                    unit = self.unlaunched_units[i]
                     self.launched_units[unit.db_id] = unit
-                    self.unlaunched_units.pop(i)
+                    units_id_to_remove.append(db_id)
                     yield unit
                 else:
                     break
+            for db_id in units_id_to_remove:
+                self.unlaunched_units.pop(db_id)
+
             time.sleep(UNIT_GENERATOR_WAIT_SECONDS)
             if not self.unlaunched_units:
                 break

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -35,6 +35,16 @@ logger = get_logger(name=__name__, verbose=True, level="info")
 UNIT_GENERATOR_WAIT_SECONDS = 10
 
 
+class LimitedDict(dict):
+    def __init__(self, limit):
+        self.limit = limit
+        super().__init__()
+
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
+        assert self.limit, len(self.keys())
+
+
 class TaskLauncher:
     """
     This class is responsible for managing the process of registering
@@ -57,7 +67,7 @@ class TaskLauncher:
         self.units: List[Unit] = []
         self.provider_type = task_run.get_provider().PROVIDER_TYPE
         self.max_num_concurrent_units = max_num_concurrent_units
-        self.launched_units: Dict[str, Unit] = {}
+        self.launched_units: LimitedDict[str, Unit] = LimitedDict(self.max_num_concurrent_units)
         self.unlaunched_units: List[Unit] = []
 
         run_dir = task_run.get_run_dir()

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -141,7 +141,7 @@ class TaskLauncher:
             thread = threading.Thread(target=self._launch_limited_units, args=(url,))
             thread.start()
         else:
-            for unit in self.unlaunched_units:
+            for db_id, unit in self.unlaunched_units.items():
                 unit.launch(url)
 
     def expire_units(self) -> None:

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -56,7 +56,7 @@ class TaskLauncher:
         self.provider_type = task_run.get_provider().PROVIDER_TYPE
         self.max_num_concurrent_units = max_num_concurrent_units
         self.launched_units: List[Unit] = []
-        self.unlaunched_units: Dict[Any, Unit] = {}
+        self.unlaunched_units: List[Unit] = []
 
         run_dir = task_run.get_run_dir()
         os.makedirs(run_dir, exist_ok=True)
@@ -94,9 +94,7 @@ class TaskLauncher:
                     task_run.sandbox,
                 )
                 self.units.append(Unit(self.db, unit_id))
-
-        for unit in self.units:
-            self.unlaunched_units[unit.db_id] = unit
+                self.unlaunched_units.append(Unit(self.db, unit_id))
 
     def generate_units(self):
         """ units generator which checks that only 'max_num_concurrent_units' running at the same time,
@@ -113,8 +111,8 @@ class TaskLauncher:
 
             num_avail_units = self.max_num_concurrent_units - len(self.launched_units)
             for i in range(len(self.unlaunched_units)):
-                unit = self.unlaunched_units[i]
                 if i < num_avail_units:
+                    unit = self.unlaunched_units[i]
                     self.launched_units.append(unit)
                     self.unlaunched_units.pop(i)
                     yield unit

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -261,12 +261,7 @@ class TaskRun:
             is_self_set = map(lambda u: u.worker_id == worker.db_id, unit_set)
             if not any(is_self_set):
                 units += unit_set
-        valid_units = [
-            u
-            for u in units
-            if u.get_assigned_agent() is None
-            and u.get_status() == AssignmentState.LAUNCHED
-        ]
+        valid_units = [u for u in units if u.get_status() == AssignmentState.LAUNCHED]
         return valid_units
 
     def clear_reservation(self, unit: "Unit") -> None:

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -261,7 +261,12 @@ class TaskRun:
             is_self_set = map(lambda u: u.worker_id == worker.db_id, unit_set)
             if not any(is_self_set):
                 units += unit_set
-        valid_units = [u for u in units if u.get_assigned_agent() is None]
+        valid_units = [
+            u
+            for u in units
+            if u.get_assigned_agent() is None
+            and u.get_status() == AssignmentState.LAUNCHED
+        ]
         return valid_units
 
     def clear_reservation(self, unit: "Unit") -> None:

--- a/mephisto/providers/mock/mock_unit.py
+++ b/mephisto/providers/mock/mock_unit.py
@@ -43,13 +43,14 @@ class MockUnit(Unit):
 
         # TODO(OWN) get this link to the frontend
         port = task_url.split(":")[1].split("/")[0]
+        print(task_url)
         print(
             f"Mock task launched: localhost:{port} for preview, "
-            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id} for task"
+            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id}"
         )
         logger.info(
             f"Mock task launched: localhost:{port} for preview, "
-            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id} for task"
+            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id} for assignment {self.assignment_id}"
         )
 
         return None

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -131,6 +131,7 @@ class TestTaskLauncher(unittest.TestCase):
                 if curr_time - start_time > MAX_WAIT_TIME_UNIT_LAUNCH:
                     break
             launcher.expire_units()
+            self.tearDown()
             self.setUp()
 
 

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -68,9 +68,7 @@ class TestTaskLauncher(unittest.TestCase):
     def test_create_expire_assignments(self):
         """Initialize a launcher on a task run, then create the assignments"""
         mock_data_array = self.get_mock_assignment_data_array()
-        launcher = TaskLauncher(
-            self.db, self.task_run, mock_data_array, max_num_concurrent_units=1
-        )
+        launcher = TaskLauncher(self.db, self.task_run, mock_data_array)
         launcher.create_assignments()
 
         self.assertEqual(

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -105,7 +105,6 @@ class TestTaskLauncher(unittest.TestCase):
         """Initialize a launcher on a task run, then create the assignments"""
         cap_values = [1, 2, 3, 4, 5]
         for max_num_units in cap_values:
-            self.setUp()
             mock_data_array = self.get_mock_assignment_data_array()
             launcher = TaskLauncher(
                 self.db,
@@ -127,6 +126,7 @@ class TestTaskLauncher(unittest.TestCase):
                 self.assertEqual(launcher.launched_units.exceed_limit, False)
 
             launcher.expire_units()
+            self.setUp()
 
 
 if __name__ == "__main__":

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -32,8 +32,6 @@ class LimitedDict(dict):
     def __setitem__(self, key, value):
         if len(self.keys()) > self.limit:
             self.exceed_limit = True
-        time.sleep(10)
-        value.set_db_status(AssignmentState.ASSIGNED)
         super().__setitem__(key, value)
 
 
@@ -107,8 +105,14 @@ class TestTaskLauncher(unittest.TestCase):
         launcher.launched_units = LimitedDict(launcher.max_num_concurrent_units)
         launcher.create_assignments()
         launcher.launch_units("dummy-url:3000")
+
+        for unit in launcher.units:
+            if unit.get_status() == AssignmentState.LAUNCHED:
+                unit.set_db_status(AssignmentState.COMPLETED)
+                time.sleep(10)
         self.assertEqual(launcher.launched_units.exceed_limit, False)
-        launcher.expire_units()
+
+        # launcher.expire_units()
 
 
 if __name__ == "__main__":

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -22,6 +22,8 @@ from mephisto.providers.mock.mock_provider import MockProvider
 from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprint
 from mephisto.server.blueprints.mock.mock_task_runner import MockTaskRunner
 
+MAX_WAIT_TIME_UNIT_LAUNCH = 15
+
 
 class LimitedDict(dict):
     def __init__(self, limit):
@@ -116,6 +118,7 @@ class TestTaskLauncher(unittest.TestCase):
             launcher.create_assignments()
             launcher.launch_units("dummy-url:3000")
 
+            start_time = time.time()
             while set([u.get_status() for u in launcher.units]) != {
                 AssignmentState.COMPLETED
             }:
@@ -124,7 +127,9 @@ class TestTaskLauncher(unittest.TestCase):
                         unit.set_db_status(AssignmentState.COMPLETED)
                     time.sleep(0.1)
                 self.assertEqual(launcher.launched_units.exceed_limit, False)
-
+                curr_time = time.time()
+                if curr_time - start_time > MAX_WAIT_TIME_UNIT_LAUNCH:
+                    break
             launcher.expire_units()
             self.setUp()
 

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -112,7 +112,7 @@ class TestTaskLauncher(unittest.TestCase):
                 time.sleep(10)
         self.assertEqual(launcher.launched_units.exceed_limit, False)
 
-        # launcher.expire_units()
+        launcher.expire_units()
 
 
 if __name__ == "__main__":

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -128,8 +128,7 @@ class TestTaskLauncher(unittest.TestCase):
                     time.sleep(0.1)
                 self.assertEqual(launcher.launched_units.exceed_limit, False)
                 curr_time = time.time()
-                if curr_time - start_time > MAX_WAIT_TIME_UNIT_LAUNCH:
-                    break
+                self.assertLessEqual(curr_time - start_time, MAX_WAIT_TIME_UNIT_LAUNCH)
             launcher.expire_units()
             self.tearDown()
             self.setUp()


### PR DESCRIPTION
I modified the `launch_units` in `task_launcher.py` to be limited with a `max_num_concurrent_units` attribute in `TaskLauncher`.
The idea is to keep track of launched and un-launched units in dictionary (to be able to pop the `COMPLETED` units from the launched dictionary).

What I'm trying to know is when the task is changed its status from `CREATED` to `COMPLETED` because it works fine in the first 2 units but the 2nd unit fails to update its status to `COMPLETED` even if the task physically done (open the url, choose the rating in `static_test_script.py` test case and push 'Submit').