### PR TITLE
Some additional hydra suggestions

### DIFF
--- a/docs/hydra_migration.md
+++ b/docs/hydra_migration.md
@@ -207,9 +207,9 @@ Via variable interpolation in hydra, we can define `task_dir` in this configurat
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     "conf/base",
     {"conf": "example"},
 ]
@@ -241,7 +241,7 @@ register_script_config(name='scriptconfig', module=TestScriptConfig)
 Most of the new configuration happens in the `TestScriptConfig`. This will need to inherit from `RunScriptConfig` in order to get parsing of the standard `mephisto` components for free. Afterwards, we need to call `register_script_config` and name our configuration file such that Hydra knows what to parse from the command line when you execute your script.
 
 #### defaults
-It's important to note the step of creating the `defaults` entry for your `RunScriptConfig`. This will provide Hydra with some default values for keys in the created `yaml` file. The `{"mephisto.blueprint": BLUEPRINT_TYPE},` entry ensures that Hydra loads up the blueprint argument configuration that corresponds with the blueprint you're running, for instance. 
+It's important to note the step of creating the `defaults` entry for your `RunScriptConfig`. This will provide Hydra with some default values for keys in the created `yaml` file. The `{"mephisto/blueprint": BLUEPRINT_TYPE},` entry ensures that Hydra loads up the blueprint argument configuration that corresponds with the blueprint you're running, for instance. 
 
 Setting `architect` to `local` and `provider` to `mock` will make the script default to that configuration when given no arguments, however you can provide different values either in configuration files or on the command line (with `mephisto.provider.requester_name=some_requester`, or `mephisto.architect=heroku` for instance).
 
@@ -361,9 +361,9 @@ from typing import List, Any
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     "conf/base",
     {"conf": "example"},
 ]

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,12 +78,12 @@ You can choose any name for `my_mturk_user`, as this will be the id that you lat
 
 ```bash
 $ cd examples/simple_static_task
-$ python static_test_script.py mephisto.architect=heroku mephisto.provider.requester.name=my_mturk_user_sandbox
+$ python static_test_script.py mephisto.architect=heroku mephisto.provider.requester_name=my_mturk_user_sandbox
 
 # Note: my_mturk_user_sandbox is what we used to name the requester
 # when we registered the mturk account in the previous step.
 ```
-The arguments `mephisto.provider.requester.name=my_mturk_user_sandbox` and `mephisto.architect=heroku` will tell the the script to use the mturk sandbox provider and the heroku architect (as opposed to the mock provider and local architect).
+The arguments `mephisto.provider.requester_name=my_mturk_user_sandbox` and `mephisto.architect=heroku` will tell the the script to use the mturk sandbox provider and the heroku architect (as opposed to the mock provider and local architect).
 
 **Note**: If this is your first time running with the heroku architect, you may be asked to do some one-time setup work.
 

--- a/examples/parlai_chat_task_demo/conf/custom_prebuilt.yaml
+++ b/examples/parlai_chat_task_demo/conf/custom_prebuilt.yaml
@@ -5,9 +5,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Prebuilt Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
+    task_description: >
+      This is a simple chat between two people 
       used to demonstrate the functionalities around using Mephisto 
-      for ParlAI tasks."
+      for ParlAI tasks.
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"

--- a/examples/parlai_chat_task_demo/conf/custom_simple.yaml
+++ b/examples/parlai_chat_task_demo/conf/custom_simple.yaml
@@ -5,9 +5,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Simply Built Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
+    task_description: >
+      This is a simple chat between two people 
       used to demonstrate the functionalities around using Mephisto 
-      for ParlAI tasks."
+      for ParlAI tasks.
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"

--- a/examples/parlai_chat_task_demo/conf/example.yaml
+++ b/examples/parlai_chat_task_demo/conf/example.yaml
@@ -3,9 +3,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
+    task_description: >
+      This is a simple chat between two people 
       used to demonstrate the functionalities around using Mephisto 
-      for ParlAI tasks."
+      for ParlAI tasks.
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"

--- a/examples/parlai_chat_task_demo/conf/onboarding_example.yaml
+++ b/examples/parlai_chat_task_demo/conf/onboarding_example.yaml
@@ -5,9 +5,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
+    task_description: >
+      This is a simple chat between two people 
       used to demonstrate the functionalities around using Mephisto 
-      for ParlAI tasks."
+      for ParlAI tasks.
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"

--- a/examples/parlai_chat_task_demo/parlai_test_script.py
+++ b/examples/parlai_chat_task_demo/parlai_test_script.py
@@ -18,9 +18,9 @@ from typing import List, Any
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     "conf/base",
     {"conf": "example"},
 ]

--- a/examples/simple_static_task/static_run_with_onboarding.py
+++ b/examples/simple_static_task/static_run_with_onboarding.py
@@ -20,9 +20,9 @@ TASK_DIRECTORY = os.path.join(get_root_dir(), "examples/simple_static_task")
 CORRECT_ANSWER = "apple"
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     {"conf": "onboarding_example"},
 ]
 

--- a/examples/simple_static_task/static_test_script.py
+++ b/examples/simple_static_task/static_test_script.py
@@ -19,9 +19,9 @@ from typing import List, Any
 TASK_DIRECTORY = os.path.join(get_root_dir(), "examples/simple_static_task")
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     {"conf": "example"},
 ]
 

--- a/examples/static_react_task/README.md
+++ b/examples/static_react_task/README.md
@@ -21,9 +21,9 @@ This task is configured using [Hydra](https://hydra.cc/) - details about using h
 In this script, we set certain configuration variables by default in every run:
 ```python
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     {"conf": "example"},
 ]
 ```

--- a/examples/static_react_task/run_task.py
+++ b/examples/static_react_task/run_task.py
@@ -23,9 +23,9 @@ from typing import List, Any
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
 defaults = [
-    {"mephisto.blueprint": BLUEPRINT_TYPE},
-    {"mephisto.architect": 'local'},
-    {"mephisto.provider": 'mock'},
+    {"mephisto/blueprint": BLUEPRINT_TYPE},
+    {"mephisto/architect": 'local'},
+    {"mephisto/provider": 'mock'},
     {"conf": "example"},
 ]
 

--- a/mephisto/core/hydra_config.py
+++ b/mephisto/core/hydra_config.py
@@ -30,7 +30,7 @@ class RunScriptConfig:
 
 
 def register_abstraction_config(name: str, node: Any, abstraction_type: str):
-    config.store(name=name, node=node, group=f"mephisto.{abstraction_type}", package="_group_")
+    config.store(name=name, node=node, group=f"mephisto/{abstraction_type}", package="_group_")
      
 
 def initialize_named_configs():

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -133,10 +133,10 @@ class Operator:
             shared_state = SharedTaskState()
 
         # First try to find the requester:
-        requester_name = run_config.provider.requester.name
+        requester_name = run_config.provider.requester_name
         requesters = self.db.find_requesters(requester_name=requester_name)
         if len(requesters) == 0:
-            if run_config.provider.requester.name == "MOCK_REQUESTER":
+            if run_config.provider.requester_name == "MOCK_REQUESTER":
                 requesters = [get_mock_requester(self.db)]
             else:
                 raise EntryDoesNotExistException(

--- a/mephisto/data_model/test/utils.py
+++ b/mephisto/data_model/test/utils.py
@@ -22,7 +22,6 @@ from omegaconf import OmegaConf
 import json
 
 from mephisto.providers.mock.mock_provider import MockProviderArgs
-from mephisto.providers.mock.mock_requester import MockRequesterArgs
 from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprintArgs
 from mephisto.server.architects.mock_architect import MockArchitectArgs
 from mephisto.data_model.task_config import TaskConfigArgs

--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -104,11 +104,10 @@ def augment_config_from_db(script_cfg: DictConfig, db: "MephistoDB") -> DictConf
         )
     if provider_type in ["mturk_sandbox", "mturk"] and architect_type != 'heroku':
         input(
-            f"This task is going to launch live on {provider_type}, but your '
+            f"This task is going to launch live on {provider_type}, but your "
             f'provided architect is {architect_type}, are you sure you '
-            'want to do this? : "
+            'want to do this? : '
         )
 
     cfg.provider.requester_name = requester_name
-
-    return cfg
+    return script_cfg

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -20,7 +20,6 @@ from mephisto.core.operator import Operator
 from mephisto.server.architects.mock_architect import MockArchitect, MockArchitectArgs
 from mephisto.core.hydra_config import MephistoConfig
 from mephisto.providers.mock.mock_provider import MockProviderArgs
-from mephisto.providers.mock.mock_requester import MockRequesterArgs
 from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprintArgs
 from mephisto.data_model.task_config import TaskConfigArgs
 from omegaconf import OmegaConf
@@ -90,7 +89,7 @@ class TestOperator(unittest.TestCase):
                 is_concurrent=True,
             ),
             provider=MockProviderArgs(
-                requester=MockRequesterArgs(name=self.requester_name),
+                requester_name=self.requester_name,
             ),
             architect=MockArchitectArgs(should_run_server=True),
             task=MOCK_TASK_ARGS,
@@ -160,7 +159,7 @@ class TestOperator(unittest.TestCase):
                 is_concurrent=False,
             ),
             provider=MockProviderArgs(
-                requester=MockRequesterArgs(name=self.requester_name),
+                requester_name=self.requester_name,
             ),
             architect=MockArchitectArgs(should_run_server=True),
             task=MOCK_TASK_ARGS,
@@ -225,7 +224,7 @@ class TestOperator(unittest.TestCase):
         """Ensure allowed_concurrent and maximum_units_per_worker work"""
         self.operator = Operator(self.db)
         provider_args = MockProviderArgs(
-            requester=MockRequesterArgs(name=self.requester_name),
+            requester_name=self.requester_name,
         )
         architect_args = MockArchitectArgs(should_run_server=True)
         config = MephistoConfig(
@@ -367,7 +366,7 @@ class TestOperator(unittest.TestCase):
                 is_concurrent=True,
             ),
             provider=MockProviderArgs(
-                requester=MockRequesterArgs(name=self.requester_name),
+                requester_name=self.requester_name,
             ),
             architect=MockArchitectArgs(should_run_server=True),
             task=TaskConfigArgs(

--- a/test/core/test_supervisor.py
+++ b/test/core/test_supervisor.py
@@ -29,7 +29,6 @@ from mephisto.data_model.blueprint import SharedTaskState
 from mephisto.server.architects.mock_architect import MockArchitect, MockArchitectArgs
 from mephisto.core.hydra_config import MephistoConfig
 from mephisto.providers.mock.mock_provider import MockProviderArgs
-from mephisto.providers.mock.mock_requester import MockRequesterArgs
 from mephisto.server.blueprints.mock.mock_blueprint import MockBlueprintArgs
 from mephisto.data_model.task_config import TaskConfigArgs
 from omegaconf import OmegaConf


### PR DESCRIPTION
# Overview
Just a few general fixes following Omry's advice in #246 
- Renaming the path for structured configs from `mephisto.<abstraction>` to `mephisto/<abstraction>` to fit norms
- fixing multiline yaml by using `>`
- Updating all mephisto configs to directly use `mephisto.provider.requester_name` instead of instantiating a requester config for just that.
- Some additional string fixes that were breaking parsing (oops).