### PR TITLE
Fix onboarding agent statuses

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -494,8 +494,14 @@ class OnboardingAgent(ABC):
         return self.db_status
 
     def mark_done(self) -> None:
-        """Mark this agent as done by setting the status to completed"""
-        self.update_status(AgentState.STATUS_WAITING)
+        """Mark this agent as done by setting the status to a terminal onboarding state"""
+        # TODO the logic for when onboarding gets marked as waiting or approved/rejected
+        # should likely be cleaned up to remove these conditionals.
+        if self.get_status not in [
+            AgentState.STATUS_APPROVED,
+            AgentState.STATUS_REJECTED,
+        ]:
+            self.update_status(AgentState.STATUS_WAITING)
 
     @staticmethod
     def new(db: "MephistoDB", worker: Worker, task_run: "TaskRun") -> "OnboardingAgent":


### PR DESCRIPTION
# Overview
Properly only set a pending `OnboardingAgent` to `WAITING` if it is not already `APPROVED` or `REJECTED`. This allows us to always check the status of onboarding just by looking at the agent.