### PR TITLE
Swapping order of operator abstraction initialization

### DIFF
--- a/mephisto/core/operator.py
+++ b/mephisto/core/operator.py
@@ -190,18 +190,17 @@ class Operator:
         task_run = TaskRun(self.db, new_run_id)
 
         try:
-            # If anything fails after here, we have to cleanup the architect
+            # Register the blueprint with args to the task run,
+            # ensure cached
+            blueprint = BlueprintClass(task_run, run_config, shared_state)
+            task_run.get_blueprint(args=run_config, shared_state=shared_state)
 
+            # If anything fails after here, we have to cleanup the architect
             build_dir = os.path.join(task_run.get_run_dir(), "build")
             os.makedirs(build_dir, exist_ok=True)
             architect = ArchitectClass(
                 self.db, run_config, shared_state, task_run, build_dir
             )
-
-            # Register the blueprint with args to the task run,
-            # ensure cached
-            blueprint = BlueprintClass(task_run, run_config, shared_state)
-            task_run.get_blueprint(args=run_config, shared_state=shared_state)
 
             # Setup and deploy the server
             built_dir = architect.prepare()


### PR DESCRIPTION
As other elements of setup (the Architect primarly) may rely on options set by a blueprint, it's important that we initialize the blueprint before the other abstractions.

This was surfaced in a strange internal case where we couldn't launch a server without the task details, but realistically this ordering should be more correct overall.