### PR TITLE
Agent's status assigned

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -196,7 +196,9 @@ class Agent(ABC):
             unit.task_type,
             provider_type,
         )
-        return Agent(db, db_id)
+        a = Agent(db, db_id)
+        a.update_status(AgentState.STATUS_ACCEPTED)
+        return a
 
     # Specialized child cases may need to implement the following
 

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -384,6 +384,7 @@ class AgentState(ABC):
         # TODO(#97) write a test that ensures all AgentState statuses are here
         return [
             AgentState.STATUS_NONE,
+            AgentState.STATUS_ACCEPTED,
             AgentState.STATUS_ONBOARDING,
             AgentState.STATUS_WAITING,
             AgentState.STATUS_IN_TASK,

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -168,7 +168,8 @@ class TaskRunner(ABC):
             self.run_unit(unit, agent)
         except (AgentReturnedError, AgentTimeoutError, AgentDisconnectedError):
             # A returned Unit can be worked on again by someone else.
-            unit.clear_assigned_agent()
+            if unit.get_assigned_agent().db_id == agent.db_id:
+                unit.clear_assigned_agent()
             self.cleanup_unit(unit)
         except Exception as e:
             print(f"Unhandled exception in unit {unit}: {repr(e)}")


### PR DESCRIPTION
Agents weren't given the "Assigned" status when created. As it's impossible to create an agent without already having a unit to assign it to, the Agent should immediately move to Assigned. This allows the Unit to move from `LAUNCHED` to `ASSIGNED`.

Testing:
```
# Before accepting assignment
['launched', 'launched', 'launched', 'launched']
# After accepting assignment
['assigned', 'launched', 'launched', 'launched']
```