### PR TITLE
Cli command for mephisto wut

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -100,5 +100,99 @@ def register_provider(args):
         click.echo(str(e))
 
 
+@cli.command("wut", context_settings={"ignore_unknown_options": True})
+@click.argument("args", nargs=-1)
+def get_help_arguments(args):
+    if len(args) == 0:
+        click.echo("Usage: mephisto wut <abstraction>[=<type>] [...specific args to check]")
+        return
+
+
+    from mephisto.core.registry import (
+        get_blueprint_from_type,
+        get_crowd_provider_from_type,
+        get_architect_from_type,
+        get_valid_blueprint_types,
+        get_valid_provider_types,
+        get_valid_architect_types,
+    )
+    from mephisto.core.argparse_parser import get_extra_argument_dicts
+
+    VALID_ABSTRACTIONS = ['blueprint', 'architect', 'requester', 'provider', 'task']
+
+    abstraction_equal_split = args[0].split('=', 1)
+    abstraction = abstraction_equal_split[0]
+
+    if abstraction not in VALID_ABSTRACTIONS:
+        click.echo(f"Given abstraction {abstraction} not in valid abstractions {VALID_ABSTRACTIONS}")
+        return 
+
+    if abstraction == 'task':
+        from mephisto.data_model.task_config import TaskConfig
+        target_class = TaskConfig
+    else:
+        if len(abstraction_equal_split) == 1:
+            # querying about the general abstraction
+            if abstraction == 'blueprint':
+                click.echo(
+                    f"The blueprint determines the task content. Valid blueprints are {get_valid_blueprint_types()}"
+                )
+                return
+            elif abstraction == 'architect':
+                click.echo(
+                    f"The architect determines the server where a task is hosted. Valid architects are {get_valid_architect_types()}"
+                )
+                return
+            elif abstraction == 'requester':
+                click.echo(
+                    f"The requester is an account for a crowd provider. Valid requester types are {get_valid_provider_types()}. \n"
+                    "Use `mephisto requesters` to see registered requesters, and `mephisto register <requester type>` to register."
+                )
+                return
+            elif abstraction == 'provider':
+                click.echo(
+                    f"The crowd provider determines the source of the crowd workers. Valid provider are {get_valid_provider_types()}"
+                )
+                return
+
+        # There's a specific abstraction to check
+        abstract_value = abstraction_equal_split[1]
+        target_class = None
+        valid = None
+        if abstraction == 'blueprint':
+            try:
+                target_class = get_blueprint_from_type(abstract_value)
+            except:
+                valid = get_valid_blueprint_types()
+        elif abstraction == 'architect':
+            try:
+                target_class = get_architect_from_type(abstract_value)
+            except:
+                valid = get_valid_architect_types()
+        elif abstraction == 'provider':
+            try:
+                target_class = get_crowd_provider_from_type(abstract_value)
+            except:
+                valid = get_valid_provider_types()
+        elif abstraction == 'requester':
+            try:
+                target_class = get_crowd_provider_from_type(abstract_value).RequesterClass
+            except:
+                valid = get_valid_provider_types()
+        if valid is not None:
+            click.echo(
+                f"The valid types for {abstraction} are {valid}. '{abstract_value}' not found."
+            )
+            return
+
+    from tabulate import tabulate
+    arg_dict = get_extra_argument_dicts(target_class)[0]
+    click.echo(arg_dict["desc"])
+    checking_args = arg_dict['args']
+    if len(args) > 1:
+        checking_args = {k: v for k, v in checking_args.items() if k in args[1:]}
+    click.echo(tabulate(checking_args.values(), headers="keys"))
+
+    
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
# Overview
After #246, it's now possible to set a whole slew of options in mephisto. This is great in that people can now control a whole bunch of things, but it can be confusing. This PR introduces `mephisto wut`, which should hopefully help people parse through the options they have (as Hydra isn't yet easy to get argument help on just yet).

# Usage
### `mephisto wut`
Tells you about `mephisto wut`
### `mephisto wut <abstraction>`
Tells you about one of the core abstractions in mephisto, or really the set of things that comes after the `mephisto.` in any of the configuration files. Will tell you available options.
### `mephisto wut <abstraction>=<instance>`
Tells you about the specific arguments for a specific abstraction, with help text
### `mephisto wut <abstraction>=<instance> [list of argument names]`
Tells you only about the arguments you list, rather than dumping all of them.

# Testing
### `mephisto wut`
```
>>> mephisto wut
Usage: mephisto wut <abstraction>[=<type>] [...specific args to check]
```
### `mephisto wut <abstraction>`
```
>>> mephisto wut blueprint
The blueprint determines the task content. Valid blueprints are ['parlai_chat', 'mock', 'static_task', 'static_react_task']
>>> mephisto wut requester
The requester is an account for a crowd provider. Valid requester types are ['mock', 'mturk', 'mturk_sandbox']. 
Use `mephisto requesters` to see registered requesters, and `mephisto register <requester type>` to register.
>>> mephisto wut dolphins
Given abstraction dolphins not in valid abstractions ['blueprint', 'architect', 'requester', 'provider', 'task']
```
### `mephisto wut <abstraction>=<instance>`
```
>>> mephisto wut architect=local

dest      type    default    help                                choices    required
--------  ------  ---------  ----------------------------------  ---------  ----------
hostname  str     localhost  Addressible location of the server             False
port      str     3000       Port to launch the server on                   False

>>> mephisto wut blueprint=parlai_chat

                Tasks launched from static blueprints need a
                source html file to display to workers, as well as a csv
                containing values that will be inserted into templates in
                the html.
            
dest                      type    default    help                                                                                                        choices    required
------------------------  ------  ---------  ----------------------------------------------------------------------------------------------------------  ---------  ----------
onboarding_qualification  str     ???        Specify the name of a qualification used to block workers who fail onboarding, Empty will skip onboarding.             False
block_qualification       str     ???        Specify the name of a qualification used to soft block workers.                                                        False
world_file                str     ???        Path to file containing ParlAI world                                                                                   True
preview_source            str     ???        Optional path to source HTML file to preview the task                                                                  False
task_description_file     str     ???        Path to file for the extended description of the task. Required if not providing a custom source bundle.               False
custom_source_bundle      str     ???        Optional path to a fully custom frontend bundle                                                                        False
custom_source_dir         str     ???        Optional path to a directory containing custom js code                                                                 False
extra_source_dir          str     ???        Optional path to sources that the frontend may refer to (such as images/video/css/scripts)                             False
context_csv               str     ???        Optional path to csv containing task context                                                                           False
num_conversations         int     ???        Optional count of conversations to have if no context provided                                                         False

>>> mephisto wut task

dest                            type     default    help                                                                                                                   choices    required
------------------------------  -------  ---------  ---------------------------------------------------------------------------------------------------------------------  ---------  ----------
task_name                       unknown  ???        Grouping to launch this task run under, none defaults to the blueprint type                                                       False
task_title                      str      ???        Display title for your task on the crowd provider.                                                                                True
task_description                str      ???        Longer form description for what your task entails.                                                                               True
task_reward                     float    ???        Amount to pay per worker per unit, in dollars.                                                                                    True
task_tags                       str      ???        Comma seperated tags for workers to use to find your task.                                                                        True
assignment_duration_in_seconds  int      1800       Time that workers have to work on your task once accepted.                                                                        False
allowed_concurrent              int      0          Maximum units a worker is allowed to work on at once. (0 is infinite)                                                             True
maximum_units_per_worker        int      0          Maximum tasks of this task name that a worker can work on across all tasks that share this task_name. (0 is infinite)             False

```
### `mephisto wut <abstraction>=<instance> [list of argument names]`
```
>>> mephisto wut blueprint=parlai_chat world_file preview_source context_csv

                Tasks launched from static blueprints need a
                source html file to display to workers, as well as a csv
                containing values that will be inserted into templates in
                the html.
            
dest            type    default    help                                                   choices    required
--------------  ------  ---------  -----------------------------------------------------  ---------  ----------
world_file      str     ???        Path to file containing ParlAI world                              True
preview_source  str     ???        Optional path to source HTML file to preview the task             False
context_csv     str     ???        Optional path to csv containing task context                      False
```