### PR TITLE
Tests with coverage (and flags)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
 omit =
   **/parlai/*
+  **/parlai_fb/*
   test/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+omit =
+  **/parlai/*
+  test/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,8 @@ examples/**/build/*
 **/build/*
 **/_generated/*
 **/outputs/*
+.coverage
 
-# temporary files for inspiration from ParlAI-MTurk
-old_code/*
-mephisto/server/architects/router_old/*
 
 # PyCharm
 .idea

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,6 +154,17 @@ version = "0.9.1"
 test = ["flake8 (3.7.8)", "hypothesis (3.55.3)"]
 
 [[package]]
+category = "dev"
+description = "Code coverage measurement for Python"
+name = "coverage"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.3"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 category = "main"
 description = "A backport of the dataclasses module for Python 3.6"
 marker = "python_version == \"3.6\""
@@ -705,6 +716,21 @@ version = ">=0.12"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+category = "dev"
+description = "Pytest plugin for measuring coverage."
+name = "pytest-cov"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.10.1"
+
+[package.dependencies]
+coverage = ">=4.4"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
 category = "main"
 description = "Extensions to the standard Python datetime module"
 marker = "python_version >= \"2.7\""
@@ -1175,7 +1201,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 parlai = ["parlai", "torch", "pyyaml"]
 
 [metadata]
-content-hash = "771427a65448d8b0a6e1a00faf1118bb0603a4399ee48c44178dfef93cf17479"
+content-hash = "dc7f8b0c30a831ea1a112ef249cfb055a944dbfa38d8f9c8446a35745a117106"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -1232,6 +1258,42 @@ colorama = [
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
     {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
+]
+coverage = [
+    {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
+    {file = "coverage-5.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9342dd70a1e151684727c9c91ea003b2fb33523bf19385d4554f7897ca0141d4"},
+    {file = "coverage-5.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:63808c30b41f3bbf65e29f7280bf793c79f54fb807057de7e5238ffc7cc4d7b9"},
+    {file = "coverage-5.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4d6a42744139a7fa5b46a264874a781e8694bb32f1d76d8137b68138686f1729"},
+    {file = "coverage-5.3-cp27-cp27m-win32.whl", hash = "sha256:86e9f8cd4b0cdd57b4ae71a9c186717daa4c5a99f3238a8723f416256e0b064d"},
+    {file = "coverage-5.3-cp27-cp27m-win_amd64.whl", hash = "sha256:7858847f2d84bf6e64c7f66498e851c54de8ea06a6f96a32a1d192d846734418"},
+    {file = "coverage-5.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:530cc8aaf11cc2ac7430f3614b04645662ef20c348dce4167c22d99bec3480e9"},
+    {file = "coverage-5.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:381ead10b9b9af5f64646cd27107fb27b614ee7040bb1226f9c07ba96625cbb5"},
+    {file = "coverage-5.3-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:71b69bd716698fa62cd97137d6f2fdf49f534decb23a2c6fc80813e8b7be6822"},
+    {file = "coverage-5.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d44bb3a652fed01f1f2c10d5477956116e9b391320c94d36c6bf13b088a1097"},
+    {file = "coverage-5.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:1c6703094c81fa55b816f5ae542c6ffc625fec769f22b053adb42ad712d086c9"},
+    {file = "coverage-5.3-cp35-cp35m-win32.whl", hash = "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636"},
+    {file = "coverage-5.3-cp35-cp35m-win_amd64.whl", hash = "sha256:7f43286f13d91a34fadf61ae252a51a130223c52bfefb50310d5b2deb062cf0f"},
+    {file = "coverage-5.3-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:c851b35fc078389bc16b915a0a7c1d5923e12e2c5aeec58c52f4aa8085ac8237"},
+    {file = "coverage-5.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aac1ba0a253e17889550ddb1b60a2063f7474155465577caa2a3b131224cfd54"},
+    {file = "coverage-5.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2b31f46bf7b31e6aa690d4c7a3d51bb262438c6dcb0d528adde446531d0d3bb7"},
+    {file = "coverage-5.3-cp36-cp36m-win32.whl", hash = "sha256:c5f17ad25d2c1286436761b462e22b5020d83316f8e8fcb5deb2b3151f8f1d3a"},
+    {file = "coverage-5.3-cp36-cp36m-win_amd64.whl", hash = "sha256:aef72eae10b5e3116bac6957de1df4d75909fc76d1499a53fb6387434b6bcd8d"},
+    {file = "coverage-5.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"},
+    {file = "coverage-5.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:29a6272fec10623fcbe158fdf9abc7a5fa032048ac1d8631f14b50fbfc10d17f"},
+    {file = "coverage-5.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2d43af2be93ffbad25dd959899b5b809618a496926146ce98ee0b23683f8c51c"},
+    {file = "coverage-5.3-cp37-cp37m-win32.whl", hash = "sha256:c3888a051226e676e383de03bf49eb633cd39fc829516e5334e69b8d81aae751"},
+    {file = "coverage-5.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9669179786254a2e7e57f0ecf224e978471491d660aaca833f845b72a2df3709"},
+    {file = "coverage-5.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0203acd33d2298e19b57451ebb0bed0ab0c602e5cf5a818591b4918b1f97d516"},
+    {file = "coverage-5.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:582ddfbe712025448206a5bc45855d16c2e491c2dd102ee9a2841418ac1c629f"},
+    {file = "coverage-5.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0f313707cdecd5cd3e217fc68c78a960b616604b559e9ea60cc16795c4304259"},
+    {file = "coverage-5.3-cp38-cp38-win32.whl", hash = "sha256:78e93cc3571fd928a39c0b26767c986188a4118edc67bc0695bc7a284da22e82"},
+    {file = "coverage-5.3-cp38-cp38-win_amd64.whl", hash = "sha256:8f264ba2701b8c9f815b272ad568d555ef98dfe1576802ab3149c3629a9f2221"},
+    {file = "coverage-5.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:50691e744714856f03a86df3e2bff847c2acede4c191f9a1da38f088df342978"},
+    {file = "coverage-5.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9361de40701666b034c59ad9e317bae95c973b9ff92513dd0eced11c6adf2e21"},
+    {file = "coverage-5.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c1b78fb9700fc961f53386ad2fd86d87091e06ede5d118b8a50dea285a071c24"},
+    {file = "coverage-5.3-cp39-cp39-win32.whl", hash = "sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7"},
+    {file = "coverage-5.3-cp39-cp39-win_amd64.whl", hash = "sha256:47a11bdbd8ada9b7ee628596f9d97fbd3851bd9999d398e9436bd67376dbece7"},
+    {file = "coverage-5.3.tar.gz", hash = "sha256:280baa8ec489c4f542f8940f9c4c2181f0306a8ee1a54eceba071a449fb870a0"},
 ]
 dataclasses = [
     {file = "dataclasses-0.7-py3-none-any.whl", hash = "sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836"},
@@ -1544,6 +1606,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
     {file = "pytest-5.3.2.tar.gz", hash = "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
+    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ hydra-core = "^1.0.0"
 pytest = "^5.0"
 pylint = "^2.4"
 mypy = "^0.761.0"
+pytest-cov = "^2.10.1"
 
 [tool.poetry.extras]
 parlai = [ "parlai" , "torch" , "pyyaml" ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+# pytest.ini
+[pytest]
+addopts = -ra -q
+markers =
+    req_creds: test which requires credentials
+testpaths =
+    test

--- a/test/providers/mturk_sandbox/test_mturk_provider.py
+++ b/test/providers/mturk_sandbox/test_mturk_provider.py
@@ -9,6 +9,7 @@ import shutil
 import os
 import tempfile
 import time
+import pytest
 
 from typing import Type
 from mephisto.data_model.test.utils import get_test_requester
@@ -49,6 +50,7 @@ class TestSandboxMTurkCrowdProvider(CrowdProviderTests):
         """Return the account balance we expect for a requester on sandbox"""
         return 10000
 
+    @pytest.mark.req_creds
     def test_grant_and_revoke_qualifications(self) -> None:
         """Ensure we can grant and revoke qualifications for a worker"""
         db = self.db

--- a/test/server/architects/test_heroku_architect.py
+++ b/test/server/architects/test_heroku_architect.py
@@ -5,12 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-import shutil
 import os
-import tempfile
-import sh
-import shlex
-import subprocess
+import pytest
 
 from typing import Type, ClassVar, Optional
 from mephisto.data_model.test.architect_tester import ArchitectTests
@@ -64,6 +60,11 @@ class HerokuArchitectTests(ArchitectTests):
         """Ensure process is no longer running"""
         assert self.curr_architect is not None, "No architect to check"
         return not self.curr_architect.server_is_running()
+
+    @pytest.mark.req_creds
+    def test_deploy_shutdown(self) -> None:
+        """Test deploying the server, and shutting it down"""
+        super().test_deploy_shutdown()
 
     # TODO(#102) maybe a test where we need to re-instance an architect?
 


### PR DESCRIPTION
# Overview
Adding some additional pytest functionality will help set us up both for coverage metrics and for automated testing on commits!

`pytest -v --cov` works for all tests if you have the required certifications installed locally.
`pytest -v -m "not req_creds"` should work everywhere (and will be what we use for automated testing before we have creds set up there)

Plus we have our first coverage metric - 70%

# Testing
```
>>> pytest -v --cov
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 3.8.3, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/jju/mephisto, inifile: pytest.ini, testpaths: test
plugins: hydra-core-1.0.0, cov-2.10.1, requests-mock-1.7.0
collected 105 items                                                                                                                                                                                  

test/test_mephisto.py .                                                                                                                                                                        [  0%]
test/core/test_database.py sssssssssssssssssssssss.......................                                                                                                                      [ 44%]
test/core/test_operator.py ....                                                                                                                                                                [ 48%]
test/core/test_supervisor.py ......                                                                                                                                                            [ 54%]
test/core/test_task_launcher.py ....                                                                                                                                                           [ 58%]
test/providers/mturk/test_mturk.py .                                                                                                                                                           [ 59%]
test/providers/mturk_sandbox/test_mturk_provider.py ssss.....                                                                                                                                  [ 67%]
test/server/architects/test_heroku_architect.py sss...                                                                                                                                         [ 73%]
test/server/architects/test_local_architect.py sss...                                                                                                                                          [ 79%]
test/server/architects/test_mock_architect.py sss...                                                                                                                                           [ 84%]
test/server/blueprints/test_mock_blueprint.py ssssssss........                                                                                                                                 [100%]

========================================================================================== warnings summary ==========================================================================================
/Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/botocore-1.12.246-py3.8.egg/botocore/vendored/requests/packages/urllib3/_collections.py:1
/Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/botocore-1.12.246-py3.8.egg/botocore/vendored/requests/packages/urllib3/_collections.py:1
  /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/botocore-1.12.246-py3.8.egg/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping

test/core/test_operator.py::TestOperator::test_run_job_concurrent
test/core/test_operator.py::TestOperator::test_run_job_not_concurrent
test/core/test_operator.py::TestOperator::test_run_jobs_with_restrictions
test/core/test_operator.py::TestOperator::test_run_jobs_with_restrictions
test/core/test_supervisor.py::TestSupervisor::test_register_concurrent_job
test/core/test_supervisor.py::TestSupervisor::test_register_concurrent_job_with_onboarding
test/core/test_supervisor.py::TestSupervisor::test_register_job
test/core/test_supervisor.py::TestSupervisor::test_register_job_with_onboarding
  /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/websocket_client-0.56.0-py3.8.egg/websocket/_app.py:230: DeprecationWarning: isAlive() is deprecated, use is_alive() instead
    if thread and thread.isAlive():

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---------- coverage: platform darwin, python 3.8.3-final-0 -----------
Name                                                                        Stmts   Miss  Cover
-----------------------------------------------------------------------------------------------
mephisto/__init__.py                                                            7      0   100%
mephisto/core/__init__.py                                                       0      0   100%
mephisto/core/config_handler.py                                                37     21    43%
mephisto/core/hydra_config.py                                                  24      1    96%
mephisto/core/local_database.py                                               421     42    90%
mephisto/core/logger_core.py                                                   17      2    88%
mephisto/core/operator.py                                                     199     71    64%
mephisto/core/registry.py                                                      77     10    87%
mephisto/core/supervisor.py                                                   401     91    77%
mephisto/core/task_launcher.py                                                119      8    93%
mephisto/core/utils.py                                                         87     56    36%
mephisto/data_model/__init__.py                                                 0      0   100%
mephisto/data_model/agent.py                                                  269     85    68%
mephisto/data_model/architect.py                                               34     13    62%
mephisto/data_model/assignment.py                                             255     93    64%
mephisto/data_model/assignment_state.py                                        29      2    93%
mephisto/data_model/blueprint.py                                              243     64    74%
mephisto/data_model/constants.py                                                2      0   100%
mephisto/data_model/crowd_provider.py                                          50      7    86%
mephisto/data_model/database.py                                               176     44    75%
mephisto/data_model/exceptions.py                                              13      5    62%
mephisto/data_model/packet.py                                                  31      1    97%
mephisto/data_model/project.py                                                 26     11    58%
mephisto/data_model/qualification.py                                           85     47    45%
mephisto/data_model/requester.py                                               55     15    73%
mephisto/data_model/task.py                                                   235     60    74%
mephisto/data_model/task_config.py                                             41      3    93%
mephisto/data_model/test/__init__.py                                            0      0   100%
mephisto/data_model/test/architect_tester.py                                   90      4    96%
mephisto/data_model/test/blueprint_tester.py                                  112      6    95%
mephisto/data_model/test/crowd_provider_tester.py                              74      3    96%
mephisto/data_model/test/data_model_database_tester.py                        524      2    99%
mephisto/data_model/test/utils.py                                              75     14    81%
mephisto/data_model/worker.py                                                 108     26    76%
mephisto/providers/__init__.py                                                  0      0   100%
mephisto/providers/mock/__init__.py                                             0      0   100%
mephisto/providers/mock/mock_agent.py                                          38      8    79%
mephisto/providers/mock/mock_datastore.py                                     105     47    55%
mephisto/providers/mock/mock_provider.py                                       41      7    83%
mephisto/providers/mock/mock_requester.py                                      34     12    65%
mephisto/providers/mock/mock_unit.py                                           31      5    84%
mephisto/providers/mock/mock_worker.py                                         28     12    57%
mephisto/providers/mock/provider_type.py                                        1      0   100%
mephisto/providers/mturk/__init__.py                                            0      0   100%
mephisto/providers/mturk/mturk_agent.py                                        47     29    38%
mephisto/providers/mturk/mturk_datastore.py                                    95     29    69%
mephisto/providers/mturk/mturk_provider.py                                     77     33    57%
mephisto/providers/mturk/mturk_requester.py                                    59     16    73%
mephisto/providers/mturk/mturk_unit.py                                        135    110    19%
mephisto/providers/mturk/mturk_utils.py                                       273    190    30%
mephisto/providers/mturk/mturk_worker.py                                       91     22    76%
mephisto/providers/mturk/provider_type.py                                       1      0   100%
mephisto/providers/mturk_sandbox/__init__.py                                    0      0   100%
mephisto/providers/mturk_sandbox/provider_type.py                               1      0   100%
mephisto/providers/mturk_sandbox/sandbox_mturk_agent.py                        18      9    50%
mephisto/providers/mturk_sandbox/sandbox_mturk_provider.py                     29      6    79%
mephisto/providers/mturk_sandbox/sandbox_mturk_requester.py                    23      4    83%
mephisto/providers/mturk_sandbox/sandbox_mturk_unit.py                         15      5    67%
mephisto/providers/mturk_sandbox/sandbox_mturk_worker.py                       22      3    86%
mephisto/server/__init__.py                                                     0      0   100%
mephisto/server/architects/__init__.py                                          0      0   100%
mephisto/server/architects/heroku_architect.py                                198     53    73%
mephisto/server/architects/local_architect.py                                 100     32    68%
mephisto/server/architects/mock_architect.py                                  139     11    92%
mephisto/server/architects/router/__init__.py                                   0      0   100%
mephisto/server/architects/router/build_router.py                              40      3    92%
mephisto/server/blueprints/__init__.py                                          0      0   100%
mephisto/server/blueprints/abstract/__init__.py                                 0      0   100%
mephisto/server/blueprints/abstract/static_task/__init__.py                     0      0   100%
mephisto/server/blueprints/abstract/static_task/empty_task_builder.py           7      2    71%
mephisto/server/blueprints/abstract/static_task/static_agent_state.py          60     42    30%
mephisto/server/blueprints/abstract/static_task/static_blueprint.py            89     52    42%
mephisto/server/blueprints/abstract/static_task/static_task_runner.py          33     19    42%
mephisto/server/blueprints/mock/__init__.py                                     0      0   100%
mephisto/server/blueprints/mock/mock_agent_state.py                            28      5    82%
mephisto/server/blueprints/mock/mock_blueprint.py                              42      6    86%
mephisto/server/blueprints/mock/mock_task_builder.py                           17      4    76%
mephisto/server/blueprints/mock/mock_task_runner.py                            63     10    84%
mephisto/server/blueprints/parlai_chat/__init__.py                              0      0   100%
mephisto/server/blueprints/parlai_chat/parlai_chat_agent_state.py              66     49    26%
mephisto/server/blueprints/parlai_chat/parlai_chat_blueprint.py               119     69    42%
mephisto/server/blueprints/parlai_chat/parlai_chat_task_builder.py            109     87    20%
mephisto/server/blueprints/parlai_chat/parlai_chat_task_runner.py             127     93    27%
mephisto/server/blueprints/static_react_task/__init__.py                        0      0   100%
mephisto/server/blueprints/static_react_task/static_react_blueprint.py         38     13    66%
mephisto/server/blueprints/static_react_task/static_react_task_builder.py      21     11    48%
mephisto/server/blueprints/static_task/__init__.py                              0      0   100%
mephisto/server/blueprints/static_task/static_html_blueprint.py                62     35    44%
mephisto/server/blueprints/static_task/static_html_task_builder.py             57     38    33%
mephisto/server/channels/__init__.py                                            0      0   100%
mephisto/server/channels/channel.py                                            20      0   100%
mephisto/server/channels/websocket_channel.py                                  86     18    79%
-----------------------------------------------------------------------------------------------
TOTAL                                                                        6612   2010    70%

====================================================================================== short test summary info =======================================================================================
SKIPPED [23] /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/unittest.py:237: Skip BaseDatabaseTests tests, it's a base class
SKIPPED [4] /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/unittest.py:237: Skip CrowdProviderTests tests, it's a base class
SKIPPED [3] /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/unittest.py:237: Skip ArchitectTests tests, it's a base class
SKIPPED [2] mephisto/data_model/test/architect_tester.py:148: Skipping test as no ArchitectClass set
SKIPPED [2] mephisto/data_model/test/architect_tester.py:110: Skipping test as no ArchitectClass set
SKIPPED [2] mephisto/data_model/test/architect_tester.py:139: Skipping test as no ArchitectClass set
SKIPPED [8] /Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/_pytest/unittest.py:237: Skip BlueprintTests tests, it's a base class
====================================================================== 61 passed, 44 skipped, 10 warnings in 143.82s (0:02:23) =======================================================================
```