### PR TITLE
Making it possible to further control task pairing

### DIFF
--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -273,11 +273,13 @@ class TaskRun:
 
         # Should load cached blueprint for SharedTaskState
         blueprint = self.get_blueprint()
-        valid_units = [
-            u for u in units if blueprint.shared_state.worker_can_do_unit(worker, u)
+        ret_units = [
+            u
+            for u in valid_units
+            if blueprint.shared_state.worker_can_do_unit(worker, u)
         ]
 
-        return valid_units
+        return ret_units
 
     def clear_reservation(self, unit: "Unit") -> None:
         """

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -56,7 +56,7 @@ def assert_task_is_valid(dir_name, task_type) -> None:
 class Task:
     """
     This class contains all of the required tidbits for launching a set of
-    assignments, primarily by leveraging a blueprint. It also takes the 
+    assignments, primarily by leveraging a blueprint. It also takes the
     project name if this task is to be associated with a specific project.
     """
 
@@ -270,6 +270,13 @@ class TaskRun:
             if not any(is_self_set):
                 units += unit_set
         valid_units = [u for u in units if u.get_status() == AssignmentState.LAUNCHED]
+
+        # Should load cached blueprint for SharedTaskState
+        blueprint = self.get_blueprint()
+        valid_units = [
+            u for u in units if blueprint.shared_state.worker_can_do_unit(worker, u)
+        ]
+
         return valid_units
 
     def clear_reservation(self, unit: "Unit") -> None:


### PR DESCRIPTION
# Overview
ParlAI MTurk used to have the ability to individually check to see if a worker was eligible to work on a particular task. This was batched into a number of options collectively called `eligibility_function`. 

This PR intends to restore that functionality to Mephisto, using the `SharedTaskState` to register a function called `worker_can_do_unit`.

# Implementation
- Adds `worker_can_do_unit` to `SharedTaskState`
- `get_valid_units_for_worker` now calls `worker_can_do_unit` to filter out the units before returning a list.
- Default value for `worker_can_do_unit` always returns `True`

# Testing
Replacing the default return value with `False` makes it impossible to launch any tasks.
As is, it's possible to run the demo tasks to completion.