### PR TITLE
Allow the ability to override the return values of useMephistoReviewHook for mock purposes

### DIFF
--- a/packages/mephisto-review-hook/src/index.js
+++ b/packages/mephisto-review-hook/src/index.js
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from "react";
 
-function useMephistoReview() {
+function useMephistoReview({ useMock, mock }) {
+  if (mock !== undefined && (useMock === undefined || useMock === true)) {
+    return mock;
+  }
+
   const [data, setData] = useState(null);
   const [counter, setCounter] = useState(0);
   const [error, setError] = useState(null);


### PR DESCRIPTION
Providing a `mock` argument allows you to override the hook for debugging/testing/prototyping purposes.

```jsx
 const { data, isFinished, isLoading, submit, error } = useMephistoReview({
    mock: {
      data: {
        file: "https://example.org/video.mp4",
        info: mockData,
      },
      isFinished: false,
      isLoading: false,
      submit: () => {},
      error: null
    }
  });
```
Also adds a `useMock` argument to quickly toggle the provided mock object on and off, without having to delete or comment out the mock:

```jsx
 const { data, isFinished, isLoading, submit, error } = useMephistoReview({
    useMock: false,
    mock: {
      // ...same as above
    }
  });
```