### PR TITLE
Handling post-expire `LAUNCHED` state bug.

### DIFF
--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -27,6 +27,7 @@ from mephisto.data_model.exceptions import (
     AgentDisconnectedError,
     AgentTimeoutError,
 )
+from mephisto.data_model.assignment_state import AssignmentState
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent, OnboardingAgent
@@ -168,7 +169,10 @@ class TaskRunner(ABC):
             self.run_unit(unit, agent)
         except (AgentReturnedError, AgentTimeoutError, AgentDisconnectedError):
             # A returned Unit can be worked on again by someone else.
-            if unit.get_assigned_agent().db_id == agent.db_id:
+            if (
+                unit.get_status() == AssignmentState.LAUNCHED
+                and unit.get_assigned_agent().db_id == agent.db_id
+            ):
                 unit.clear_assigned_agent()
             self.cleanup_unit(unit)
         except Exception as e:

--- a/mephisto/data_model/blueprint.py
+++ b/mephisto/data_model/blueprint.py
@@ -170,7 +170,7 @@ class TaskRunner(ABC):
         except (AgentReturnedError, AgentTimeoutError, AgentDisconnectedError):
             # A returned Unit can be worked on again by someone else.
             if (
-                unit.get_status() == AssignmentState.LAUNCHED
+                unit.get_status() != AssignmentState.EXPIRED
                 and unit.get_assigned_agent().db_id == agent.db_id
             ):
                 unit.clear_assigned_agent()


### PR DESCRIPTION
# Description
During an expiration, if a worker returned the task, it would be left in a permanent `LAUNCHED` state thanks to the operations of `clear_assigned_agent`. Thus, we need to special case to not clear the status if we're in the `EXPIRED` state. It's okay for us to keep the last agent still assigned after an expiration has occurred, as the status of the Unit will not change.

Thanks @bottler for isolating the bug and an initial solution.