### PR TITLE
Directly softblock MTurk workers

### DIFF
--- a/mephisto/providers/mturk/utils/__init__.py
+++ b/mephisto/providers/mturk/utils/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional
+
+from mephisto.providers.mturk.mturk_utils import give_worker_qualification
+from mephisto.core.local_database import LocalMephistoDB
+from mephisto.data_model.requester import Requester
+
+
+def direct_soft_block_mturk_workers(
+    worker_list: List[str], 
+    soft_block_qual_name: str, 
+    requester_name: Optional[str] = None,
+):
+    db = LocalMephistoDB()
+    reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
+    requester = reqs[0]
+
+    mturk_qual_details = requester.datastore.get_qualification_mapping(
+        soft_block_qual_name
+    )
+    if mturk_qual_details is not None:
+        # Overrule the requester, as this qualification already exists
+        requester = Requester(db, mturk_qual_details["requester_id"])
+        qualification_id = mturk_qual_details["mturk_qualification_id"]
+    else:
+        qualification_id = requester._create_new_mturk_qualification(
+            soft_block_qual_name
+        )
+    
+    mturk_client = requester._get_client(requester._requester_name)
+    for worker_id in worker_list:
+        give_worker_qualification(
+            mturk_client,
+            worker_id,
+            qualification_id,
+            value=1,
+        )
+
+
+

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -4,19 +4,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 from mephisto.providers.mturk.mturk_utils import give_worker_qualification
-from mephisto.core.local_database import LocalMephistoDB
 from mephisto.data_model.requester import Requester
 
+if TYPE_CHECKING:
+    from mephisto.data_model.database import MephistoDB
 
 def direct_soft_block_mturk_workers(
+    db: "MephistoDB",
     worker_list: List[str],
     soft_block_qual_name: str,
     requester_name: Optional[str] = None,
 ):
-    db = LocalMephistoDB()
     reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
     requester = reqs[0]
 

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -12,8 +12,8 @@ from mephisto.data_model.requester import Requester
 
 
 def direct_soft_block_mturk_workers(
-    worker_list: List[str], 
-    soft_block_qual_name: str, 
+    worker_list: List[str],
+    soft_block_qual_name: str,
     requester_name: Optional[str] = None,
 ):
     db = LocalMephistoDB()
@@ -31,15 +31,7 @@ def direct_soft_block_mturk_workers(
         qualification_id = requester._create_new_mturk_qualification(
             soft_block_qual_name
         )
-    
+
     mturk_client = requester._get_client(requester._requester_name)
     for worker_id in worker_list:
-        give_worker_qualification(
-            mturk_client,
-            worker_id,
-            qualification_id,
-            value=1,
-        )
-
-
-
+        give_worker_qualification(mturk_client, worker_id, qualification_id, value=1)

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -25,7 +25,7 @@ def direct_soft_block_mturk_workers(
     in the database
     """
     reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
-    requester = reqs[0]
+    requester = reqs[-1]
 
     mturk_qual_details = requester.datastore.get_qualification_mapping(
         soft_block_qual_name

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -18,6 +18,12 @@ def direct_soft_block_mturk_workers(
     soft_block_qual_name: str,
     requester_name: Optional[str] = None,
 ):
+    """
+    Directly assign the soft blocking MTurk qualification that Mephisto 
+    associates with soft_block_qual_name to all of the workers in worker_list.
+    If requester_name is not provided, it will use the first mturk requester
+    in the database
+    """
     reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
     requester = reqs[0]
 

--- a/mephisto/providers/mturk/utils/script_utils.py
+++ b/mephisto/providers/mturk/utils/script_utils.py
@@ -20,9 +20,9 @@ def direct_soft_block_mturk_workers(
 ):
     """
     Directly assign the soft blocking MTurk qualification that Mephisto 
-    associates with soft_block_qual_name to all of the workers in worker_list.
-    If requester_name is not provided, it will use the first mturk requester
-    in the database
+    associates with soft_block_qual_name to all of the MTurk worker ids 
+    in worker_list. If requester_name is not provided, it will use the 
+    most recently registered mturk requester in the database.
     """
     reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
     requester = reqs[-1]

--- a/mephisto/scripts/__init__.py
+++ b/mephisto/scripts/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/mephisto/scripts/mturk/__init__.py
+++ b/mephisto/scripts/mturk/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
+++ b/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
@@ -18,7 +18,7 @@ soft_block_qual_name = input("Provide a soft blocking qualification name: ")
 
 workers_to_block = []
 while True:
-    new_id = input("MTurk Worker Id to soft block (blank to continue): ")
+    new_id = input("MTurk Worker Id to soft block (blank to block all entered): ")
     if len(new_id.strip()) == 0:
         break
     workers_to_block.append(new_id)

--- a/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
+++ b/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
@@ -23,8 +23,4 @@ while True:
         break
     workers_to_block.append(new_id)
 
-direct_soft_block_mturk_workers(
-    workers_to_block,
-    soft_block_qual_name, 
-    requester_name,
-)
+direct_soft_block_mturk_workers(workers_to_block, soft_block_qual_name, requester_name)

--- a/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
+++ b/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.providers.mturk.utils.script_utils import direct_soft_block_mturk_workers
+
+from mephisto.core.local_database import LocalMephistoDB
+
+db = LocalMephistoDB()
+reqs = db.find_requesters(provider_type="mturk")
+names = [r.requester_name for r in reqs]
+print("Available Requesters: ", names)
+
+requester_name = input("Select a requester to soft block from: ")
+soft_block_qual_name = input("Provide a soft blocking qualification name: ")
+
+workers_to_block = []
+while True:
+    new_id = input("MTurk Worker Id to soft block (blank to continue): ")
+    if len(new_id.strip()) == 0:
+        break
+    workers_to_block.append(new_id)
+
+direct_soft_block_mturk_workers(
+    workers_to_block,
+    soft_block_qual_name, 
+    requester_name,
+)

--- a/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
+++ b/mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py
@@ -23,4 +23,4 @@ while True:
         break
     workers_to_block.append(new_id)
 
-direct_soft_block_mturk_workers(workers_to_block, soft_block_qual_name, requester_name)
+direct_soft_block_mturk_workers(db, workers_to_block, soft_block_qual_name, requester_name)


### PR DESCRIPTION
# Overview
This includes a utility function that allows directly softblocking MTurk workers. It also includes a script that lets you block from the command line.

Closes #183

cc @mwillwork @EricMichaelSmith @jxmsML 

# Testing
Ran:
```
> python mephisto/scripts/mturk/soft_block_workers_by_mturk_id.py 
```
and assigned a block qualification to myself directly from MTurk worker id.