### PR TITLE
Various Acute eval state fixes

### DIFF
--- a/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
@@ -61,7 +61,7 @@ class StaticAgentState(AgentState):
         Return the initial state for this agent,
         None if no such state exists
         """
-        return self.state["inputs"]
+        return self.state["inputs"].copy()
 
     def load_data(self) -> None:
         """Load data for this agent from disk"""
@@ -75,7 +75,7 @@ class StaticAgentState(AgentState):
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict of this agent's state"""
-        return self.state
+        return self.state.copy()
 
     def save_data(self) -> None:
         """Save static agent data to disk"""

--- a/mephisto/server/blueprints/acute_eval/acute_eval_agent_state.py
+++ b/mephisto/server/blueprints/acute_eval/acute_eval_agent_state.py
@@ -49,6 +49,6 @@ class AcuteEvalAgentState(StaticAgentState):
         assert (
             packet.data.get("MEPHISTO_is_submit") is True
         ), "Static tasks should only have final act"
-        times_dict["task_end"] = time.time()
+        self.state["times"]["task_end"] = time.time()
         self.state["outputs"] = packet.data["task_data"]
         self.save_data()

--- a/mephisto/server/blueprints/acute_eval/acute_eval_agent_state.py
+++ b/mephisto/server/blueprints/acute_eval/acute_eval_agent_state.py
@@ -9,6 +9,7 @@ from mephisto.server.blueprints.abstract.static_task.static_agent_state import (
     StaticAgentState,
 )
 import os
+import time
 import json
 
 if TYPE_CHECKING:
@@ -48,5 +49,6 @@ class AcuteEvalAgentState(StaticAgentState):
         assert (
             packet.data.get("MEPHISTO_is_submit") is True
         ), "Static tasks should only have final act"
+        times_dict["task_end"] = time.time()
         self.state["outputs"] = packet.data["task_data"]
         self.save_data()

--- a/mephisto/server/blueprints/acute_eval/acute_eval_builder.py
+++ b/mephisto/server/blueprints/acute_eval/acute_eval_builder.py
@@ -46,7 +46,6 @@ class AcuteEvalBuilder(TaskBuilder):
                 "please make sure npm is installed, otherwise view "
                 "the above error for more info."
             )
-        subprocess.call(["npm", "link", "mephisto-task"])
         webpack_complete = subprocess.call(["npm", "run", "dev"])
         if webpack_complete != 0:
             raise Exception(

--- a/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
+++ b/mephisto/server/blueprints/acute_eval/webapp/src/components/core_components.jsx
@@ -232,15 +232,15 @@ class EvalResponse extends React.Component {
   }
 
   checkValidData() {
+    let response_data = {
+      speakerChoice: this.state.speakerChoice,
+      textReason: this.state.textReason,
+    };
     if (this.state.speakerChoice !== "" && this.state.textReason.length > 4) {
-      let response_data = {
-        speakerChoice: this.state.speakerChoice,
-        textReason: this.state.textReason,
-      };
       this.props.onValidDataChange(true, response_data);
       return;
     }
-    this.props.onValidDataChange(false, {});
+    this.props.onValidDataChange(false, response_data);
   }
 
   handleInputChange(event) {


### PR DESCRIPTION
# Overview
A few Acute eval bugs have come up lately:
- Sometimes the task build is asking for permissions that a user may not have
- Not saving the task duration
- Sometimes the last evaluation is not saved
- Some errant scripts seemed to have been able to edit valid `AgentStates's while in-flight (potentially breaking them during the save).

This PR fixes those

# Implementation
- `subprocess.call(["npm", "link", "mephisto-task"])` was only required before `mephisto-task` was published, and isn't necessary anymore. This was responsible for the permission issue.
-  Added the step of saving task duration
- Implemented a frontend change that should prevent the clearest possible cause of saving `{}` as the last value.
- To prevent possible `AgentState` corruption, includes a change that only returns a copy of the internal state when requested via accessor functions.

# Testing
Ran Acute eval locally, didn't see any of the above issues.