### PR TITLE
[bug] Fixing bad input state copy

### DIFF
--- a/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/server/blueprints/abstract/static_task/static_agent_state.py
@@ -61,6 +61,8 @@ class StaticAgentState(AgentState):
         Return the initial state for this agent,
         None if no such state exists
         """
+        if self.state["inputs"] is None:
+            return None
         return self.state["inputs"].copy()
 
     def load_data(self) -> None:


### PR DESCRIPTION
# Overview
A bug was introduced in #209 that cause other static tasks to fail when loading the initial state (as the initial state being copied was `None`. This PR fixes that bug.

# Testing
Launched a static task in sandbox successfully.

cc @douwekiela 