### PR TITLE
Saving full onboarding status in onboarding agents

### DIFF
--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -482,6 +482,9 @@ class Supervisor:
             worker.grant_qualification(
                 blueprint.onboarding_failed_name, int(worker_passed)
             )
+            onboarding_agent.update_status(AgentState.STATUS_REJECTED)
+        else:
+            onboarding_agent.update_status(AgentState.STATUS_APPROVED)
 
         # get the list of tentatively valid units
         units = task_run.get_valid_units_for_worker(worker)

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -422,9 +422,11 @@ class OnboardingAgent(ABC):
         them of this update"""
         if self.db_status == new_status:
             return  # Noop, this is already the case
-        assert (
-            self.db_status not in AgentState.complete()
-        ), f"Cannot update a final status, was {self.db_status} and want to set to {new_status}"
+        if self.db_status in AgentState.complete():
+            print(
+                f"Updating a final status, was {self.db_status} "
+                f"and want to set to {new_status}"
+            )
         self.db.update_onboarding_agent(self.db_id, status=new_status)
         self.db_status = new_status
         self.has_updated_status.set()


### PR DESCRIPTION
# Overview
Recently we started saving full onboarding agent data in #206. This PR additionally ensures that the success or failure of that onboarding is saved, allowing us to get onboarding statistics for a given task run.

# Testing
Ran the ParlAI chat task, disconnected from one onboarding and then completed a second.
```python
>>> from mephisto.core.local_database import LocalMephistoDB
>>> db = LocalMephistoDB()
>>> onboarding_agents = db.find_onboarding_agents(task_run_id=802)
>>> statuses = [o.get_status() for o in onboarding_agents]
>>> print(statuses)
['disconnect', 'approved']

```