### PR TITLE
Tone down message around onboarding resubmit error, save all onboarding

### DIFF
--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -235,8 +235,8 @@ class Supervisor:
         """Handle the submission of onboarding data"""
         onboarding_id = packet.sender_id
         if onboarding_id not in self.agents:
-            logger.warn(
-                f"Onboarding agent {onboarding_id} already registered or disconnected, "
+            logger.warning(
+                f"Onboarding agent {onboarding_id} already submitted or disconnected, "
                 f"but is calling _on_submit_onboarding again"
             )
             return

--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -234,6 +234,12 @@ class Supervisor:
     def _on_submit_onboarding(self, packet: Packet, channel_info: ChannelInfo):
         """Handle the submission of onboarding data"""
         onboarding_id = packet.sender_id
+        if onboarding_id not in self.agents:
+            logger.warn(
+                f"Onboarding agent {onboarding_id} already registered or disconnected, "
+                f"but is calling _on_submit_onboarding again"
+            )
+            return
         agent_info = self.agents[onboarding_id]
         agent = agent_info.agent
         # Update the request id for the original packet (which has the required
@@ -249,6 +255,7 @@ class Supervisor:
         agent.pending_actions.append(packet)
         agent.has_action.set()
         self._register_agent_from_onboarding(agent_info)
+        logger.info(f"Onboarding agent {onboarding_id} registered out from onboarding")
         del self.agents[onboarding_id]
         del self.onboarding_packets[onboarding_id]
 
@@ -309,6 +316,10 @@ class Supervisor:
         finally:
             if tracked_agent.get_status() != AgentState.STATUS_WAITING:
                 onboarding_id = tracked_agent.get_agent_id()
+                logger.info(
+                    f"Onboarding agent {onboarding_id} disconnected or errored, "
+                    f"final status {tracked_agent.get_status()}."
+                )
                 del self.agents[onboarding_id]
                 del self.onboarding_packets[onboarding_id]
 

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -414,7 +414,7 @@ class OnboardingAgent(ABC):
         this agent into
         """
         task_run_dir = self.get_task_run().get_run_dir()
-        return os.path.join(task_run_dir, "onboarding")
+        return os.path.join(task_run_dir, "onboarding", self.get_agent_id())
 
     def update_status(self, new_status: str) -> None:
         """Update the database status of this agent, and


### PR DESCRIPTION
# Overview
Some kind of race condition in the onboarding setup is causing workers to be able to resubmit onboarding multiple times. The downstream impact on monitoring this at the moment is a wall of scary exception text with a `KeyError('onboarding_<>')` at the root. 

It's clear what has to have happened for this to occur (either a worker is somehow submitting onboarding twice, or submitting after they have disconnected), but to fully debug I'll need to observe the behavior in the wild as I've never been able to reproduce on sandbox or local. 

# Implementation
I've added logging for the two locations that remove the onboarding id key from the agents dict, and have wrapped the call to (re-)submitting with a warning if the key is missing. This should allow us to be able to tell where these issues are coming from, but without a wall of scary exception text.

I've also added a change that saves all onboarding agent data for a task in the `<run_dir>/onboarding/<>` directory, which may be useful to see the kinds of activity that people take while in onboarding.

# Testing
Ran the static react task with onboarding, ensured that logging came up. Then checked the run directory:
```
> ls data/data/runs/NO_PROJECT/800/onboarding/
onboarding_237	onboarding_238	onboarding_239
> cat data/data/runs/NO_PROJECT/800/onboarding/onboarding_237/agent_data.json 
{"inputs": {}, "outputs": {"success": true}, "times": {"task_start": 1595445580.180634, "task_end": 1595445584.343036}}
```

cc @mwillwork, @jxmsML