### PR TITLE
Fixing accidental marking complete of incomplete units

### DIFF
--- a/mephisto/providers/mturk/mturk_unit.py
+++ b/mephisto/providers/mturk/mturk_unit.py
@@ -100,6 +100,7 @@ class MTurkUnit(Unit):
         mturk_hit_id = self.get_mturk_hit_id()
         if mturk_hit_id is not None:
             self.datastore.register_assignment_to_hit(mturk_hit_id)
+            self._sync_hit_mapping()
 
     # Required Unit functions
 


### PR DESCRIPTION
# Overview
A small bug in the agent status and requeue logic introduced somewhat recently was causing an issue with regards to cached values in `MTurkUnit`. Namely, when `clear_assigned_agent` was called, the `Unit` would no longer have an assigned agent, but it would still have a set `mturk_hit_id`. Later, if another unit was given the same `hit_id` and then was completed, a call to `Unit.get_status()` on the returned unit would lead to it being marked as `COMPLETED`, even when no such completion occurred.

Even worse, this would interfere with the `MephistoDataBrowser` and most `examine_results` scripts, as the `Unit`s would be surfaced for review due to being marked as completed, but would not have an associated agent or agent state to pull data from.

# Implementation
Fixes the issue by resetting the cache when `clear_assigned_agent` is called.

# Testing
Tested by returning a HIT on sandbox.

cc @bottler @EricMichaelSmith 