### PR TITLE
Using the correct mturk client for bonus

### DIFF
--- a/mephisto/providers/mturk/mturk_worker.py
+++ b/mephisto/providers/mturk/mturk_worker.py
@@ -149,7 +149,7 @@ class MTurkWorker(Worker):
 
         unit = cast("MTurkUnit", unit)
         requester = unit.get_assignment().get_task_run().get_requester()
-        client = self._get_client(requester.requester_name)
+        client = self._get_client(requester._requester_name)
         mturk_assignment_id = unit.get_mturk_assignment_id()
         assert mturk_assignment_id is not None, "Cannot bonus for a unit with no agent"
         pay_bonus(


### PR DESCRIPTION
# Overview
The sandbox client wasn't being used properly when calling `pay_bonus`. This is a one-line fix.