### PR TITLE
Resolve double message regression

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -6,6 +6,7 @@
 
 import os
 import threading
+from uuid import uuid4
 
 from abc import ABC, abstractmethod, abstractstaticmethod
 from mephisto.abstractions.blueprint import AgentState
@@ -226,6 +227,8 @@ class Agent(ABC):
         Pass the observed information to the AgentState, then
         queue the information to be pushed to the user
         """
+        if packet.data.get("message_id") is None:
+            packet.data["message_id"] = str(uuid4())
         sending_packet = packet.copy()
         sending_packet.receiver_id = self.db_id
         self.state.update_data(sending_packet)

--- a/packages/mephisto-task/src/socket_handler.jsx
+++ b/packages/mephisto-task/src/socket_handler.jsx
@@ -120,6 +120,7 @@ function useMephistoSocket({
     setting_socket: false, // Flag for socket setup being underway
     heartbeats_without_response: 0, // HBs to the router without a pong back
     last_mephisto_ping: Date.now(),
+    used_message_ids: [],
   };
 
   const [state, setState] = React.useReducer(
@@ -333,6 +334,15 @@ function useMephistoSocket({
 
   function parseSocketMessage(packet) {
     if (packet.packet_type == PACKET_TYPE_AGENT_ACTION) {
+      let used_message_ids = state.used_message_ids;
+
+      if (used_message_ids.includes(packet.data.message_id)) {
+        // Skip this message
+        return;
+      } else {
+        let new_message_ids = [...used_message_ids, packet.data.message_id];
+        setState({ used_message_ids: new_message_ids });
+      }
       onMessageReceived(packet.data);
     } else if (packet.packet_type == PACKET_TYPE_UPDATE_STATE) {
       onStateUpdate(packet.data); // packet.data looks like - {state: {}, status: "<>"}


### PR DESCRIPTION
Resolves a regression of #107 that was re-introduced in the swap over to `mephisto-task`. Ensures all messages have a message id, and then filters out duplicates on the `mephisto-task` level. I'm still unsure why the double message happens in the first place (likely the router's first connection, or a lack of ack or something), but this will prevent it moving forward.