### PR TITLE
Small ParlAI blueprint improvements

### DIFF
--- a/examples/parlai_chat_task_demo/README.md
+++ b/examples/parlai_chat_task_demo/README.md
@@ -72,6 +72,14 @@ ParlAI chat tasks have a number of arguments set up, primarily via Hydra but als
 ### Task description content
 For simple tasks, you can provide an HTML task description (via the `task_description_file` argument above) containing a preview and description of what the worker is going to be doing in their task.
 
+### Simple custom frontend bundles
+Using the `mephisto.blueprint.custom_source_dir` option, it's possible to specify a just directory containing any frontend code you are using for a task, so long as you've built the app contained using the `bootstrap-chat` package. In this case, Mephisto will handle the process of generating the bundle whenever it detects changed files, meaning you can not have to think about things.
+
+The automated build process looks for three special paths:
+- `[custom_source_dir]/main.js` : this should contain your main application code, and is the only required file in the custom source directory. It should probably end with `ReactDOM.render(<MainApp />, document.getElementById("app"));`
+- `[custom_source_dir]/components/`: This is a special directory that can contain additional elements that your `main.js` file references (using relative paths)
+- `[custom_source_dir]/package.json`: If you want additional dependencies, you can specify them in a `package.json` file. We suggest copying the one present at `mephisto/abstractions/blueprints/parlai_chat/webapp/package.json`.
+
 ### Custom frontend bundles
 Custom frontend bundles can be provided that override the view of how the ParlAI chat looks, and the kinds of inputs you can pass. Much of the ParlAI-specific interfaceing logic is encapsulated in the `webapp/src/app.jsx` file. The actual view logic is in `webapp/src/components/core_components.jsx`. Here we define the `BaseFrontend` component, which is the root of the core task. 
 

--- a/examples/parlai_chat_task_demo/README.md
+++ b/examples/parlai_chat_task_demo/README.md
@@ -73,7 +73,7 @@ ParlAI chat tasks have a number of arguments set up, primarily via Hydra but als
 For simple tasks, you can provide an HTML task description (via the `task_description_file` argument above) containing a preview and description of what the worker is going to be doing in their task.
 
 ### Simple custom frontend bundles
-Using the `mephisto.blueprint.custom_source_dir` option, it's possible to specify a just directory containing any frontend code you are using for a task, so long as you've built the app contained using the `bootstrap-chat` package. In this case, Mephisto will handle the process of generating the bundle whenever it detects changed files, meaning you can not have to think about things.
+Using the `mephisto.blueprint.custom_source_dir` option, it's possible to specify just a directory containing any frontend code you are using for a task, so long as you've built the app contained using the `bootstrap-chat` package. In this case, Mephisto will handle the process of generating the bundle whenever it detects changed files, meaning that you don't have to think about that part of the process.
 
 The automated build process looks for three special paths:
 - `[custom_source_dir]/main.js` : this should contain your main application code, and is the only required file in the custom source directory. It should probably end with `ReactDOM.render(<MainApp />, document.getElementById("app"));`

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -188,8 +188,10 @@ class ParlAIChatTaskRunner(TaskRunner):
         """Shutdown the world"""
         onboarding_id = agent.get_agent_id()
         world_id = self.get_world_id("onboard", onboarding_id)
-        self.id_to_worlds[world_id].shutdown()
-        del self.id_to_worlds[world_id]
+        # Only shut down world if it was actually started
+        if world_id in self.id_to_worlds:
+            self.id_to_worlds[world_id].shutdown()
+            del self.id_to_worlds[world_id]
 
     def run_assignment(self, assignment: "Assignment", agents: List["Agent"]) -> None:
         """


### PR DESCRIPTION
Adds two improvements to the `ParlAIChatBlueprint`:

1. For builds using the simple directory build process (relying on `bootstrap-chat`), these directories can now contain a `src/` directory that `main.js` refers to for subcomponents.
2. Now that `shared_state` is standard, we can pass the actual world module from the run script in this to the blueprint rather than needing to pass the path, which makes this code compatible with compiled/bundled/packaged python scripts like we use internally.

These are used in the `TurnAnnotationsBlueprint` being created for ParlAI.