### PR TITLE
MTurk qual value can be none on some comparators

### DIFF
--- a/mephisto/providers/mturk/mturk_utils.py
+++ b/mephisto/providers/mturk/mturk_utils.py
@@ -338,11 +338,6 @@ def convert_mephisto_qualifications(
                 converted["IntegerValues"] = value
             elif isinstance(value, int):
                 converted["IntegerValue"] = value
-            else:
-                raise Exception(
-                    f"Unexpected qualification value {value} given in "
-                    f"qualification {qualification}, expected types list or int"
-                )
 
         # IntegerValue is deprecated, and needs conversion to IntegerValues
         if converted["IntegerValue"] is not None:


### PR DESCRIPTION
The fix in #211 had a bug that broke special disqualifying qualifications. This reverts the `None` check which fixes the bug for qualifications.
