### PR TITLE
[WIP] adding tasks/assignments dynamically

### DIFF
--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -289,6 +289,7 @@ class Operator:
                 if task_run.get_is_completed():
                     self.supervisor.shutdown_job(tracked_run.job)
                     tracked_run.architect.shutdown()
+                    tracked_run.task_launcher.shutdown()
                     del self._task_runs_tracked[task_run.db_id]
             time.sleep(2)
 
@@ -297,6 +298,7 @@ class Operator:
         self.is_shutdown = True
         for tracked_run in self._task_runs_tracked.values():
             logger.info("expiring units")
+            tracked_run.task_launcher.shutdown()
             tracked_run.task_launcher.expire_units()
         try:
             remaining_runs = self._task_runs_tracked.values()

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -270,8 +270,7 @@ class Operator:
             raise e
 
         launcher = TaskLauncher(self.db, task_run, initialization_data_array)
-        launcher.create_assignments()
-        launcher.launch_units(task_url)
+        launcher.start(task_url)
 
         self._task_runs_tracked[task_run.db_id] = TrackedRun(
             task_run=task_run,

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -246,9 +246,7 @@ class Operator:
             initialization_data_array = blueprint.get_initialization_data()
             # TODO(#99) extend
             if not isinstance(initialization_data_array, list):
-                raise NotImplementedError(
-                    "Non-list initialization data is not yet supported"
-                )
+                logger.info("Non-list initialization data is now supported")
 
             # Link the job together
             job = self.supervisor.register_job(
@@ -270,7 +268,8 @@ class Operator:
             raise e
 
         launcher = TaskLauncher(self.db, task_run, initialization_data_array)
-        launcher.start(task_url)
+        launcher.create_assignments()
+        launcher.launch_units(task_url)
 
         self._task_runs_tracked[task_run.db_id] = TrackedRun(
             task_run=task_run,

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -244,9 +244,6 @@ class Operator:
 
             blueprint = BlueprintClass(task_run, task_args)
             initialization_data_array = blueprint.get_initialization_data()
-            # TODO(#99) extend
-            if not isinstance(initialization_data_array, list):
-                logger.info("Non-list initialization data is now supported")
 
             # Link the job together
             job = self.supervisor.register_job(

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -32,6 +32,7 @@ from mephisto.core.logger_core import get_logger
 logger = get_logger(name=__name__, verbose=True, level="info")
 
 UNIT_GENERATOR_WAIT_SECONDS = 10
+ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5
 
 
 class TaskLauncher:
@@ -58,18 +59,32 @@ class TaskLauncher:
         self.max_num_concurrent_units = max_num_concurrent_units
         self.launched_units: Dict[str, Unit] = {}
         self.unlaunched_units: Dict[str, Unit] = {}
-        self.keep_launching: bool = False
+        self.keep_launching_units: bool = False
+        self.assignment_exist: bool = False
         run_dir = task_run.get_run_dir()
         os.makedirs(run_dir, exist_ok=True)
 
-    def create_assignments(self) -> None:
-        """
-        Create an assignment and associated units for any data
-        currently in the assignment config
-        """
-        task_run = self.task_run
-        task_config = task_run.get_task_config()
+    def start(self, url):
+        """ Start generating assignments and units """
+        assignments_thread = threading.Thread(
+            target=self._try_create_assignments, args=()
+        )
+        assignments_thread.start()
+
+        units_thread = threading.Thread(target=self._try_launch_units, args=(url,))
+        units_thread.start()
+
+    def generate_assignments(self):
+        """ Generate an assignment data from the current dynamic self.assignment_data_list """
         for data in self.assignment_data_list:
+            self.assignment_exist = True
+            yield data
+
+    def _try_create_assignments(self) -> None:
+        """ Create an assignment and associated units for the generated assignment data """
+        for data in self.generate_assignments():
+            task_run = self.task_run
+            task_config = task_run.get_task_config()
             assignment_id = self.db.new_assignment(
                 task_run.task_id,
                 task_run.db_id,
@@ -96,12 +111,14 @@ class TaskLauncher:
                 )
                 self.units.append(Unit(self.db, unit_id))
                 self.unlaunched_units[unit_id] = Unit(self.db, unit_id)
-                self.keep_launching = True
+                self.keep_launching_units = True
+            time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
+        self.assignment_exist = False
 
     def generate_units(self):
         """ units generator which checks that only 'max_num_concurrent_units' running at the same time,
         i.e. in the LAUNCHED or ASSIGNED states """
-        while self.keep_launching:
+        while self.keep_launching_units:
             units_id_to_remove = []
             for db_id, unit in self.launched_units.items():
                 status = unit.get_status()
@@ -130,23 +147,21 @@ class TaskLauncher:
             if not self.unlaunched_units:
                 break
 
-    def _launch_limited_units(self, url: str) -> None:
-        """ use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
-        for unit in self.generate_units():
-            unit.launch(url)
-
-    def launch_units(self, url: str) -> None:
-        """launch any units registered by this TaskLauncher"""
-        if self.max_num_concurrent_units > 0:
-            thread = threading.Thread(target=self._launch_limited_units, args=(url,))
-            thread.start()
-        else:
-            for db_id, unit in self.unlaunched_units.items():
-                unit.launch(url)
+    def _try_launch_units(self, url: str) -> None:
+        """ Launch all units or limited number of units according to (max_num_concurrent_units)"""
+        while self.assignment_exist:
+            if self.max_num_concurrent_units > 0:
+                for unit in self.generate_units():
+                    unit.launch(url)
+            else:
+                for _ in range(len(self.unlaunched_units.items())):
+                    db_id, unit = self.unlaunched_units.popitem()
+                    unit.launch(url)
+                time.sleep(0.5)
 
     def expire_units(self) -> None:
         """Clean up all units on this TaskLauncher"""
-        self.keep_launching = False
+        self.keep_launching_units = False
         for unit in self.units:
             try:
                 unit.expire()

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -32,8 +32,8 @@ import types
 
 logger = get_logger(name=__name__, verbose=True, level="debug")
 
-UNIT_GENERATOR_WAIT_SECONDS = 1
-ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.05
+UNIT_GENERATOR_WAIT_SECONDS = 10
+ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5
 
 
 class GeneratorType(enum.Enum):

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -17,10 +17,10 @@ from mephisto.data_model.assignment import (
     AssignmentState,
 )
 
-from typing import Dict, Optional, List, Any, TYPE_CHECKING
-
+from typing import Dict, Optional, List, Any, TYPE_CHECKING, Iterator
 import os
 import time
+import enum
 
 if TYPE_CHECKING:
     from mephisto.data_model.task import TaskRun
@@ -28,11 +28,18 @@ if TYPE_CHECKING:
 
 import threading
 from mephisto.core.logger_core import get_logger
+import types
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__, verbose=True, level="debug")
 
 UNIT_GENERATOR_WAIT_SECONDS = 10
-ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5
+GENERATOR_WAIT_SECONDS = 0.5
+
+
+class GeneratorType(enum.Enum):
+    none = 0
+    unit = 1
+    assignment = 2
 
 
 class TaskLauncher:
@@ -46,13 +53,13 @@ class TaskLauncher:
         self,
         db: "MephistoDB",
         task_run: "TaskRun",
-        assignment_data_list: List[InitializationData],
+        assignment_data_iterator: Iterator[InitializationData],
         max_num_concurrent_units: int = 0,
     ):
         """Prepare the task launcher to get it ready to launch the assignments"""
         self.db = db
         self.task_run = task_run
-        self.assignment_data_list = assignment_data_list
+        self.assignment_data_iterable = assignment_data_iterator
         self.assignments: List[Assignment] = []
         self.units: List[Unit] = []
         self.provider_type = task_run.get_provider().PROVIDER_TYPE
@@ -60,60 +67,81 @@ class TaskLauncher:
         self.launched_units: Dict[str, Unit] = {}
         self.unlaunched_units: Dict[str, Unit] = {}
         self.keep_launching_units: bool = False
-        self.assignment_exist: bool = False
+        self.finished_generators: bool = False
+        self.did_create_assignments = False
+        self.did_launch_units = False
+        self.unlaunched_units_access_condition = threading.Condition()
+        if isinstance(self.assignment_data_iterable, types.GeneratorType):
+            self.generator_type = GeneratorType.assignment
+        else:
+            self.generator_type = GeneratorType.none
         run_dir = task_run.get_run_dir()
         os.makedirs(run_dir, exist_ok=True)
 
-    def start(self, url):
-        """ Start generating assignments and units """
-        assignments_thread = threading.Thread(
-            target=self._try_create_assignments, args=()
+        logger.debug(f"type of assignment data: {type(self.assignment_data_iterable)}")
+        if self.generator_type is not GeneratorType.none:
+            self.finished_generators = False
+            main_thread = threading.Thread(target=self.manage_generators, args=())
+            main_thread.start()
+
+    def manage_generators(self) -> None:
+        while not self.finished_generators:
+            if self.did_create_assignments:
+                # try generating assignments
+                self._try_generate_assignments()
+            time.sleep(GENERATOR_WAIT_SECONDS)
+
+    def _create_single_assignment(self, assignment_data) -> None:
+        """ Create a single assignment in the database using its read assignment_data """
+        task_run = self.task_run
+        task_config = task_run.get_task_config()
+        assignment_id = self.db.new_assignment(
+            task_run.task_id,
+            task_run.db_id,
+            task_run.requester_id,
+            task_run.task_type,
+            task_run.provider_type,
+            task_run.sandbox,
         )
-        assignments_thread.start()
-
-        units_thread = threading.Thread(target=self._try_launch_units, args=(url,))
-        units_thread.start()
-
-    def generate_assignments(self):
-        """ Generate an assignment data from the current dynamic self.assignment_data_list """
-        for data in self.assignment_data_list:
-            self.assignment_exist = True
-            yield data
-
-    def _try_create_assignments(self) -> None:
-        """ Create an assignment and associated units for the generated assignment data """
-        for data in self.generate_assignments():
-            task_run = self.task_run
-            task_config = task_run.get_task_config()
-            assignment_id = self.db.new_assignment(
+        assignment = Assignment(self.db, assignment_id)
+        assignment.write_assignment_data(assignment_data)
+        self.assignments.append(assignment)
+        unit_count = len(assignment_data["unit_data"])
+        for unit_idx in range(unit_count):
+            unit_id = self.db.new_unit(
                 task_run.task_id,
                 task_run.db_id,
                 task_run.requester_id,
-                task_run.task_type,
+                assignment_id,
+                unit_idx,
+                task_config.task_reward,
                 task_run.provider_type,
+                task_run.task_type,
                 task_run.sandbox,
             )
-            assignment = Assignment(self.db, assignment_id)
-            assignment.write_assignment_data(data)
-            self.assignments.append(assignment)
-            unit_count = len(data["unit_data"])
-            for unit_idx in range(unit_count):
-                unit_id = self.db.new_unit(
-                    task_run.task_id,
-                    task_run.db_id,
-                    task_run.requester_id,
-                    assignment_id,
-                    unit_idx,
-                    task_config.task_reward,
-                    task_run.provider_type,
-                    task_run.task_type,
-                    task_run.sandbox,
-                )
-                self.units.append(Unit(self.db, unit_id))
+            self.units.append(Unit(self.db, unit_id))
+            with self.unlaunched_units_access_condition:
                 self.unlaunched_units[unit_id] = Unit(self.db, unit_id)
-                self.keep_launching_units = True
-            time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
-        self.assignment_exist = False
+            self.keep_launching_units = True
+
+    def _try_generate_assignments(self) -> None:
+        """ Try to generate more assignments from the assignments_data_iterator"""
+        try:
+            data = next(self.assignment_data_iterable)
+            self._create_single_assignment(data)
+        except StopIteration:
+            self.did_create_assignments = False
+            self.did_launch_units = False
+            self.finished_generators = True
+
+    def create_assignments(self) -> None:
+        """ Create an assignment and associated units for the generated assignment data """
+        if self.generator_type == GeneratorType.none:
+            for data in self.assignment_data_iterable:
+                self._create_single_assignment(data)
+        else:
+            self.did_create_assignments = True
+            self.did_launch_units = True
 
     def generate_units(self):
         """ units generator which checks that only 'max_num_concurrent_units' running at the same time,
@@ -131,6 +159,12 @@ class TaskLauncher:
                 self.launched_units.pop(db_id)
 
             num_avail_units = self.max_num_concurrent_units - len(self.launched_units)
+            num_avail_units = (
+                len(self.unlaunched_units)
+                if self.max_num_concurrent_units == 0
+                else num_avail_units
+            )
+
             units_id_to_remove = []
             for i, item in enumerate(self.unlaunched_units.items()):
                 db_id, unit = item
@@ -140,28 +174,33 @@ class TaskLauncher:
                     yield unit
                 else:
                     break
-            for db_id in units_id_to_remove:
-                self.unlaunched_units.pop(db_id)
+            with self.unlaunched_units_access_condition:
+                for db_id in units_id_to_remove:
+                    self.unlaunched_units.pop(db_id)
 
             time.sleep(UNIT_GENERATOR_WAIT_SECONDS)
             if not self.unlaunched_units:
                 break
 
-    def _try_launch_units(self, url: str) -> None:
-        """ Launch all units or limited number of units according to (max_num_concurrent_units)"""
-        while self.assignment_exist:
-            if self.max_num_concurrent_units > 0:
-                for unit in self.generate_units():
-                    unit.launch(url)
-            else:
-                for _ in range(len(self.unlaunched_units.items())):
-                    db_id, unit = self.unlaunched_units.popitem()
-                    unit.launch(url)
-                time.sleep(0.5)
+    def _launch_limited_units(self, url: str) -> None:
+        """ use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
+        while self.did_launch_units:
+            for unit in self.generate_units():
+                unit.launch(url)
+            if self.generator_type == GeneratorType.none:
+                self.did_launch_units = False
+                break
+
+    def launch_units(self, url: str) -> None:
+        """launch any units registered by this TaskLauncher"""
+        self.did_launch_units = True
+        thread = threading.Thread(target=self._launch_limited_units, args=(url,))
+        thread.start()
 
     def expire_units(self) -> None:
         """Clean up all units on this TaskLauncher"""
         self.keep_launching_units = False
+        self.finished_generators = True
         for unit in self.units:
             try:
                 unit.expire()

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -32,8 +32,8 @@ import types
 
 logger = get_logger(name=__name__, verbose=True, level="debug")
 
-UNIT_GENERATOR_WAIT_SECONDS = 10
-ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5
+UNIT_GENERATOR_WAIT_SECONDS = 1
+ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.05
 
 
 class GeneratorType(enum.Enum):
@@ -200,6 +200,9 @@ class TaskLauncher:
                     f"Warning: failed to expire unit {unit.db_id}. Stated error: {e}",
                     exc_info=True,
                 )
-        if self.units_thread is not None and self.assignments_thread is not None:
-            self.units_thread.join()
+
+    def shutdown(self) -> None:
+        """Clean up running threads for generating assignments and units"""
+        if self.assignments_thread is not None:
             self.assignments_thread.join()
+        self.units_thread.join()

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -616,6 +616,17 @@ class Blueprint(ABC):
         builder_group = group.add_argument_group("task_builder_args")
         cls.TaskRunnerClass.add_args_to_group(runner_group)
         cls.TaskBuilderClass.add_args_to_group(builder_group)
+
+        group.add_argument(
+            "--block-qualification",
+            dest="block_qualification",
+            help=(
+                "Name of qualification to use in order to soft block workers "
+                "from working on this task (or any task using this block "
+                "qualification name)."
+            ),
+            required=False,
+        )
         # group.description = 'For `Blueprint`, you can supply...'
         # group.add_argument('--task-option', help='Lets you customize')
         return

--- a/mephisto/providers/mturk/mturk_provider.py
+++ b/mephisto/providers/mturk/mturk_provider.py
@@ -108,6 +108,8 @@ class MTurkProvider(CrowdProvider):
                     "QualificationTypeId"
                 ] = requester._create_new_mturk_qualification(qualification_name)
 
+        qualifications += task_args.get("mturk_specific_qualifications", [])
+
         # Set up HIT type
         client = self._get_client(requester._requester_name)
         hit_type_id = create_hit_type(client, task_config, qualifications)

--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -384,7 +384,7 @@ def create_hit_type(
                 "QualificationTypeId": MTURK_LOCALE_REQUIREMENT,
                 "Comparator": "In",
                 "LocaleValues": allowed_locales,
-                "RequiredToPreview": True,
+                "ActionsGuarded": "DiscoverPreviewAndAccept",
             }
         )
 

--- a/mephisto/server/blueprints/abstract/static_task/static_blueprint.py
+++ b/mephisto/server/blueprints/abstract/static_task/static_blueprint.py
@@ -75,7 +75,7 @@ class StaticBlueprint(Blueprint, OnboardingRequired):
             jsonl_file = os.path.expanduser(opts["data_jsonl"])
             with open(jsonl_file, "r", encoding="utf-8-sig") as jsonl_fp:
                 line = jsonl_fp.readline()
-                while (line):
+                while line:
                     j = json.loads(line)
                     self._initialization_data_dicts.append(j)
                     line = jsonl_fp.readline()

--- a/mephisto/server/blueprints/acute_eval/acute_eval_runner.py
+++ b/mephisto/server/blueprints/acute_eval/acute_eval_runner.py
@@ -303,19 +303,19 @@ class AcuteEvalRunner(TaskRunner):
         tasks_per_unit = self.opts["subtasks_per_unit"]
         # first add onboarding tasks
         task_data = self.get_onboarding_tasks(worker_id)
-        logger.debug("Onboarding task data gotten: ", len(task_data))
+        logger.debug(f"Onboarding task data gotten: {len(task_data)}")
         if len(task_data) == tasks_per_unit:
             return task_data
 
         # poll the task queue for more tasks
         task_data = self._poll_task_queue(worker_id, task_data)
-        logger.debug("Task queue data gotten: ", len(task_data))
+        logger.debug(f"Task queue data gotten: {len(task_data)}")
         if len(task_data) == tasks_per_unit:
             return task_data
 
         # top up the task_data if we don't hit the desired tasks_per_unit
         task_data = self._top_up_task_data(worker_id, task_data)
-        logger.debug("Topped off data gotten: ", len(task_data))
+        logger.debug(f"Topped off data gotten: {len(task_data)}")
         return task_data
 
     def requeue_task_data(self, worker_id: str, task_data: List[PairingsDict]):

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -19,6 +19,8 @@ from mephisto.core.local_database import LocalMephistoDB
 from mephisto.core.operator import Operator
 from mephisto.server.architects.mock_architect import MockArchitect
 
+TIMEOUT_TIME = 10
+
 
 class TestOperator(unittest.TestCase):
     """
@@ -123,7 +125,6 @@ class TestOperator(unittest.TestCase):
 
         # Give up to 5 seconds for whole mock task to complete
         start_time = time.time()
-        TIMEOUT_TIME = 3
         while time.time() - start_time < TIMEOUT_TIME:
             if len(self.operator.get_running_task_runs()) == 0:
                 break
@@ -195,7 +196,6 @@ class TestOperator(unittest.TestCase):
 
         # Give up to 5 seconds for both tasks to complete
         start_time = time.time()
-        TIMEOUT_TIME = 3
         while time.time() - start_time < TIMEOUT_TIME:
             if len(self.operator.get_running_task_runs()) == 0:
                 break
@@ -328,7 +328,6 @@ class TestOperator(unittest.TestCase):
 
         # Give up to 5 seconds for whole mock task to complete
         start_time = time.time()
-        TIMEOUT_TIME = 3
         while time.time() - start_time < TIMEOUT_TIME:
             if len(self.operator.get_running_task_runs()) == 0:
                 break
@@ -396,7 +395,6 @@ class TestOperator(unittest.TestCase):
 
         # Ensure the task run completed and that all assignments are done
         start_time = time.time()
-        TIMEOUT_TIME = 3
         while time.time() - start_time < TIMEOUT_TIME:
             if len(self.operator.get_running_task_runs()) == 0:
                 break

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -8,7 +8,7 @@ import unittest
 import shutil
 import os
 import tempfile
-from typing import List
+from typing import List, Iterable
 import time
 
 from mephisto.data_model.test.utils import get_test_task_run
@@ -23,6 +23,8 @@ from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprint
 from mephisto.server.blueprints.mock.mock_task_runner import MockTaskRunner
 
 MAX_WAIT_TIME_UNIT_LAUNCH = 15
+NUM_GENERATED_ASSIGNMENTS = 10
+WAIT_TIME_TILL_NEXT_ASSIGNMENT = 1
 
 
 class LimitedDict(dict):
@@ -55,6 +57,12 @@ class TestTaskLauncher(unittest.TestCase):
 
     def get_mock_assignment_data_array(self) -> List[InitializationData]:
         return [MockTaskRunner.get_mock_assignment_data()]
+
+    @staticmethod
+    def get_mock_assignment_data_generator() -> Iterable[InitializationData]:
+        for _ in range(NUM_GENERATED_ASSIGNMENTS):
+            yield MockTaskRunner.get_mock_assignment_data()
+            time.sleep(WAIT_TIME_TILL_NEXT_ASSIGNMENT)
 
     def test_init_on_task_run(self):
         """Initialize a launcher on a task_run"""
@@ -132,6 +140,35 @@ class TestTaskLauncher(unittest.TestCase):
             launcher.expire_units()
             self.tearDown()
             self.setUp()
+
+    def test_assignments_generator(self):
+        """Initialize a launcher on a task run, then create the assignments"""
+        mock_data_array = self.get_mock_assignment_data_generator()
+        launcher = TaskLauncher(self.db, self.task_run, mock_data_array)
+
+        start_time = time.time()
+        launcher.create_assignments()
+        end_time = time.time()
+        self.assertLessEqual(end_time-start_time, (NUM_GENERATED_ASSIGNMENTS * WAIT_TIME_TILL_NEXT_ASSIGNMENT)/2)
+
+        for unit in launcher.units:
+            self.assertEqual(unit.get_db_status(), AssignmentState.CREATED)
+        for assignment in launcher.assignments:
+            self.assertEqual(assignment.get_status(), AssignmentState.CREATED)
+
+        launcher.launch_units("dummy-url:3000")
+
+        for unit in launcher.units:
+            self.assertEqual(unit.get_db_status(), AssignmentState.LAUNCHED)
+        for assignment in launcher.assignments:
+            self.assertEqual(assignment.get_status(), AssignmentState.LAUNCHED)
+
+        launcher.expire_units()
+
+        for unit in launcher.units:
+            self.assertEqual(unit.get_db_status(), AssignmentState.EXPIRED)
+        for assignment in launcher.assignments:
+            self.assertEqual(assignment.get_status(), AssignmentState.EXPIRED)
 
 
 if __name__ == "__main__":

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -25,7 +25,7 @@ from mephisto.server.blueprints.mock.mock_task_runner import MockTaskRunner
 MAX_WAIT_TIME_UNIT_LAUNCH = 15
 NUM_GENERATED_ASSIGNMENTS = 10
 WAIT_TIME_TILL_NEXT_ASSIGNMENT = 1
-
+WAIT_TIME_TILL_NEXT_UNIT = 0.01
 
 class LimitedDict(dict):
     def __init__(self, limit):
@@ -102,6 +102,7 @@ class TestTaskLauncher(unittest.TestCase):
 
         for unit in launcher.units:
             self.assertEqual(unit.get_db_status(), AssignmentState.LAUNCHED)
+            time.sleep(WAIT_TIME_TILL_NEXT_UNIT)
         for assignment in launcher.assignments:
             self.assertEqual(assignment.get_status(), AssignmentState.LAUNCHED)
 

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -55,7 +55,8 @@ class TestTaskLauncher(unittest.TestCase):
         self.db.shutdown()
         shutil.rmtree(self.data_dir)
 
-    def get_mock_assignment_data_array(self) -> List[InitializationData]:
+    @staticmethod
+    def get_mock_assignment_data_array() -> List[InitializationData]:
         return [MockTaskRunner.get_mock_assignment_data()]
 
     @staticmethod
@@ -142,33 +143,17 @@ class TestTaskLauncher(unittest.TestCase):
             self.setUp()
 
     def test_assignments_generator(self):
-        """Initialize a launcher on a task run, then create the assignments"""
+        """Initialize a launcher on a task run, then try generate the assignments"""
         mock_data_array = self.get_mock_assignment_data_generator()
-        launcher = TaskLauncher(self.db, self.task_run, mock_data_array)
 
         start_time = time.time()
+        launcher = TaskLauncher(self.db, self.task_run, mock_data_array)
         launcher.create_assignments()
         end_time = time.time()
-        self.assertLessEqual(end_time-start_time, (NUM_GENERATED_ASSIGNMENTS * WAIT_TIME_TILL_NEXT_ASSIGNMENT)/2)
-
-        for unit in launcher.units:
-            self.assertEqual(unit.get_db_status(), AssignmentState.CREATED)
-        for assignment in launcher.assignments:
-            self.assertEqual(assignment.get_status(), AssignmentState.CREATED)
-
-        launcher.launch_units("dummy-url:3000")
-
-        for unit in launcher.units:
-            self.assertEqual(unit.get_db_status(), AssignmentState.LAUNCHED)
-        for assignment in launcher.assignments:
-            self.assertEqual(assignment.get_status(), AssignmentState.LAUNCHED)
-
-        launcher.expire_units()
-
-        for unit in launcher.units:
-            self.assertEqual(unit.get_db_status(), AssignmentState.EXPIRED)
-        for assignment in launcher.assignments:
-            self.assertEqual(assignment.get_status(), AssignmentState.EXPIRED)
+        self.assertLessEqual(
+            end_time - start_time,
+            (NUM_GENERATED_ASSIGNMENTS * WAIT_TIME_TILL_NEXT_ASSIGNMENT) / 2,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I've started with Jack's first suggestion in the issue#99: 

- create a main thread that is responsible of running both: `try_launch_units()` and `try_create_assignments()` threads.
- I doubt that `generate_assignment()` with its current version will work if `self.assignment_data_list` is changing its size (which is what I expect as the required task is to allow dynamic size of this list) but I need to think about how to test it to know if it works.