### PR TITLE
operator shut down is aware of finished assignments thread

### DIFF
--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -290,12 +290,10 @@ class Operator:
             runs_to_check = list(self._task_runs_tracked.values())
             for tracked_run in runs_to_check:
                 task_run = tracked_run.task_run
-                if not tracked_run.task_launcher.assignment_thread_done:
+                task_run.update_completion_progress(tracked_run.task_launcher)
+                if not task_run.get_is_completed():
                     continue
                 else:
-                    task_run.assignment_generators_done = True
-
-                if task_run.get_is_completed():
                     self.supervisor.shutdown_job(tracked_run.job)
                     tracked_run.architect.shutdown()
                     tracked_run.task_launcher.shutdown()

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -279,7 +279,7 @@ class Operator:
             architect=architect,
             job=job,
         )
-        task_run.update_assignment_generator_done(False)
+        task_run.update_completion_progress(status=False)
 
         return task_run.db_id
 
@@ -292,7 +292,7 @@ class Operator:
             runs_to_check = list(self._task_runs_tracked.values())
             for tracked_run in runs_to_check:
                 task_run = tracked_run.task_run
-                task_run.update_completion_progress(tracked_run.task_launcher)
+                task_run.update_completion_progress(task_launcher=tracked_run.task_launcher)
                 if not task_run.get_is_completed():
                     continue
                 else:

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -279,6 +279,7 @@ class Operator:
             architect=architect,
             job=job,
         )
+        task_run.assignments_generator_done = False
         return task_run.db_id
 
     def _track_and_kill_runs(self):

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -279,7 +279,8 @@ class Operator:
             architect=architect,
             job=job,
         )
-        task_run.assignments_generator_done = False
+        task_run.update_assignment_generator_done(False)
+
         return task_run.db_id
 
     def _track_and_kill_runs(self):

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -290,6 +290,11 @@ class Operator:
             runs_to_check = list(self._task_runs_tracked.values())
             for tracked_run in runs_to_check:
                 task_run = tracked_run.task_run
+                if not tracked_run.task_launcher.assignment_thread_done:
+                    continue
+                else:
+                    task_run.assignment_generators_done = True
+
                 if task_run.get_is_completed():
                     self.supervisor.shutdown_job(tracked_run.job)
                     tracked_run.architect.shutdown()

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -73,7 +73,7 @@ class TaskLauncher:
         self.unlaunched_units_access_condition = threading.Condition()
         if isinstance(self.assignment_data_iterable, types.GeneratorType):
             self.generator_type = GeneratorType.ASSIGNMENT
-            self.assignments_thread = False
+            self.assignment_thread_done = False
         else:
             self.generator_type = GeneratorType.NONE
         run_dir = task_run.get_run_dir()

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -68,9 +68,12 @@ class TaskLauncher:
         self.unlaunched_units: Dict[str, Unit] = {}
         self.keep_launching_units: bool = False
         self.finished_generators: bool = False
+        self.assignment_thread_done: bool = True
+
         self.unlaunched_units_access_condition = threading.Condition()
         if isinstance(self.assignment_data_iterable, types.GeneratorType):
             self.generator_type = GeneratorType.ASSIGNMENT
+            self.assignments_thread = False
         else:
             self.generator_type = GeneratorType.NONE
         run_dir = task_run.get_run_dir()
@@ -120,6 +123,7 @@ class TaskLauncher:
                 self._create_single_assignment(data)
             except StopIteration:
                 self.finished_generators = True
+                self.assignment_thread_done = True
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
 
     def create_assignments(self) -> None:

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -192,6 +192,9 @@ class TaskLauncher:
         )
         self.units_thread.start()
 
+    def get_assignment_thread_flag(self) -> bool:
+        return self.assignment_thread_done
+
     def expire_units(self) -> None:
         """Clean up all units on this TaskLauncher"""
         self.keep_launching_units = False

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -192,7 +192,7 @@ class TaskLauncher:
         )
         self.units_thread.start()
 
-    def get_assignment_thread_flag(self) -> bool:
+    def get_assignments_are_all_created(self) -> bool:
         return self.assignment_thread_done
 
     def expire_units(self) -> None:

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -363,13 +363,13 @@ class TaskRun:
             for status in AssignmentState.valid()
         }
 
-    def update_assignment_generator_done(self, status) -> None:
-        self.assignments_generator_done = False
-
-    def update_completion_progress(self, task_launcher) -> None:
+    def update_completion_progress(self, task_launcher=None, status=None) -> None:
         """ Flag the task run that the assignments' generator has finished """
-        if task_launcher.get_assignments_are_all_created():
-            self.assignments_generator_done = True
+        if task_launcher:
+            if task_launcher.get_assignments_are_all_created():
+                self.assignments_generator_done = True
+        if status:
+            self.assignments_generator_done = status
 
     def get_is_completed(self) -> bool:
         """get the completion status of this task"""

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -363,9 +363,12 @@ class TaskRun:
             for status in AssignmentState.valid()
         }
 
+    def update_assignment_generator_done(self, status) -> None:
+        self.assignments_generator_done = False
+
     def update_completion_progress(self, task_launcher) -> None:
         """ Flag the task run that the assignments' generator has finished """
-        if task_launcher.get_assignment_thread_flag():
+        if task_launcher.get_assignments_are_all_created():
             self.assignments_generator_done = True
 
     def get_is_completed(self) -> bool:
@@ -386,12 +389,7 @@ class TaskRun:
             for status in AssignmentState.incomplete():
                 if statuses[status] > 0:
                     has_incomplete = True
-            if (
-                not has_incomplete
-                and self.assignments_generator_done is None
-                or not has_incomplete
-                and self.assignments_generator_done
-            ):
+            if not has_incomplete and self.assignments_generator_done is not False:
                 self.db.update_task_run(self.db_id, is_completed=True)
                 self.__is_completed = True
 

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -363,6 +363,11 @@ class TaskRun:
             for status in AssignmentState.valid()
         }
 
+    def update_completion_progress(self, task_launcher) -> None:
+        """ Flag the task run that the assignments' generator has finished """
+        if task_launcher.assignment_thread_done:
+            self.assignment_generators_done = True
+
     def get_is_completed(self) -> bool:
         """get the completion status of this task"""
         self.sync_completion_status()

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -199,7 +199,7 @@ class TaskRun:
         self.provider_type = row["provider_type"]
         self.task_type = row["task_type"]
         self.sandbox = row["sandbox"]
-        self.assignment_generators_done: bool = False
+        self.assignments_generator_done: bool = None
 
         # properties with deferred loading
         self.__is_completed = row["is_completed"]
@@ -366,7 +366,7 @@ class TaskRun:
     def update_completion_progress(self, task_launcher) -> None:
         """ Flag the task run that the assignments' generator has finished """
         if task_launcher.get_assignment_thread_flag():
-            self.assignment_generators_done = True
+            self.assignments_generator_done = True
 
     def get_is_completed(self) -> bool:
         """get the completion status of this task"""
@@ -386,7 +386,12 @@ class TaskRun:
             for status in AssignmentState.incomplete():
                 if statuses[status] > 0:
                     has_incomplete = True
-            if not has_incomplete and self.assignment_generators_done:
+            if (
+                not has_incomplete
+                and self.assignments_generator_done is None
+                or not has_incomplete
+                and self.assignments_generator_done
+            ):
                 self.db.update_task_run(self.db_id, is_completed=True)
                 self.__is_completed = True
 

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -199,6 +199,7 @@ class TaskRun:
         self.provider_type = row["provider_type"]
         self.task_type = row["task_type"]
         self.sandbox = row["sandbox"]
+        self.assignment_generators_done: bool = False
 
         # properties with deferred loading
         self.__is_completed = row["is_completed"]
@@ -380,7 +381,7 @@ class TaskRun:
             for status in AssignmentState.incomplete():
                 if statuses[status] > 0:
                     has_incomplete = True
-            if not has_incomplete:
+            if not has_incomplete and self.assignment_generators_done:
                 self.db.update_task_run(self.db_id, is_completed=True)
                 self.__is_completed = True
 

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -365,7 +365,7 @@ class TaskRun:
 
     def update_completion_progress(self, task_launcher) -> None:
         """ Flag the task run that the assignments' generator has finished """
-        if task_launcher.assignment_thread_done:
+        if task_launcher.get_assignment_thread_flag():
             self.assignment_generators_done = True
 
     def get_is_completed(self) -> bool:


### PR DESCRIPTION
Regarding the 3rd point of this thread, this PR is for the `operator.shut_down()` to shut down and update the database of the completed run only if the assignments generator thread is done (if it exists)