### PR TITLE
Add `mephisto review --json` flag. Default reading in is csv

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -31,8 +31,9 @@ def web():
 @click.option("--stdout", "output_method", flag_value="stdout")
 @click.option("--file", "output_method", flag_value="file", default=True)
 @click.option("--csv-headers/--no-csv-headers", default=False)
+@click.option("--json/--csv", default=False)
 @click.option("-d", "--debug", type=(bool), default=False)
-def review(review_app_dir, port, output, output_method, csv_headers, debug):
+def review(review_app_dir, port, output, output_method, csv_headers, json, debug):
     """Launch a local review UI server. Reads in rows froms stdin and outputs to either a file or stdout."""
     from mephisto.client.review_server import run
 
@@ -41,7 +42,7 @@ def review(review_app_dir, port, output, output_method, csv_headers, debug):
             "You must specify an output file via --output=<filename>, unless the --stdout flag is set."
         )
 
-    run(review_app_dir, port, output, csv_headers, debug)
+    run(review_app_dir, port, output, csv_headers, json, debug)
 
 
 @cli.command("check")

--- a/mephisto/client/review_server.py
+++ b/mephisto/client/review_server.py
@@ -35,7 +35,7 @@ def run(build_dir, port, output, csv_headers, json=False, debug=False):
         static_folder=build_dir + "/static",
     )
 
-    def read_json(f):
+    def json_reader(f):
         import json
 
         for jsonline in f:
@@ -45,7 +45,7 @@ def run(build_dir, port, output, csv_headers, json=False, debug=False):
         global ready_for_next, current_data, finished, counter
 
         if json:
-            data_source = read_json(iter(sys.stdin.readline, ""))
+            data_source = json_reader(iter(sys.stdin.readline, ""))
         else:
             data_source = csv.reader(iter(sys.stdin.readline, ""))
 

--- a/mephisto/client/review_server.py
+++ b/mephisto/client/review_server.py
@@ -14,7 +14,7 @@ import time
 import threading
 
 
-def run(build_dir, port, output, csv_headers, debug=False):
+def run(build_dir, port, output, csv_headers, json=False, debug=False):
     global index_file, app
     global ready_for_next, current_data, finished, index_file
     global counter
@@ -35,9 +35,19 @@ def run(build_dir, port, output, csv_headers, debug=False):
         static_folder=build_dir + "/static",
     )
 
+    def read_json(f):
+        import json
+
+        for jsonline in f:
+            yield json.loads(jsonline)
+
     def consume_data():
         global ready_for_next, current_data, finished, counter
-        data_source = csv.reader(iter(sys.stdin.readline, ""))
+
+        if json:
+            data_source = read_json(iter(sys.stdin.readline, ""))
+        else:
+            data_source = csv.reader(iter(sys.stdin.readline, ""))
 
         if csv_headers:
             next(data_source)


### PR DESCRIPTION
Adding a `--json` flag will parse the input stream as a list of newline separated json objects. The default option is `--csv`.

---

Sample usage:

**data.json**
```
{"value": 1}
{"value": 2}
{"value": 3}
{"value": 4}
```

```cat data.json | mephisto review my-review-ui/ --json --stdout```