### PR TITLE
Script option to print config

### DIFF
--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def load_db_and_process_config(
-    cfg: DictConfig, should_print=True
+    cfg: DictConfig, should_print=False
 ) -> Tuple["MephistoDB", DictConfig]:
     """
     Using a Hydra DictConfig built from a RunScriptConfig,

--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def load_db_and_process_config(
-    cfg: DictConfig, should_print=False
+    cfg: DictConfig, should_print=True
 ) -> Tuple["MephistoDB", DictConfig]:
     """
     Using a Hydra DictConfig built from a RunScriptConfig,

--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -10,7 +10,7 @@ Utilities that are useful for Mephisto-related scripts.
 from mephisto.core.local_database import LocalMephistoDB
 from mephisto.core.utils import get_mock_requester, get_root_data_dir
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 import argparse
 from typing import Tuple, Dict, Any, TYPE_CHECKING
@@ -20,15 +20,21 @@ if TYPE_CHECKING:
     from mephisto.data_model.database import MephistoDB
 
 
-def load_db_and_process_config(cfg: DictConfig) -> Tuple["MephistoDB", DictConfig]:
+def load_db_and_process_config(
+    cfg: DictConfig, should_print=True
+) -> Tuple["MephistoDB", DictConfig]:
     """
     Using a Hydra DictConfig built from a RunScriptConfig,
     load the desired MephistoDB and
     validate the config against the database contents, then
     return the database and validated config.
+
+    Takes in an option to print out the configuration before returning
     """
     db = get_db_from_config(cfg)
     valid_config = augment_config_from_db(cfg, db)
+    if should_print:
+        print(OmegaConf.to_yaml(valid_config))
     return db, valid_config
 
 

--- a/mephisto/utils/scripts.py
+++ b/mephisto/utils/scripts.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def load_db_and_process_config(
-    cfg: DictConfig, should_print=False
+    cfg: DictConfig, print_config=False
 ) -> Tuple["MephistoDB", DictConfig]:
     """
     Using a Hydra DictConfig built from a RunScriptConfig,
@@ -33,7 +33,7 @@ def load_db_and_process_config(
     """
     db = get_db_from_config(cfg)
     valid_config = augment_config_from_db(cfg, db)
-    if should_print:
+    if print_config:
         print(OmegaConf.to_yaml(valid_config))
     return db, valid_config
 


### PR DESCRIPTION
# Overview
Adds a simple flag to the script method `load_db_and_process_config` that most Mephisto scripts will be using that allows for printing the loaded and parsed config. Users can enable this by setting `should_print=True`.

# Testing
```
python parlai_test_script.py 
mephisto:
  blueprint:
    _blueprint_type: parlai_chat
    onboarding_qualification: ???
    block_qualification: ???
    _group: ParlAIChatBlueprint
    world_file: ${task_dir}/demo_worlds.py
    preview_source: ???
    task_description_file: ${task_dir}/task_description.html
    custom_source_bundle: ???
    custom_source_dir: ???
    extra_source_dir: ???
    context_csv: ???
    num_conversations: 1
  provider:
    _provider_type: mock
    requester_name: test_requester
  architect:
    _architect_type: local
    hostname: localhost
    port: '3000'
  task:
    task_name: parlai-chat-example
    task_title: Test ParlAI Chat Task
    task_description: 'This is a simple chat between two people  used to demonstrate
      the functionalities around using Mephisto  for ParlAI tasks.

      '
    task_reward: 0.3
    task_tags: dynamic,chat,testing
    assignment_duration_in_seconds: 1800
    allowed_concurrent: 0
    maximum_units_per_worker: 0
task_dir: /Users/jju/mephisto/examples/parlai_chat_task_demo
num_turns: 3
turn_timeout: 300

[09-22 11:31:44] p80445 {operator.py:179}  INFO - Creating a task run under task name: parlai-chat-example
[2020-09-22 11:31:44,556][mephisto.core.operator][INFO] - Creating a task run under task name: parlai-chat-example
...
```