### PR TITLE
Fixing integer value mturk qual specification

### DIFF
--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -326,7 +326,11 @@ def convert_mephisto_qualifications(
         if converted["Comparator"] is None:
             converted["Comparator"] = qualification["comparator"]
 
-        if converted["IntegerValue"] is None and converted["LocaleValues"] is None:
+        if (
+            converted["IntegerValue"] is None
+            and converted["IntegerValues"] is None
+            and converted["LocaleValues"] is None
+        ):
             value = qualification["value"]
             if isinstance(value, list):
                 converted["IntegerValues"] = value

--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -300,6 +300,7 @@ def convert_mephisto_qualifications(
             "QualificationTypeId",
             "Comparator",
             "IntegerValue",
+            "IntegerValues",
             "LocaleValues",
             "ActionsGuarded",
         ]

--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -335,10 +335,13 @@ def convert_mephisto_qualifications(
             value = qualification["value"]
             if isinstance(value, list):
                 converted["IntegerValues"] = value
+                del converted["IntegerValue"]
             elif isinstance(value, int):
                 converted["IntegerValue"] = value
+                del converted["IntegerValues"]
             else:
                 del converted["IntegerValue"]
+                del converted["IntegerValues"]
 
         if converted["LocaleValues"] is None:
             del converted["LocaleValues"]


### PR DESCRIPTION
# Overview
MTurk-specific qualifications have a few possible fields for values that need to be copied over, and `mturk_utils` was expecting to need to copy `LocaleValues` or `IntegerValue`, but not `IntegerValues`. This PR adds the missing key.

# Testing
Launched on sandbox with an `IntegerValues` qualification.

cc @douwekiela 