### PR TITLE
Allow displaying images for ACUTE-Evals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ examples/**/build/*
 # temporary files for inspiration from ParlAI-MTurk
 old_code/*
 mephisto/server/architects/router_old/*
+
+# PyCharm
+.idea

--- a/examples/acute_eval_demo/README.md
+++ b/examples/acute_eval_demo/README.md
@@ -62,6 +62,8 @@ This is a template of the expected format with the minimal expected fields:
       ]
     }
 
+You can add an `"image_src"` key to an entry of `"dialogue"` to append an image to a chat message. The value of the key should be a serialized image, starting with a string such `data:image/jpeg;base64,`.
+
 For onboarding tasks - tasks used to filter workers, see below for more details - you must additionally set a `correct_answer` field:
 
     {

--- a/examples/acute_eval_demo/example_script.py
+++ b/examples/acute_eval_demo/example_script.py
@@ -83,7 +83,7 @@ extra_args = {
     "annotations_per_pair": args["annotations_per_pair"],
     "random_seed": 42,  # random seed
     "subtasks_per_unit": args[
-        "subtask_per_unit"
+        "subtasks_per_unit"
     ],  # num comparisons to show within one unit
     "num_matchup_pairs": args[
         "num_matchup_pairs"

--- a/examples/acute_eval_demo/example_script.py
+++ b/examples/acute_eval_demo/example_script.py
@@ -76,7 +76,7 @@ ARG_STRING = (
 )
 
 extra_args = {
-    "pairings_filepath": f"{TASK_DIRECTORY}/pairings.jsonl",
+    "pairings_filepath": args['pairings_filepath'],
     "block_on_onboarding_fail": True,
     "block_qualification": f"acute_eval_{int(time.time())}_block",
     # num times to use the same conversation pair

--- a/mephisto/server/blueprints/acute_eval/acute_eval_blueprint.py
+++ b/mephisto/server/blueprints/acute_eval/acute_eval_blueprint.py
@@ -159,11 +159,18 @@ class AcuteEvalBlueprint(Blueprint):
         #     default=None,
         #     help='Path to list of workers to softblock, separated by line breaks',
         # )
+        group.add_argument(
+            "--additional-task-description",
+            dest="additional_task_description",
+            type=str,
+            default='',
+            help="Additional text to show on the left pane",
+        )
         return
 
     def get_frontend_args(self) -> Dict[str, Any]:
         """
-        Specifies what options within a task_config should be fowarded 
+        Specifies what options within a task_config should be forwarded
         to the client for use by the task's frontend
         """
         return {
@@ -173,6 +180,7 @@ class AcuteEvalBlueprint(Blueprint):
             "question": self.opts["eval_question"],
             "block_mobile": True,
             "get_task_feedback": False,  # TODO(#95) make option
+            "additional_task_description": self.opts['additional_task_description'],
         }
 
     def get_initialization_data(self) -> Iterable["InitializationData"]:

--- a/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
+++ b/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
@@ -103,7 +103,9 @@ function MessageList({ task_data, index }) {
     messageList = messages.map((m, idx) => (
       <div key={model + "_" + idx}>
         <ChatMessage
-          message={m.text}
+          message={m.image_src !== undefined ? m.text + (
+            <img src={m.image_src} alt='Image'/>
+          ) : m.text}
           is_primary_speaker={m.id == primary_speaker}
           model={model}
         />

--- a/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
+++ b/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
@@ -48,7 +48,7 @@ const otherspeaker_style = {
   backgroundColor: otherspeaker_color,
 };
 
-function ChatMessage({ message, model, is_primary_speaker }) {
+function ChatMessage({ message, model, is_primary_speaker, image_src }) {
   let primary_speaker_color =
     model === "model_left" ? speaker1_color : speaker2_color;
   let message_container_style = {
@@ -79,11 +79,21 @@ function ChatMessage({ message, model, is_primary_speaker }) {
           backgroundColor: otherspeaker_color,
         }),
   };
-  return (
-    <div style={message_container_style}>
-      <div style={message_style}>{message}</div>
-    </div>
-  );
+  if (image_src !== null) {
+    return (
+      <div style={message_container_style}>
+        <div style={message_style}>
+          {message}<img src={image_src} width="320" alt='Image'/>
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div style={message_container_style}>
+        <div style={message_style}>{message}</div>
+      </div>
+    );
+  }
 }
 
 function MessageList({ task_data, index }) {
@@ -103,12 +113,10 @@ function MessageList({ task_data, index }) {
     messageList = messages.map((m, idx) => (
       <div key={model + "_" + idx}>
         <ChatMessage
-          message={
-            m.image_src !== undefined && m.image_src !== null
-              ? m.text + "<img src={m.image_src} alt='Image'/>" : m.text
-          }
+          message={m.text}
           is_primary_speaker={m.id == primary_speaker}
           model={model}
+          image_src={m.image_src !== undefined ? m.image_src : null}
         />
       </div>
     ));
@@ -555,6 +563,7 @@ class TaskDescription extends React.Component {
     let num_subtasks = task_config.num_subtasks;
     let question = task_config.question;
     let additional_task_description = task_config.additional_task_description;
+    console.log(additional_task_description);
     let content = (
       <div>
         In this task, you will read two conversations and judge&nbsp;
@@ -585,6 +594,8 @@ class TaskDescription extends React.Component {
         Additional pages will show errors or fail to load and you wll not be
         able to submit the hit.&nbsp;
         <h4>Please accept the task if you're ready.</h4>
+        <br />
+        {additional_task_description}
       </div>
     );
     if (!this.props.is_cover_page) {
@@ -623,6 +634,7 @@ class TaskDescription extends React.Component {
             You will do this for {num_subtasks} pairs of conversations.&nbsp;
             After completing each judgement, use the [NEXT] button.
           </b>
+          <br />
           <br />
           {additional_task_description}
         </div>

--- a/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
+++ b/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
@@ -90,7 +90,7 @@ function MessageList({ task_data, index }) {
   let messageList;
 
   if (task_data.pairing_dict === undefined) {
-    messageLists = (
+    messageList = (
       <div>
         <p> Loading chats </p>
       </div>
@@ -103,9 +103,10 @@ function MessageList({ task_data, index }) {
     messageList = messages.map((m, idx) => (
       <div key={model + "_" + idx}>
         <ChatMessage
-          message={m.image_src !== undefined ? m.text + (
-            <img src={m.image_src} alt='Image'/>
-          ) : m.text}
+          message={
+            m.image_src !== undefined && m.image_src !== null
+              ? m.text + "<img src={m.image_src} alt='Image'/>" : m.text
+          }
           is_primary_speaker={m.id == primary_speaker}
           model={model}
         />
@@ -553,6 +554,7 @@ class TaskDescription extends React.Component {
     let task_config = this.props.task_config;
     let num_subtasks = task_config.num_subtasks;
     let question = task_config.question;
+    let additional_task_description = task_config.additional_task_description;
     let content = (
       <div>
         In this task, you will read two conversations and judge&nbsp;
@@ -622,6 +624,7 @@ class TaskDescription extends React.Component {
             After completing each judgement, use the [NEXT] button.
           </b>
           <br />
+          {additional_task_description}
         </div>
       );
     }

--- a/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
+++ b/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
@@ -563,7 +563,6 @@ class TaskDescription extends React.Component {
     let num_subtasks = task_config.num_subtasks;
     let question = task_config.question;
     let additional_task_description = task_config.additional_task_description;
-    console.log(additional_task_description);
     let content = (
       <div>
         In this task, you will read two conversations and judge&nbsp;


### PR DESCRIPTION
If a message has an "image_src" field (consisting of a serialized image string), show it in a chat bubble.

Also:
- Add the option to include additional task description text at the bottom of the left pane for ACUTE-Evals
- Fix in passing through "pairings_filepath" in `examples/acute_eval_demo/example_script.py`
- Small addition to .gitignore