### PR TITLE
Adding codecov step to github actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -25,4 +25,9 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test with pytest
         run: |
-          python -m pytest -v -m "not req_creds" --cov
+          python -m pytest -v -m "not req_creds" --cov --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
# Details
Saw that ParlAI was getting cool code coverage details on codecov.io, so I wanted some. Will use [these](https://codecov.io/gh/facebookresearch/mephisto/branch/code-cov-io) to try to increase coverage wherever possible.