### PR TITLE
Hydra MTurk fixes, plus doc update

### DIFF
--- a/docs/hydra_migration.md
+++ b/docs/hydra_migration.md
@@ -1,7 +1,7 @@
 # Transitioning from ARG_STRING to Hydra
-As Mephisto has moved away from the `ARG_STRING` in [#246](https://github.com/facebookresearch/Mephisto/pull/246), all existing scripts that used to use the `ARG_STRING` will need to use Hydra moving forward. 
+As Mephisto has moved away from the `ARG_STRING` in [#246](https://github.com/facebookresearch/Mephisto/pull/246), all existing scripts that used to use the `ARG_STRING` will need to use Hydra moving forward.
 
-This document shows the transition steps from moving from the old format to the new format, using the `ParlAIChatBlueprint` as an example. 
+This document shows the transition steps from moving from the old format to the new format, using the `ParlAIChatBlueprint` as an example.
 
 # Original file
 ```python
@@ -140,9 +140,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
-      used to demonstrate the functionalities around using Mephisto 
+    task_description:
+      "This is a simple chat between two people
+      used to demonstrate the functionalities around using Mephisto
       for ParlAI tasks."
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"
@@ -153,9 +153,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Simply Built Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
-      used to demonstrate the functionalities around using Mephisto 
+    task_description:
+      "This is a simple chat between two people
+      used to demonstrate the functionalities around using Mephisto
       for ParlAI tasks."
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"
@@ -199,7 +199,7 @@ parser.add_argument(
 Many of these are set directly as part of the standard Mephisto config now, as arguments about using onboarding and such are exposed directly in the hydra config. Some of these are handled differently now though.
 
 ### After
-We replace configuring via argparse and `RunScriptParser` by using a `dataclass` containing the configuration you want to add to a script. In the below we add `num_turns` and `turn_timeout` as options. 
+We replace configuring via argparse and `RunScriptParser` by using a `dataclass` containing the configuration you want to add to a script. In the below we add `num_turns` and `turn_timeout` as options.
 
 Via variable interpolation in hydra, we can define `task_dir` in this configuration file, and refer to this in other arguments with `${task_dir}`.
 
@@ -216,7 +216,7 @@ defaults = [
 
 from mephisto.core.hydra_config import RunScriptConfig, register_script_config
 
-@dataclass 
+@dataclass
 class TestScriptConfig(RunScriptConfig):
     defaults: List[Any] = field(default_factory=lambda: defaults)
     task_dir: str = TASK_DIRECTORY
@@ -229,7 +229,7 @@ class TestScriptConfig(RunScriptConfig):
     turn_timeout: int = field(
         default=300,
         metadata={
-            'help': 
+            'help':
                 "Maximum response time before kicking "
                 "a worker out, default 300 seconds",
         },
@@ -241,17 +241,17 @@ register_script_config(name='scriptconfig', module=TestScriptConfig)
 Most of the new configuration happens in the `TestScriptConfig`. This will need to inherit from `RunScriptConfig` in order to get parsing of the standard `mephisto` components for free. Afterwards, we need to call `register_script_config` and name our configuration file such that Hydra knows what to parse from the command line when you execute your script.
 
 #### defaults
-It's important to note the step of creating the `defaults` entry for your `RunScriptConfig`. This will provide Hydra with some default values for keys in the created `yaml` file. The `{"mephisto/blueprint": BLUEPRINT_TYPE},` entry ensures that Hydra loads up the blueprint argument configuration that corresponds with the blueprint you're running, for instance. 
+It's important to note the step of creating the `defaults` entry for your `RunScriptConfig`. This will provide Hydra with some default values for keys in the created `yaml` file. The `{"mephisto/blueprint": BLUEPRINT_TYPE},` entry ensures that Hydra loads up the blueprint argument configuration that corresponds with the blueprint you're running, for instance.
 
-Setting `architect` to `local` and `provider` to `mock` will make the script default to that configuration when given no arguments, however you can provide different values either in configuration files or on the command line (with `mephisto.provider.requester_name=some_requester`, or `mephisto.architect=heroku` for instance).
+Setting `architect` to `local` and `provider` to `mock` will make the script default to that configuration when given no arguments, however you can provide different values either in configuration files or on the command line (with `mephisto.provider.requester_name=some_requester`, or `mephisto/architect=heroku` for instance). Configuring a full abstraction uses slash notation as in `mephisto/abstraction=value`, while configuring variables within an abstraction uses dot notation as in `mephisto/abstraction.variable=value`.
 
-The entry with just `"conf/base"` tells hydra to load the entire contents of `conf/base.yaml` as default values. 
+The entry with just `"conf/base"` tells hydra to load the entire contents of `conf/base.yaml` as default values.
 
 Lastly, `{"conf": "example"},` gives hydra the command to load specifically the configuration in `conf/example.yaml`, however on the command line you can use `conf=<>` to make hydra use the defaults you've specified in a different configuration file instead. This last line is useful for a demo version for your script, but it's likely your important configuration options will exist in files you can access with `python script.py conf=<>` instead.
 
 ## Extra arguments
 ### Before
-Extra arguments used to be provided via the `extra_args` parameter to the run script, however this used to be merged with the regular argument dict passed in. 
+Extra arguments used to be provided via the `extra_args` parameter to the run script, however this used to be merged with the regular argument dict passed in.
 ```python
 world_opt = {"num_turns": 3, "turn_timeout": args["turn_timeout"]}
 ...
@@ -261,7 +261,7 @@ extra_args = {"world_opt": world_opt, "onboarding_world_opt": world_opt}
 Mephisto now asks that tasks specify their shared state with `SharedTaskState`. The `ParlAIChatBlueprint` now specifies a `SharedParlAITaskState` that we pass instead.
 ```python
 world_opt = {
-    "num_turns": cfg.num_turns, 
+    "num_turns": cfg.num_turns,
     "turn_timeout": cfg.turn_timeout,
 }
 ...
@@ -330,7 +330,7 @@ from mephisto.utils.scripts import MephistoRunScriptParser, str2bool # RunScript
 We remove unnecessary or deprecated imports.
 
 ### After
-We'll need to add a few things. First, `load_db_and_process_config` covers the old capabilities of the `MephistoRunScriptParser`. 
+We'll need to add a few things. First, `load_db_and_process_config` covers the old capabilities of the `MephistoRunScriptParser`.
 Mephisto now defines run scripts and configurations using Hydra and dataclasses, as such you'll need some imports from `dataclasses`, `hydra`, and `omegaconf` (which is the configuration library that powers hydra).
 ```python
 import os
@@ -370,7 +370,7 @@ defaults = [
 
 from mephisto.core.hydra_config import RunScriptConfig, register_script_config
 
-@dataclass 
+@dataclass
 class TestScriptConfig(RunScriptConfig):
     defaults: List[Any] = field(default_factory=lambda: defaults)
     task_dir: str = TASK_DIRECTORY
@@ -383,7 +383,7 @@ class TestScriptConfig(RunScriptConfig):
     turn_timeout: int = field(
         default=300,
         metadata={
-            'help': 
+            'help':
                 "Maximum response time before kicking "
                 "a worker out, default 300 seconds",
         },
@@ -397,7 +397,7 @@ def main(cfg: DictConfig) -> None:
     db, cfg = load_db_and_process_config(cfg)
 
     world_opt = {
-        "num_turns": cfg.num_turns, 
+        "num_turns": cfg.num_turns,
         "turn_timeout": cfg.turn_timeout,
     }
 
@@ -443,9 +443,9 @@ mephisto:
   task:
     task_name: parlai-chat-example
     task_title: "Test ParlAI Chat Task"
-    task_description: 
-      "This is a simple chat between two people 
-      used to demonstrate the functionalities around using Mephisto 
+    task_description:
+      "This is a simple chat between two people
+      used to demonstrate the functionalities around using Mephisto
       for ParlAI tasks."
     task_reward: 0.3
     task_tags: "dynamic,chat,testing"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ $ pip install -e .
 
 # Verify that mephisto is installed correctly, and handle any required config:
 $ mephisto check
-Please enter the full path to a location to store Mephisto run data. By default this would be at '/private/home/jju/mephisto/data'. This dir should NOT be on a distributed file store. Press enter to use the default:  
+Please enter the full path to a location to store Mephisto run data. By default this would be at '/private/home/jju/mephisto/data'. This dir should NOT be on a distributed file store. Press enter to use the default:
 Mephisto seems to be set up correctly.
 ```
 
@@ -28,7 +28,7 @@ $ poetry install
 
 # Verify that mephisto is installed correctly:
 $ mephisto check
-Please enter the full path to a location to store Mephisto run data. By default this would be at '/private/home/jju/mephisto/data'. This dir should NOT be on a distributed file store. Press enter to use the default: 
+Please enter the full path to a location to store Mephisto run data. By default this would be at '/private/home/jju/mephisto/data'. This dir should NOT be on a distributed file store. Press enter to use the default:
 Mephisto seems to be set up correctly.
 
 ```
@@ -83,7 +83,8 @@ $ python static_test_script.py mephisto.architect=heroku mephisto.provider.reque
 # Note: my_mturk_user_sandbox is what we used to name the requester
 # when we registered the mturk account in the previous step.
 ```
-The arguments `mephisto.provider.requester_name=my_mturk_user_sandbox` and `mephisto.architect=heroku` will tell the the script to use the mturk sandbox provider and the heroku architect (as opposed to the mock provider and local architect).
+The arguments `mephisto.provider.requester_name=my_mturk_user_sandbox` and `mephisto/architect=heroku` will tell the the script to use the mturk sandbox provider and the heroku architect (as opposed to the mock provider and local architect). Notice that if we're setting a full abstraction (like the architect) we reference it with `mephisto/abstraction=val`, however when we're setting an argument, we use `mephisto.abstraction.argument=val`. This tells hydra whether we're providing an argument value or the name of a configuration to load.
+
 
 **Note**: If this is your first time running with the heroku architect, you may be asked to do some one-time setup work.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,7 +78,7 @@ You can choose any name for `my_mturk_user`, as this will be the id that you lat
 
 ```bash
 $ cd examples/simple_static_task
-$ python static_test_script.py mephisto.architect=heroku mephisto.provider.requester_name=my_mturk_user_sandbox
+$ python static_test_script.py mephisto/architect=heroku mephisto.provider.requester_name=my_mturk_user_sandbox
 
 # Note: my_mturk_user_sandbox is what we used to name the requester
 # when we registered the mturk account in the previous step.

--- a/examples/static_react_task/README.md
+++ b/examples/static_react_task/README.md
@@ -39,7 +39,7 @@ python run_task.py mephisto.architect.port=4000
 ```
 To be able to launch with a `HerokuArchitect` rather than the default `LocalArchitect`, you can use:
 ```console
-python run_task.py mephisto.architect=heroku
+python run_task.py mephisto/architect=heroku
 ```
 ### Providing task data
 In this case, the provided app demonstrates being able to send task data forward to the fronted. See the `run_task.py` script. Here we have:

--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -58,12 +58,12 @@ class TrackedRun(NamedTuple):
 class Operator:
     """
     Acting as the controller behind the curtain, the Operator class
-    is responsible for managing the knobs, switches, and dials 
-    of the rest of the Mephisto architecture. 
+    is responsible for managing the knobs, switches, and dials
+    of the rest of the Mephisto architecture.
 
     Most convenience scripts for using Mephisto will use an Operator
-    to get the job done, though this class itself is also a 
-    good model to use to understand how the underlying 
+    to get the job done, though this class itself is also a
+    good model to use to understand how the underlying
     architecture works in order to build custom jobs or workflows.
     """
 
@@ -239,7 +239,9 @@ class Operator:
 
             # Register the task with the provider
             provider = CrowdProviderClass(self.db)
-            provider.setup_resources_for_task_run(task_run, run_config, task_url)
+            provider.setup_resources_for_task_run(
+                task_run, run_config, shared_state, task_url
+            )
 
             initialization_data_array = blueprint.get_initialization_data()
 
@@ -341,7 +343,7 @@ class Operator:
         self, run_config: DictConfig, shared_state: Optional[SharedTaskState] = None
     ) -> Optional[str]:
         """
-        Wrapper around validate_and_run_config_or_die that prints errors on 
+        Wrapper around validate_and_run_config_or_die that prints errors on
         failure, rather than throwing. Generally for use in scripts.
         """
         try:
@@ -378,7 +380,7 @@ class Operator:
         self, skip_input=False, log_rate: Optional[int] = None
     ) -> None:
         """
-        Wait for task_runs to complete, and then shutdown.  
+        Wait for task_runs to complete, and then shutdown.
 
         Set log_rate to get print statements of currently running tasks
         at the specified interval

--- a/mephisto/core/task_launcher.py
+++ b/mephisto/core/task_launcher.py
@@ -30,7 +30,7 @@ import threading
 from mephisto.core.logger_core import get_logger
 import types
 
-logger = get_logger(name=__name__, verbose=True, level="debug")
+logger = get_logger(name=__name__, verbose=True, level="info")
 
 UNIT_GENERATOR_WAIT_SECONDS = 10
 ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5
@@ -139,8 +139,8 @@ class TaskLauncher:
             self.assignments_thread.start()
 
     def generate_units(self):
-        """ units generator which checks that only 'max_num_concurrent_units' running at the same time,
-        i.e. in the LAUNCHED or ASSIGNED states """
+        """units generator which checks that only 'max_num_concurrent_units' running at the same time,
+        i.e. in the LAUNCHED or ASSIGNED states"""
         while self.keep_launching_units:
             units_id_to_remove = []
             for db_id, unit in self.launched_units.items():

--- a/mephisto/data_model/crowd_provider.py
+++ b/mephisto/data_model/crowd_provider.py
@@ -78,7 +78,7 @@ class CrowdProvider(ABC):
     @classmethod
     def assert_task_args(cls, args: DictConfig, shared_state: "SharedTaskState"):
         """
-        Assert that the provided arguments are valid. Should 
+        Assert that the provided arguments are valid. Should
         fail if a task launched with these arguments would
         not work
         """
@@ -110,7 +110,11 @@ class CrowdProvider(ABC):
 
     @abstractmethod
     def setup_resources_for_task_run(
-        self, task_run: "TaskRun", args: DictConfig, server_url: str
+        self,
+        task_run: "TaskRun",
+        args: DictConfig,
+        shared_state: "SharedTaskState",
+        server_url: str,
     ) -> None:
         """
         Setup any required resources for managing any additional resources

--- a/mephisto/providers/mock/mock_provider.py
+++ b/mephisto/providers/mock/mock_provider.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from mephisto.data_model.worker import Worker
     from mephisto.data_model.requester import Requester
     from mephisto.data_model.agent import Agent
+    from mephisto.data_model.blueprint import SharedTaskState
     from omegaconf import DictConfig
 
 
@@ -63,7 +64,11 @@ class MockProvider(CrowdProvider):
         return MockDatastore(datastore_root=storage_path)
 
     def setup_resources_for_task_run(
-        self, task_run: "TaskRun", args: "DictConfig", server_url: str
+        self,
+        task_run: "TaskRun",
+        args: "DictConfig",
+        shared_state: "SharedTaskState",
+        server_url: str,
     ) -> None:
         """Mocks don't do any initialization"""
         return None

--- a/mephisto/providers/mturk_sandbox/sandbox_mturk_provider.py
+++ b/mephisto/providers/mturk_sandbox/sandbox_mturk_provider.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from mephisto.providers.mturk_sandbox.provider_type import PROVIDER_TYPE
-from mephisto.providers.mturk.mturk_provider import MTurkProvider
+from mephisto.providers.mturk.mturk_provider import MTurkProvider, MTurkProviderArgs
 from mephisto.providers.mturk_sandbox.sandbox_mturk_agent import SandboxMTurkAgent
 from mephisto.providers.mturk_sandbox.sandbox_mturk_requester import (
     SandboxMTurkRequester,
@@ -15,6 +15,7 @@ from mephisto.providers.mturk_sandbox.sandbox_mturk_worker import SandboxMTurkWo
 from mephisto.core.registry import register_mephisto_abstraction
 
 import os
+from dataclasses import dataclass
 
 from typing import Any, ClassVar, Type, List, TYPE_CHECKING
 
@@ -23,6 +24,13 @@ if TYPE_CHECKING:
     from mephisto.data_model.worker import Worker
     from mephisto.data_model.requester import Requester
     from mephisto.data_model.agent import Agent
+
+
+@dataclass
+class SandboxMTurkProviderArgs(MTurkProviderArgs):
+    """Provider args for a sandbox MTurk provider"""
+
+    _provider_type: str = PROVIDER_TYPE
 
 
 @register_mephisto_abstraction()
@@ -42,6 +50,8 @@ class SandboxMTurkProvider(MTurkProvider):
     WorkerClass: ClassVar[Type["Worker"]] = SandboxMTurkWorker
 
     AgentClass: ClassVar[Type["Agent"]] = SandboxMTurkAgent
+
+    ArgsClass = SandboxMTurkProviderArgs
 
     SUPPORTED_TASK_TYPES: ClassVar[List[str]] = [
         # TODO

--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 """
-Utilities that are useful for Mephisto-related scripts. 
+Utilities that are useful for Mephisto-related scripts.
 """
 
 from mephisto.core.local_database import LocalMephistoDB
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
 def load_db_and_process_config(cfg: DictConfig) -> Tuple["MephistoDB", DictConfig]:
     """
-    Using a Hydra DictConfig built from a RunScriptConfig, 
-    load the desired MephistoDB and 
+    Using a Hydra DictConfig built from a RunScriptConfig,
+    load the desired MephistoDB and
     validate the config against the database contents, then
     return the database and validated config.
     """
@@ -110,4 +110,5 @@ def augment_config_from_db(script_cfg: DictConfig, db: "MephistoDB") -> DictConf
         )
 
     cfg.provider.requester_name = requester_name
+    cfg.provider._provider_type = provider_type
     return script_cfg

--- a/test/core/test_supervisor.py
+++ b/test/core/test_supervisor.py
@@ -39,7 +39,7 @@ EMPTY_STATE = SharedTaskState()
 
 class TestSupervisor(unittest.TestCase):
     """
-    Unit testing for the Mephisto Supervisor, 
+    Unit testing for the Mephisto Supervisor,
     uses WebsocketChannel and MockArchitect
     """
 
@@ -64,7 +64,7 @@ class TestSupervisor(unittest.TestCase):
         self.url = self.urls[0]
         self.provider = MockProvider(self.db)
         self.provider.setup_resources_for_task_run(
-            self.task_run, self.task_run.args, self.url
+            self.task_run, self.task_run.args, EMPTY_STATE, self.url
         )
         self.launcher = TaskLauncher(
             self.db, self.task_run, self.get_mock_assignment_data_array()
@@ -96,7 +96,7 @@ class TestSupervisor(unittest.TestCase):
 
     def test_channel_operations(self):
         """
-        Initialize a channel, and ensure the basic 
+        Initialize a channel, and ensure the basic
         startup and shutdown functions are working
         """
         sup = Supervisor(self.db)


### PR DESCRIPTION
# Overview
A small bug was flagged in #256 that was breaking deploys to MTurk sandbox (as well as an unexpected change following applying Omry's advice in #250). This updates the Doc describing how to work things in the quickstart, and fixes the underlying bug in the mturk provider.

# Testing
![Screen Shot 2020-09-21 at 9 30 59 AM](https://user-images.githubusercontent.com/1276867/93774217-0225ab00-fbef-11ea-8525-d7f2ceccc66f.png)
`pytest` runs tests fine.