### PR TITLE
Making taskConfig configurable

### DIFF
--- a/examples/static_react_task/README.md
+++ b/examples/static_react_task/README.md
@@ -39,6 +39,10 @@ which if you look at the `webapp/src/components/core_components.jsx` file you ca
 ```
 This is the flow for providing data to a static react task.
 
+#### Adding taskConfig
+
+You can also pass an additional dict under the key `task_config` as a part of `extra_args` to populate the frontend's `taskConfig` with those values for every task in a run.
+
 ### Getting data back
 From within the frontend, any call to the `handleSubmit` method will store the data in any object passed as an argument to the local filestorage:
 

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -206,6 +206,11 @@ class Operator:
             os.makedirs(build_dir, exist_ok=True)
             architect = ArchitectClass(self.db, task_args, task_run, build_dir)
 
+            # Register the blueprint with args to the task run,
+            # ensure cached
+            blueprint = BlueprintClass(task_run, task_args)
+            task_run.get_blueprint(opts=task_args)
+
             # Setup and deploy the server
             built_dir = architect.prepare()
             task_url = architect.deploy()
@@ -242,7 +247,6 @@ class Operator:
             provider = CrowdProviderClass(self.db)
             provider.setup_resources_for_task_run(task_run, task_args, task_url)
 
-            blueprint = BlueprintClass(task_run, task_args)
             initialization_data_array = blueprint.get_initialization_data()
             # TODO(#99) extend
             if not isinstance(initialization_data_array, list):

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -590,6 +590,7 @@ class Blueprint(ABC):
 
     def __init__(self, task_run: "TaskRun", opts: Any):
         self.opts = opts
+        self.frontend_task_config = opts.get('task_config', {})
 
     @classmethod
     def assert_task_args(cls, args: Any):
@@ -636,7 +637,7 @@ class Blueprint(ABC):
         Specifies what options should be fowarded 
         to the client for use by the task's frontend
         """
-        return {}
+        return self.frontend_task_config
 
     @abstractmethod
     def get_initialization_data(

--- a/mephisto/server/blueprints/parlai_chat/parlai_chat_blueprint.py
+++ b/mephisto/server/blueprints/parlai_chat/parlai_chat_blueprint.py
@@ -233,7 +233,7 @@ class ParlAIChatBlueprint(Blueprint, OnboardingRequired):
         Specifies what options within a task_config should be fowarded 
         to the client for use by the task's frontend
         """
-        return {
+        frontend_task_config = {
             "task_description": self.full_task_description,
             "frame_height": 650,
             "chat_title": self.opts["task_title"],
@@ -241,6 +241,8 @@ class ParlAIChatBlueprint(Blueprint, OnboardingRequired):
             "block_mobile": True,
             "frontend_task_opts": self.opts.get("task_opts", {}),
         }
+        frontend_task_config.update(super().get_frontend_args())
+        return frontend_task_config
 
     def get_initialization_data(self) -> Iterable["InitializationData"]:
         """


### PR DESCRIPTION
# Overview
This PR makes it possible to easily configure the frontend arguments passed to `taskConfig` via the `extra_args` dict passed to the operator when launching a run. By setting a `task_config` key on in `extra_args`, anything in that dict will be available in `taskConfig` on the frontend.

# Implementation
Mostly just adds a pull from `task_config` to the core `Blueprint` class, but also requires a change to the `Operator` flow to ensure that the `Blueprint` _with_ the task args is already cached in the task run so that the architect can refer to it properly.

# Testing
Edited the static react task to see if I could pass the dict `{test: "test"}`:
![Screen Shot 2020-07-22 at 2 10 27 PM](https://user-images.githubusercontent.com/1276867/88214232-d6ef0180-cc27-11ea-92a1-437dacd31b8e.png)
![Screen Shot 2020-07-22 at 2 22 18 PM](https://user-images.githubusercontent.com/1276867/88214233-d8202e80-cc27-11ea-8d2c-9a9a5cca9b48.png)



cc @douwekiela 