### PR TITLE
Cleanup script for MTurk

### DIFF
--- a/mephisto/scripts/mturk/cleanup.py
+++ b/mephisto/scripts/mturk/cleanup.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utility script that finds, expires, and disposes HITs that may not
+have been taking down during a run that exited improperly.
+"""
+from mephisto.providers.mturk.mturk_utils import (
+    get_outstanding_hits,
+    expire_and_dispose_hits,
+)
+from mephisto.core.local_database import LocalMephistoDB
+
+db = LocalMephistoDB()
+
+all_requesters = db.find_requesters(provider_type="mturk")
+all_requesters += db.find_requesters(provider_type="mturk_sandbox")
+
+print("You have the following requesters available for mturk and mturk sandbox:\n>> ")
+r_names = [r.requester_name for r in all_requesters]
+print(sorted(r_names))
+
+use_name = input("Enter the name of the requester to clear HITs from: ")
+while use_name not in r_names:
+    use_name = input(
+        f"Sorry, {use_name} is not in the requester list. "
+        f"The following are valid: {r_names}\n"
+        f"Select one:\n>> "
+    )
+
+requester = db.find_requesters(requester_name=use_name)[0]
+client = requester._get_client(requester._requester_name)
+
+outstanding_hit_types = get_outstanding_hits(client)
+num_hit_types = len(outstanding_hit_types.keys())
+sum_hits = sum([len(outstanding_hit_types[x]) for x in outstanding_hit_types.keys()])
+
+all_hits = []
+for hit_type in outstanding_hit_types.keys():
+    all_hits += outstanding_hit_types[hit_type]
+
+broken_hits = [
+    h
+    for h in all_hits
+    if h["NumberOfAssignmentsCompleted"] == 0 and h["HITStatus"] != "Reviewable"
+]
+
+print(
+    f"The requester {use_name} has {num_hit_types} outstanding HIT "
+    f"types, with {len(broken_hits)} suspected active or broken HITs.\n"
+    "This may include tasks that are still in-flight, but also "
+    "tasks that have already expired but have not been disposed of yet."
+)
+
+run_type = input("Would you like to cleanup by (t)itle, or just clean up (a)ll?\n>> ")
+use_hits = None
+
+while use_hits is None:
+    if run_type.lower().startswith("t"):
+        use_hits = []
+        for hit_type in outstanding_hit_types.keys():
+            cur_title = outstanding_hit_types[hit_type][0]["Title"]
+            print(f"HIT TITLE: {cur_title}")
+            print(f"HIT COUNT: {len(outstanding_hit_types[hit_type])}")
+            should_clear = input(
+                "Should we cleanup this hit type? (y)es for yes, anything else for no: "
+                "\n>> "
+            )
+            if should_clear.lower().startswith("y"):
+                use_hits += outstanding_hit_types[hit_type]
+    elif run_type.lower().startswith("a"):
+        use_hits = all_hits
+    else:
+        run_type = input("Options are (t)itle, or (a)ll:\n>> ")
+
+print(f"Disposing {len(use_hits)} HITs.")
+remaining_hits = expire_and_dispose_hits(client, use_hits)
+
+if len(remaining_hits) == 0:
+    print("Disposed!")
+else:
+    print(
+        f"After disposing, {len(remaining_hits)} could not be disposed.\n"
+        f"These may not have been reviewed yet, or are being actively worked on.\n"
+        "They have been expired though, so please try to dispose later."
+    )

--- a/mephisto/scripts/mturk/cleanup.py
+++ b/mephisto/scripts/mturk/cleanup.py
@@ -19,11 +19,11 @@ db = LocalMephistoDB()
 all_requesters = db.find_requesters(provider_type="mturk")
 all_requesters += db.find_requesters(provider_type="mturk_sandbox")
 
-print("You have the following requesters available for mturk and mturk sandbox:\n>> ")
+print("You have the following requesters available for mturk and mturk sandbox:")
 r_names = [r.requester_name for r in all_requesters]
 print(sorted(r_names))
 
-use_name = input("Enter the name of the requester to clear HITs from: ")
+use_name = input("Enter the name of the requester to clear HITs from:\n>> ")
 while use_name not in r_names:
     use_name = input(
         f"Sorry, {use_name} is not in the requester list. "


### PR DESCRIPTION
Adds a simple script for being able to clean up HITs from MTurk by checking the available requesters, being able to see what HITs are available to remove, and then removing them.

# Testing

```
>>>> python cleanup.py
You have the following requesters available for mturk and mturk sandbox:
['XXXXXXXXX', 'XXXXXXXXX_sandbox']
Enter the name of the requester to clear HITs from: 
>> XXXXXXXXX
The requester XXXXXXXXX has 6 outstanding HIT types, with 0 suspected active or broken HITs.
This may include tasks that are still in-flight, but also tasks that have already expired but have not been disposed of yet.
Would you like to cleanup by (t)itle, or just clean up (a)ll? 
>> t
HIT TITLE: ----------------------removed--------------
HIT COUNT: 114
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
HIT TITLE: ----------------------removed--------------
HIT COUNT: 118
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
HIT TITLE: ----------------------removed--------------
HIT COUNT: 110
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
HIT TITLE: ----------------------removed--------------
HIT COUNT: 30
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
HIT TITLE: ----------------------removed--------------
HIT COUNT: 104
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
HIT TITLE: Which Conversational Partner is Better?
HIT COUNT: 40
Should we cleanup this hit type? (y)es for yes, anything else for no: 
>> y
Disposing 516 HITs.
Disposed!



>>>> python cleanup.py
You have the following requesters available for mturk and mturk sandbox:
['XXXXXXX', 'XXXXXXX_sandbox']
Enter the name of the requester to clear HITs from:
>> XXXXXXX_sandbox
The requester XXXXXXX_sandbox has 13 outstanding HIT types, with 209 suspected active or broken HITs.
This may include tasks that are still in-flight, but also tasks that have already expired but have not been disposed of yet.
Would you like to cleanup by (t)itle, or just clean up (a)ll?
>> a
Disposing 215 HITs.
After disposing, 209 could not be disposed.
These may not have been reviewed yet, or are being actively worked on.
They have been expired though, so please try to dispose later.
```