### PR TITLE
Requeue incomplete ParlAI chats when single-person

### DIFF
--- a/mephisto/data_model/assignment.py
+++ b/mephisto/data_model/assignment.py
@@ -378,6 +378,8 @@ class Unit(ABC):
     def clear_assigned_agent(self) -> None:
         """Clear the agent that is assigned to this unit"""
         self.db.clear_unit_agent_assignment(self.db_id)
+        self.agent_id = None
+        self.__agent = None
 
     def get_assigned_agent(self) -> Optional[Agent]:
         """
@@ -468,12 +470,13 @@ class Unit(ABC):
                 computed_status = AssignmentState.COMPLETED
             elif agent_status in [AgentState.STATUS_SOFT_REJECTED]:
                 computed_status = AssignmentState.SOFT_REJECTED
+            elif agent_status in [AgentState.STATUS_EXPIRED]:
+                computed_status = AssignmentState.EXPIRED
             elif agent_status in [
                 AgentState.STATUS_DISCONNECT,
-                AgentState.STATUS_EXPIRED,
                 AgentState.STATUS_RETURNED,
             ]:
-                computed_status = AssignmentState.EXPIRED
+                computed_status = AssignmentState.ASSIGNED
             elif agent_status == AgentState.STATUS_APPROVED:
                 computed_status = AssignmentState.ACCEPTED
             elif agent_status == AgentState.STATUS_REJECTED:

--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -127,7 +127,8 @@ class ParlAIChatTaskRunner(TaskRunner):
         sys.path.append(world_module_path)
         world_module_name = os.path.basename(world_file_path)[:-3]
         self.parlai_world_module = import_module(world_module_name)
-        self.is_concurrent = True
+        world_params = self.parlai_world_module.get_world_params()
+        self.is_concurrent = world_params['agent_count'] > 1
         self.id_to_worlds: Dict[str, Any] = {}
 
     def get_init_data_for_agent(self, agent: "Agent") -> Dict[str, Any]:


### PR DESCRIPTION
# Overview
Before this PR, all ParlAI chat tasks assumed that multiple people were always in chats, which would prevent Mephisto from re-queue-ing tasks when a worker returned the task. This is valid if 2 or more people were in chat (as we needed to pay out the worker disconnected on) but not necessary when you're just talking to a model.

This allows tasks with only 1 worker to be run non-concurrently, which means the task is automatically requeued when returned.

@dianaglzrico @jxmsML @EricMichaelSmith 
This removes the need for the `parlai-as-unit` branch.

# Testing
`pytest test`  passes.
Manually running the following instances works:
- single assignment with 1 `agent_count`, disconnect, then be able to work on it again.
- single assignment with 2 `agent_count`. Complete normally
- single assignment with 2 `agent_count` with one disconnect. Allows task to complete normally, but shutdown is not always clean. This is also sometimes true on master, so not a regression. To be addressed in #158.