### PR TITLE
Mturk workers utility

### DIFF
--- a/mephisto/providers/mturk/mturk_worker.py
+++ b/mephisto/providers/mturk/mturk_worker.py
@@ -53,12 +53,14 @@ class MTurkWorker(Worker):
 
     @classmethod
     def get_from_mturk_worker_id(
-        self, 
+        cls, 
         db: "MephistoDB", 
         mturk_worker_id: str,
     ) -> Optional["MTurkWorker"]:
         """Get the MTurkWorker from the given worker_id"""
-        workers = db.find_workers(worker_name=mturk_worker_id, provider_type=PROVIDER_TYPE)
+        if cls.PROVIDER_TYPE != PROVIDER_TYPE:
+            mturk_worker_id += "_sandbox"
+        workers = db.find_workers(worker_name=mturk_worker_id, provider_type=cls.PROVIDER_TYPE)
         if len(workers) == 0:
             return None
         return workers[0]

--- a/mephisto/providers/mturk/mturk_worker.py
+++ b/mephisto/providers/mturk/mturk_worker.py
@@ -51,6 +51,18 @@ class MTurkWorker(Worker):
         )
         self._worker_name = self.worker_name  # sandbox workers use a different name
 
+    @classmethod
+    def get_from_mturk_worker_id(
+        self, 
+        db: "MephistoDB", 
+        mturk_worker_id: str,
+    ) -> Optional["MTurkWorker"]:
+        """Get the MTurkWorker from the given worker_id"""
+        workers = db.find_workers(worker_name=mturk_worker_id, provider_type=PROVIDER_TYPE)
+        if len(workers) == 0:
+            return None
+        return workers[0]
+
     def get_mturk_worker_id(self):
         return self._worker_name
 


### PR DESCRIPTION
# Contents
Simple utility function for being able to get an `MTurkWorker` (or `SandboxMTurkWorker`) from the database directly from `mturk_worker_id` without needing to know the underlying implementation.

# Testing
Added a test case
```
>>> pytest test/providers/mturk/test_mturk.py 
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.6.10, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/jju/mephisto
plugins: requests-mock-1.7.0
collected 1 item                                                                                                                                                                  

test/providers/mturk/test_mturk.py .                                                                                                                                        [100%]

================================================================================ 1 passed in 0.68s ================================================================================
```