### PR TITLE
Single file ParlAI chat builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ mephisto/server/blueprints/**/build/*
 examples/**/build/*
 **/*.log
 **/build/*
-**/pre_build/*
+**/_generated/*
 
 # temporary files for inspiration from ParlAI-MTurk
 old_code/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ tmp/*
 mephisto/server/**/package-lock.json
 mephisto/server/blueprints/**/build/*
 examples/**/build/*
+**/*.log
+**/build/*
+**/pre_build/*
 
 # temporary files for inspiration from ParlAI-MTurk
 old_code/*

--- a/examples/parlai_chat_task_demo/README.md
+++ b/examples/parlai_chat_task_demo/README.md
@@ -17,6 +17,12 @@ Further, you can try running a task using a customized frontend bundle with:
 python examples/parlai_chat_task_demo/parlai_test_script.py --use-custom-task true
 ```
 
+### Command line arguments
+- `--use-onboarding` (bool): Whether or not to launch this demo task with an onboarding world to see how onboarding worlds work.
+- `--build-custom-task` (bool): Whether to use the `ParlAIChatTaskBuilder` to build a custom frontend source from the `custom_simple` directory. See usage of `--custom-source-dir` in the Task Arguments section to use this for your task.
+- `--use-custom-task` (bool): Whether or not to launch the task with a prebuilt frontend source file (not created with the `TaskBuilder`), expected to by this script to be at `webapp/build/bundle.js`.
+- `--turn-timeout` (int): Maximum time in seconds to wait for a response between turns before marking a worker as timed out (default 300 seconds).
+
 ## Implementation
 ### Configuration
 The run script for this example task is configured using the `MephistoRunScriptParser`, and more details about using this utility can be found viewing other examples, or by checking the documentation (TODO). This task adds an additional argument for `--use-onboarding` to demonstrate how to have an onboarding step before the main task world, as well as a `--use-custom-task` argument to demonstrate how to get ParlAI tasks to load a custom frontend.
@@ -45,10 +51,11 @@ Within the run script, you'll find a number of arguments set up via an `ARG_STRI
 - `--task-reward` - The reward paid out in dollars for completing your task
 - `--onboarding-qualification` (optional) - The qualification to grant to a worker when they have completed onboarding, such that they no longer need to do onboarding in future tasks where you specify the same qualification name. This qualification will 
 - `--task-name` - This task name will be used to consolidate your data across runs. Generally we suggest using `descriptive-string-pilot-#` when piloting and `descriptive-task-string` for your main collection. More details on this are in the (TODO) Mephisto argument instructions.
-#### ParlAI arguments
+#### ParlAI-specific arguments
 - `--world-file` - Path to the python file containing your worlds. Detailed requirements of this file in the "The worlds file" section.
 - `--task-description-file` - Path to an HTML file containing the task preview and basic instructions for your task. If you use a custom built frontend, you can omit this argument and directly edit the `TaskPreviewView` in `app.jsx` instead. 
 - `--num-conversations` - Number of conversations to have. This currently leads to `--num-conversations` * `agent_count` tasks being launched for workers to do. Incomplete tasks are _currently_ not relaunched.
+- `--custom-source-dir` - Path to a folder containing, at the very least, a `main.js` for a custom ParlAI frontend view. Can also contain an updated `package.json` if that file imports anything outside of the defaults used in `server/blueprints/parlai_chat/webapp/package.json`. Providing this flag will make Mephisto build that frontend in a `_generated` directory, and refer to that build when launching your task. Mephisto will only rebuild when the source files in the provided `--custom-source-dir` are updated.
 - `--custom-source-bundle` - Path to a custom built source bundle to deploy to the frontend instead of the standard ParlAI view. For this task we specify a build in the `webapp` directory, but you'll need to run `npm install; npm run dev` in that directory the first time you use a bundle (and whenever you make changes to the `src` that you want to be picked up)
 - `world_opt` (passed via `extra_args`) - The world option will be passed to the `make_world` function as the first argument. Passing contents through `world_opt` is the preferred way to share important state between different calls to `make_world`, as this dict will be shared amongst all calls.
 - `onboarding_world_opt` (passed via `extra_args`) - The world option will be passed to the `make_onboarding_world` function as the first argument. 

--- a/examples/parlai_chat_task_demo/custom_simple/main.js
+++ b/examples/parlai_chat_task_demo/custom_simple/main.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom";
+import "bootstrap-chat/styles.css";
+
+import { ChatApp, ChatMessage, DefaultTaskDescription } from "bootstrap-chat";
+
+function RenderChatMessage({ message, mephistoContext, appContext, idx }) {
+  const { agentId } = mephistoContext;
+  const { currentAgentNames } = appContext.taskContext;
+
+  return (
+    <div onClick={() => alert("You clicked on message with index " + idx)}>
+      <ChatMessage
+        isSelf={message.id === agentId || message.id in currentAgentNames}
+        agentName={
+          message.id in currentAgentNames
+            ? currentAgentNames[message.id]
+            : message.id
+        }
+        message={message.text}
+        taskData={message.task_data}
+        messageId={message.message_id}
+      />
+    </div>
+  );
+}
+
+function MainApp() {
+  return (
+    <ChatApp
+      renderMessage={({ message, idx, mephistoContext, appContext }) => (
+        <RenderChatMessage
+          message={message}
+          mephistoContext={mephistoContext}
+          appContext={appContext}
+          idx={idx}
+          key={message.message_id + "-" + idx}
+        />
+      )}
+      renderSidePane={({ mephistoContext: { taskConfig } }) => (
+        <DefaultTaskDescription
+          chatTitle={taskConfig.chat_title}
+          taskDescriptionHtml={taskConfig.task_description}
+        >
+          <h2>This is a custom Task Description loaded from a custom bundle</h2>
+          <p>
+            It has the ability to do a number of things, like directly access
+            the contents of task data, view the number of messages so far, and
+            pretty much anything you make like. We're also able to control other
+            components as well, as in this example we've made it so that if you
+            click a message, it will alert with that message idx.
+          </p>
+          <p>The regular task description content will now appear below:</p>
+        </DefaultTaskDescription>
+      )}
+    />
+  );
+}
+
+ReactDOM.render(<MainApp />, document.getElementById("app"));

--- a/examples/parlai_chat_task_demo/custom_simple/main.js
+++ b/examples/parlai_chat_task_demo/custom_simple/main.js
@@ -50,7 +50,7 @@ function MainApp() {
           chatTitle={taskConfig.chat_title}
           taskDescriptionHtml={taskConfig.task_description}
         >
-          <h2>This is a custom Task Description loaded from a custom bundle</h2>
+          <h2>This is a custom Task Description built from a source dir</h2>
           <p>
             It has the ability to do a number of things, like directly access
             the contents of task data, view the number of messages so far, and

--- a/examples/parlai_chat_task_demo/parlai_test_script.py
+++ b/examples/parlai_chat_task_demo/parlai_test_script.py
@@ -24,7 +24,14 @@ parser.add_argument(
     "-uct",
     "--use-custom-task",
     default=False,
-    help="Launch task with custom javascript from build",
+    help="Launch task with custom pre-built javascript",
+    type=str2bool,
+)
+parser.add_argument(
+    "-bct",
+    "--build-custom-task",
+    default=False,
+    help="Launch task after building new custom js",
     type=str2bool,
 )
 parser.add_argument(
@@ -39,6 +46,7 @@ architect_type, requester_name, db, args = parser.parse_launch_arguments()
 
 USE_LOCAL = True
 DEMO_CUSTOM_BUNDLE = args["use_custom_task"]
+DEMO_BUILD_SIMPLE = args["build_custom_task"]
 USE_ONBOARDING = args["use_onboarding"]
 
 TASK_DIRECTORY = os.path.join(get_root_dir(), "examples/parlai_chat_task_demo")
@@ -75,6 +83,9 @@ if DEMO_CUSTOM_BUNDLE:
     )
     world_opt["send_task_data"] = True
     ARG_STRING += f"--custom-source-bundle {bundle_file_path} "
+if DEMO_BUILD_SIMPLE:
+    source_dir_path = f"{TASK_DIRECTORY}/custom_simple"
+    ARG_STRING += f"--custom-source-dir {source_dir_path} "
 
 extra_args = {"world_opt": world_opt, "onboarding_world_opt": world_opt}
 

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from mephisto.data_model.assignment import Unit
     from mephisto.data_model.requester import Requester
     from mephisto.data_model.task import TaskRun
-    from mephisto.data_model.qualifications import GrantedQualification
+    from mephisto.data_model.qualification import GrantedQualification
     from argparse import _ArgumentGroup as ArgumentGroup
 
 

--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_blueprint.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_blueprint.py
@@ -142,7 +142,13 @@ class ParlAIChatBlueprint(Blueprint, OnboardingRequired):
             custom_source_file_path = os.path.expanduser(args["custom_source_bundle"])
             assert os.path.exists(
                 custom_source_file_path
-            ), f"Provided custom source doesn't exist at {custom_source_file_path}"
+            ), f"Provided custom bundle doesn't exist at {custom_source_file_path}"
+
+        if args.get("custom_source_dir") is not None:
+            custom_source_dir_path = os.path.expanduser(args["custom_source_dir"])
+            assert os.path.exists(
+                custom_source_dir_path
+            ), f"Provided custom source dir doesn't exist at {custom_source_dir_path}"
 
         if args.get("preview_source") is not None:
             preview_source_file = os.path.expanduser(args["preview_source"])
@@ -195,6 +201,11 @@ class ParlAIChatBlueprint(Blueprint, OnboardingRequired):
             "--custom-source-bundle",
             dest="custom_source_bundle",
             help="Optional path to a fully custom frontend bundle",
+        )
+        group.add_argument(
+            "--custom-source-dir",
+            dest="custom_source_dir",
+            help="Optional path to a directory containing custom js code",
         )
         group.add_argument(
             "--extra-source-dir",

--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_task_builder.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_task_builder.py
@@ -24,7 +24,7 @@ FRONTEND_SOURCE_DIR = os.path.join(PARLAI_TASK_DIR, "webapp")
 FRONTEND_BUILD_DIR = os.path.join(FRONTEND_SOURCE_DIR, "build")
 
 BUILT_FILE = "done.built"
-
+CUSTOM_BUILD_DIRNAME = "_generated"
 
 class ParlAIChatTaskBuilder(TaskBuilder):
     """
@@ -57,7 +57,7 @@ class ParlAIChatTaskBuilder(TaskBuilder):
             )
         os.chdir(return_dir)
 
-    def build_and_return_custom_bundle(self, custom_build_dir):
+    def build_and_return_custom_bundle(self, custom_src_dir):
         """Locate all of the custom files used for a custom build, create
         a prebuild directory containing all of them, then build the 
         custom source.
@@ -70,7 +70,7 @@ class ParlAIChatTaskBuilder(TaskBuilder):
             'package.json': 'package.json',
         }
 
-        prebuild_path = os.path.join(custom_build_dir, 'pre_build')
+        prebuild_path = os.path.join(custom_src_dir, CUSTOM_BUILD_DIRNAME)
         build_path = os.path.join(prebuild_path, 'build', 'bundle.js')
         
         # see if we need to rebuild
@@ -78,7 +78,7 @@ class ParlAIChatTaskBuilder(TaskBuilder):
             created_date = os.path.getmtime(build_path)
             up_to_date = True
             for fn in TARGET_BUILD_FILES.keys():
-                possible_conflict = os.path.join(custom_build_dir, fn)
+                possible_conflict = os.path.join(custom_src_dir, fn)
                 if os.path.exists(possible_conflict):
                     if os.path.getmtime(possible_conflict) > created_date:
                         up_to_date = False
@@ -113,7 +113,7 @@ class ParlAIChatTaskBuilder(TaskBuilder):
 
         # copy custom files
         for src_file in TARGET_BUILD_FILES.keys():
-            src_path = os.path.join(custom_build_dir, src_file)
+            src_path = os.path.join(custom_src_dir, src_file)
             if os.path.exists(src_path):
                 dst_path = os.path.join(prebuild_path, TARGET_BUILD_FILES[src_file])
                 shutil.copy2(src_path, dst_path)

--- a/mephisto/server/blueprints/parlai_chat/webapp/__init__.py
+++ b/mephisto/server/blueprints/parlai_chat/webapp/__init__.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-
-# Copyright (c) Facebook, Inc. and its affiliates.
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
# Overview
You can now specify a full ParlAI chat frontend using just one `main.js` file. See the file `parlai_chat_task_demo/custom_simple/main.js`. A new flag `--custom-source-dir` tells mephisto to pick up the files in a custom directory, and use them to build the ParlAI chat task frontend. All build files are put into a subdirectory of the specified directory, which can be ignored when committing code. Even better, the source is only rebuilt when any of the user's custom files are altered.

# Implementation
Most of the updates are present in the `ParlAIChatTaskBuilder` in `build_and_return_custom_bundle`. The basic flow is that it checks to see if there is an existing custom build from the given dir, then to see if the existing build is up to date, and then only builds after that if there have been changes. At the moment it pulls from `TARGET_BUILD_FILES`, and these are the only files one can use to customize their task through this process.

The build is put into `{custom_source_dir}/pre_build/*`, which is a directory that Mephisto users should choose to put in their `.gitignore`'s if using Mephisto in their project.

# Testing 
<img width="1656" alt="Screen Shot 2020-07-07 at 7 46 37 PM" src="https://user-images.githubusercontent.com/1276867/86856612-ae450480-c08a-11ea-82d8-f511f1ac2e26.png">

Made edits to the `main.js` file, asserted that that caused a rebuild, but otherwise no build was needed to relaunch.

# Discussion
The folder names really aren't ideal, but I just wanted to get it working. @pringshia we can talk about something better later. Same goes for the option names, we'll likely want to condense.

# Next steps
I want to make it possible to pull from a custom component directory as well, and have those imports work, but as this is an uncommon case, I'll leave it for future work.

cc @mwillwork - This should be a more optimal writing and building process for the majority of ParlAI users. (plus thanks to @pringshia  that `main.js` file is beautiful now 🤩)