### PR TITLE
[bugfix] properly dispose of socket when error, reconnect

### DIFF
--- a/mephisto/server/channels/websocket_channel.py
+++ b/mephisto/server/channels/websocket_channel.py
@@ -100,7 +100,9 @@ class WebsocketChannel(Channel):
 
                 traceback.print_exc()
                 try:
-                    ws.close()
+                    # Close the socket to attempt to reconnect
+                    self.socket.close()
+                    self.socket.keep_running = False
                 except Exception:
                     # TODO(CLEAN) only catch socket closed connection
                     # Already closed


### PR DESCRIPTION
# Overview
When sockets would disconnect (due to any number of errors), the on_error handler is supposed to determine if the error is fatal. If so it should close the socket to relaunch.

Turns out we were closing the underlying socket and not the socketapp, so the app would continue running with no socket, preventing anything from working.

This PR closes the app, and sets keep_running to false explicitly to allow older versions to exit the `run_forever` loop.