### PR TITLE
Ensuring heroku app name is valid

### DIFF
--- a/mephisto/server/architects/heroku_architect.py
+++ b/mephisto/server/architects/heroku_architect.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import time
 import requests
+import re
 from mephisto.core.utils import get_mephisto_tmp_dir
 from mephisto.core.argparse_parser import str2bool
 from mephisto.data_model.architect import Architect
@@ -298,8 +299,8 @@ class HerokuArchitect(Architect):
             heroku_app_name = heroku_app_name.replace("_", "-")
             while heroku_app_name[-1] == "-":
                 heroku_app_name = heroku_app_name[:-1]
-            self.heroku_app_name = heroku_app_name.replace("_", "-")
-        return self.heroku_app_name
+            self.__heroku_app_name = re.sub(r'[^a-zA-Z0-9-]','', heroku_app_name)
+        return self.__heroku_app_name
 
     def __compile_server(self) -> str:
         """


### PR DESCRIPTION
# Overview
Some characters weren't being properly filtered out of heroku's app names, and as such the app would fail to launch under some conditions (and throw a message that had nothing to do with the real reason the app was failing to launch). This adds a regex to remove any invalid characters

Also fixes a bug that was incorrectly caching the heroku app name, causing it to be recomputed.

# Testing
Ran the heroku architect test.

Fixes an issue raised in the ParlAI repo here: https://github.com/facebookresearch/ParlAI/issues/2858