### PR TITLE
`bootstrap-chat` docs update

### DIFF
--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -65,8 +65,7 @@ function MyChatApp() {
 
 Here we replace the rendering of the chat message with the `renderMessage` prop. This is one of the provided optional render overrides, for the others see below.
 
-However, note that we also import the `<ChatMessage />` component and use that as part of the rendering process. We don't have to do this portion, and could easily just create our own isolated implementation, e.g. something like `<div>{message.text + "!!!!!"}</div>`. However this example illustrates how we can opt out of default behavior, while still having available to us primitives and core components that can get us back some of that default functionality at our discretion. In this case, we
-ll still have the look and feel of the original chat message component, however with a custom message property.
+Note that we also import the `<ChatMessage />` component to use as part of the render method. We don't have to do this portion, and could easily just create our own isolated implementation, e.g. something like `<div>{message.text + "!!!!!"}</div>`. However this example illustrates how we can opt out of default behavior, while still having available to us primitives and core components that can get us back some of that functionality at our discretion. In this case, we'll still have the look and feel of the original chat message component, however with a custom message property.
 
 
 ## The `<ChatApp />` component

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -101,13 +101,14 @@ Note: If `renderResponse()` is also implemented, this render prop will be ignore
 
 This render prop is for cases where you'd like to minimally alter the response text box. For larger customizations, we recommend implementing `renderReponse()` instead.
 
-```js
-{
-    onMessageSend,
-    inputMode,
-    active, // helper boolean, essentially is true when inputMode is INPUT_MODE.READY_FOR_INPUT
-}
-```
+**Arguments:**
+
+**`onMessageSend`**: 
+
+**`inputMode`**: 
+
+**`active`**: A helper boolean, essentially is true when `inputMode` is `INPUT_MODE.READY_FOR_INPUT`
+
 
 ### `renderResponse({ onMessageSend, inputMode, mephistoContext, appContext })`
 A render prop that if implemented, overrides the way the entire response panel is rendered. You will be responsible for handling all aspects of the panel in this case.

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -115,7 +115,6 @@ This render prop is for cases where you'd like to minimally alter the response t
 - `INACTIVE`: Occurs when something goes wrong, usually if the agent experiences a disconnect, timeout, the task is returned, or has expired.
 - `DONE`: The task is complete.
 - `READY_FOR_INPUT`: The current agent is ready and is ready to send over data.
-- `IDLE`: (TODO: This doesn't seem to be set anywhere. Should we remove?)
 
 **`active`**: A helper boolean, essentially is true when `inputMode` is `INPUT_MODE.READY_FOR_INPUT`
 

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -24,4 +24,4 @@ npm link bootstrap-chat
 
 ```
 
-## Usage (`useMephistoTask`)
+## Usage

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -133,7 +133,7 @@ All render props will receive the `appContext` argument. This context is general
 
 **`taskContext`**: 
 
-**`appSettings`**: 
+**`appSettings`**: You can use this to have access to various app-wide settings. By default it is used for volume control.
 
 **`setAppSettings`**: 
 

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -74,20 +74,22 @@ All render props will receive as part of their args both `mephistoContext` and `
 ### `renderMessage({ message, idx, mephistoContext, appContext })`
 A render prop that if implemented, overides the way a chat message is rendered.
 
+**Arguments:**
 
-```js
+**`message`**: An object with the following schema:
+
+TODO: where does this object come from in the backend? Find to verify the below
+
+```
 {
-    message: {
-        id,
-        text,
-        task_data
-    },
-    idx, // the 0-indexed position of this message with respect to all messages received
-
-    mephistoContext, // the current MephistoContext
-    appContext // the current AppContext
+    message_id,
+    text,
+    task_data
 }
 ```
+
+**`idx`**: The 0-based index of the current message in the list of all messages
+
 
 ### `renderSidePane({ mephistoContext, appContext })`
 A render prop that if implemented, overrides the way the side pane is rendered.
@@ -116,3 +118,24 @@ Note: If this render prop is implemented, `renderTextResponse()` will be ignored
 ### `onMessagesChange(messages)`
 
 A callback that will get called any time a new message is received. The callback will receive as an argument all messages received thus far.
+
+### The `mephistoContext` argument
+
+All render props will receive the `mephistoContext` argument.
+
+This object is basically the return value of calling the `useMephistoLiveTask` hooks. Further documentation on these properties can be found in the documentation for the `mephisto-task` package under the `useMephistoLiveTask` section.
+
+### The `appContext` argument
+
+All render props will receive the `appContext` argument. This context is generally used to handle app-specific information, as opposed to Mephisto-specific information.
+
+**Arguments:**
+
+**`taskContext`**: 
+
+**`appSettings`**: 
+
+**`setAppSettings`**: 
+
+**`onTaskComplete`**: 
+

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -17,7 +17,9 @@ npm link
 cd <app folder>
 npm link bootstrap-chat
 
-# If you're getting an invalid hooks error (https://reactjs.org/warnings/invalid-hook-call-warning.html), you can also do the following to ensure that both the app and bootstrap-chat are using the same version of React:
+# If you're getting an invalid hooks error (https://reactjs.org/warnings/invalid-hook-call-warning.html),
+# you can also do the following to ensure that both the app
+# and bootstrap-chat are using the same version of React:
 # 
 # cd packages/bootstrap-chat
 # npm link ../<app folder>/node_modules/react
@@ -25,3 +27,7 @@ npm link bootstrap-chat
 ```
 
 ## Usage
+
+This package contains both individual components for building a chat-app, as well as precomposed components that can get you going quickly.
+
+We generally recommend starting with the precomposed components, unless you have an advanced use-case.

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -149,7 +149,7 @@ By the default, the `appContext` object contains the following properties:
 
 **`taskContext`**: An object that reflects the current context of the app by merging in the `task_data` property of each subsequent chat message received. As expected, later messages will overwrite the context set by previous messages if a conflict in a property of `task_data` occurs.
 
-**`appSettings`**: You can use this to have access to various app-wide settings. For example, the default implementation uses it for volume control. `console.log(appContext.appSettings.volume)`
+**`appSettings`**: You can use this to have access to various app-wide settings. For example, the default implementation uses it for volume control - that is the sole property. `console.log(appContext.appSettings.volume)`
 
 **`setAppSettings`**: This method can be used to set app-wide settings which the rest of the app will then have access to through `appContext.appSettings`. For example, `setAppSettings({ volume: 1 }) `. `setAppSettings` will automatically merge in the passed in object with the existing `appSettings` object, so you do not have to do this merge yourself. That is, you can only pass the values you'd like to change as the argument, and the other previous values will be kept intact.
 

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -1,0 +1,27 @@
+# bootstrap-chat
+
+A Bootstrap-based set of UI components for facilitating chat-based tasks for Mephisto.
+
+## Installation
+
+```bash
+npm install --save bootstrap-chat mephisto-task
+```
+
+Install from local folder (e.g. for local development):
+
+```bash
+cd packages/bootstrap-chat
+npm link
+
+cd <app folder>
+npm link bootstrap-chat
+
+# If you're getting an invalid hooks error (https://reactjs.org/warnings/invalid-hook-call-warning.html), you can also do the following to ensure that both the app and bootstrap-chat are using the same version of React:
+# 
+# cd packages/bootstrap-chat
+# npm link ../<app folder>/node_modules/react
+
+```
+
+## Usage (`useMephistoTask`)

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -28,6 +28,91 @@ npm link bootstrap-chat
 
 ## Usage
 
-This package contains both individual components for building a chat-app, as well as precomposed components that can get you going quickly.
+This package contains both individual components for building a chat UI, as well as precomposed components that can get you going quickly.
 
-We generally recommend starting with the precomposed components, unless you have an advanced use-case.
+We generally recommend starting with the precomposed components, unless you have an advanced use-case. We provide escape-hatches for easy customization of common behaviors.
+
+### Example 1: The pre-composed ChatApp component
+
+The most simplest way to get going with 0 customizations is just the following:
+
+```jsx
+import { ChatApp } from "bootstrap-chat";
+
+ReactDOM.render(<ChatApp />, document.getElementById("root"));
+```
+
+### Example 2: Modifying ChatApp
+
+From here, you can easily opt into adding custom components and behaviors via render prop overrides.
+
+Let's consider a contrived example where we would like every message to appear suffixed with 5 exclamation marks.
+
+```jsx
+
+import { ChatApp, ChatMessage } from "bootstrap-chat";
+
+function MyChatApp() {
+    return (
+        <ChatApp
+            renderMessage={({ message }) => <ChatMessage message={message.text + "!!!!!"} />}
+        />);
+}
+
+```
+
+Here we replace the rendering of the chat message with the `renderMessage` prop. However, note that we also import the `<ChatMessage />` component and use that as part of the rendering. We don't have to do this portion, and could easily just create our own isolated implementation. However this example illustrates how we can opt out of default behavior, while still having available to us primitives and core components that can get us back some of that default functionality at our discretion.
+
+
+## `<ChatApp />` documentation
+
+`ChatApp` exposes the following props: 
+
+All render props will receive as part of their args both `mephistoContext` and `appContext`, which will be described below.
+
+
+### `renderMessage({ message, idx, mephistoContext, appContext })`
+A render prop that if implemented, overides the way a chat message is rendered.
+
+
+```js
+{
+    message: {
+        id,
+        text,
+        task_data
+    },
+    idx, // the 0-indexed position of this message with respect to all messages received
+
+    mephistoContext, // the current MephistoContext
+    appContext // the current AppContext
+}
+```
+
+### `renderSidePane({ mephistoContext, appContext })`
+A render prop that if implemented, overrides the way the side pane is rendered.
+
+### `renderTextResponse({ onMessageSend, inputMode, active, mephistoContext, appContext })`
+A render prop that if implemented, overrides the way the response text box is rendered. The default implementation of `ChatApp` is rendering a `<TextResponse />` component here.
+
+Note: If `renderResponse()` is also implemented, this render prop will be ignored.
+
+This render prop is for cases where you'd like to minimally alter the response text box. For larger customizations, we recommend implementing `renderReponse()` instead.
+
+```js
+{
+    onMessageSend,
+    inputMode,
+    active, // helper boolean, essentially is true when inputMode is INPUT_MODE.READY_FOR_INPUT
+}
+```
+
+### `renderResponse({ onMessageSend, inputMode, mephistoContext, appContext })`
+A render prop that if implemented, overrides the way the entire response panel is rendered. You will be responsible for handling all aspects of the panel in this case.
+
+Note: If this render prop is implemented, `renderTextResponse()` will be ignored.
+
+
+### `onMessagesChange(messages)`
+
+A callback that will get called any time a new message is received. The callback will receive as an argument all messages received thus far.

--- a/packages/bootstrap-chat/src/composed/BaseFrontend.jsx
+++ b/packages/bootstrap-chat/src/composed/BaseFrontend.jsx
@@ -142,7 +142,6 @@ function ResponsePane({ onMessageSend, inputMode, renderTextResponse }) {
         );
       }
       break;
-    case INPUT_MODE.IDLE:
     default:
       response_pane = null;
       break;

--- a/packages/bootstrap-chat/src/composed/ChatApp.jsx
+++ b/packages/bootstrap-chat/src/composed/ChatApp.jsx
@@ -24,7 +24,6 @@ const INPUT_MODE = {
   INACTIVE: "inactive",
   DONE: "done",
   READY_FOR_INPUT: "ready_for_input",
-  IDLE: "idle",
 };
 
 function ChatApp({


### PR DESCRIPTION
Finished up the `bootstrap-chat` docs.

Have one minor note below regarding the `IDLE` state for `INPUT_MODE` which doesn't seem to be ever set anywhere. Should we remove? Or does this represent a future feature we will be adding regarding idleness/timeouts?