### PR TITLE
[Bug] Use full list of possible final flags after onboarding

### DIFF
--- a/mephisto/core/supervisor.py
+++ b/mephisto/core/supervisor.py
@@ -314,7 +314,11 @@ class Supervisor:
             traceback.print_exc()
             task_runner.cleanup_onboarding(tracked_agent)
         finally:
-            if tracked_agent.get_status() != AgentState.STATUS_WAITING:
+            if tracked_agent.get_status() not in [
+                AgentState.STATUS_WAITING,
+                AgentState.STATUS_APPROVED,
+                AgentState.STATUS_REJECTED,
+            ]:
                 onboarding_id = tracked_agent.get_agent_id()
                 logger.info(
                     f"Onboarding agent {onboarding_id} disconnected or errored, "


### PR DESCRIPTION
# Overview 
A small bug captured in #206 actually gets to the bottom of the whole assigning agents out of onboarding failing issue. This resolves one of the longer-running Mephisto bugs, and should squash away all of the "missing id `onboarding_<>`" errors for good.

# Details
A race condition in the supervisor sometimes allowed an onboarding agent to be marked as approved when registering from onboarding but before the full `_launch_and_run_onboarding` function completed. As such, the worker's information could be dropped due to a failure to be in the expected `WAITING` state (used for onboarding agents to signify waiting for automated evaluation).

As such, the fix is to simply add the additional final onboarding agent states to the end of `_launch_and_run_onboarding`.

# Testing
Running the local html example with onboarding, I was able to reproduce the bug. After the fix I'm no longer able to do so. 