### PR TITLE
Proper Glob in heroku architect

### DIFF
--- a/mephisto/core/utils.py
+++ b/mephisto/core/utils.py
@@ -49,7 +49,7 @@ def ensure_user_confirm(display_text, skip_input=False) -> None:
 def get_root_dir() -> str:
     """Return the currently configured root mephisto directory"""
     # This file is at ROOT/mephisto/core/utils.py
-    return os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def get_mock_requester(db) -> "Requester":

--- a/mephisto/server/architects/heroku_architect.py
+++ b/mephisto/server/architects/heroku_architect.py
@@ -232,7 +232,7 @@ class HerokuArchitect(Architect):
             if os.path.exists(tar_path):
                 os.remove(tar_path)
 
-        heroku_directory_name = os.path.dirname(
+        heroku_directory_name = os.path.basename(
             glob.glob(os.path.join(HEROKU_TMP_DIR, "heroku-cli-*"))[0]
         )
         heroku_directory_path = os.path.join(HEROKU_TMP_DIR, heroku_directory_name)

--- a/mephisto/server/architects/heroku_architect.py
+++ b/mephisto/server/architects/heroku_architect.py
@@ -232,9 +232,9 @@ class HerokuArchitect(Architect):
             if os.path.exists(tar_path):
                 os.remove(tar_path)
 
-        heroku_directory_name = glob.glob(os.path.join(HEROKU_TMP_DIR, "heroku-cli-*"))[
-            0
-        ]
+        heroku_directory_name = os.path.dirname(
+            glob.glob(os.path.join(HEROKU_TMP_DIR, "heroku-cli-*"))[0]
+        )
         heroku_directory_path = os.path.join(HEROKU_TMP_DIR, heroku_directory_name)
         return os.path.join(heroku_directory_path, "bin", "heroku")
 


### PR DESCRIPTION
This wasn't quite working on all platforms, so I'm using `os.basename` to extract the heroku dir and append it to the rest of the path name.