### PR TITLE
Bringing back argument parsing functionality.

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -83,7 +83,7 @@ def register_provider(args):
 
     from mephisto.abstractions.databases.local_database import LocalMephistoDB
     from mephisto.operations.registry import get_crowd_provider_from_type
-    from mephisto.core.argparse_parser import parse_arg_dict, get_extra_argument_dicts
+    from mephisto.operations.utils import parse_arg_dict, get_extra_argument_dicts
 
     provider_type, requester_args = args[0], args[1:]
     args_dict = dict(arg.split("=", 1) for arg in requester_args)
@@ -138,7 +138,7 @@ def get_help_arguments(args):
         get_valid_provider_types,
         get_valid_architect_types,
     )
-    from mephisto.core.argparse_parser import get_extra_argument_dicts
+    from mephisto.operations.utils import get_extra_argument_dicts
 
     VALID_ABSTRACTIONS = ["blueprint", "architect", "requester", "provider", "task"]
 

--- a/mephisto/operations/utils.py
+++ b/mephisto/operations/utils.py
@@ -18,7 +18,8 @@ from mephisto.operations.config_handler import (
     DATA_STORAGE_KEY,
     DEFAULT_CONFIG_FILE,
 )
-
+from omegaconf import OmegaConf, MISSING, DictConfig
+from dataclasses import fields, Field
 from typing import Optional, Dict, Any, List, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -193,3 +194,51 @@ def find_or_create_qualification(db, qualification_name) -> None:
         db.make_qualification(qualification_name)
     except EntryAlreadyExistsException:
         pass  # qualification already exists
+
+
+def get_dict_from_field(in_field: Field) -> Dict[str, Any]:
+    """
+    Extract all of the arguments from an argument group
+    and return a dict mapping from argument dest to argument dict
+    """
+    found_type = "str"
+    try:
+        found_type = in_field.type.__name__
+    except AttributeError:
+        found_type = "unknown"
+    return {
+        "dest": in_field.name,
+        "type": found_type,
+        "default": in_field.default,
+        "help": in_field.metadata.get("help"),
+        "choices": in_field.metadata.get("choices"),
+        "required": in_field.metadata.get("required", False),
+    }
+
+
+def get_extra_argument_dicts(customizable_class: Any) -> List[Dict[str, Any]]:
+    """
+    Produce the argument dicts for the given customizable class
+    (Blueprint, Architect, etc)
+    """
+    dict_fields = fields(customizable_class.ArgsClass)
+    usable_fields = []
+    group_field = None
+    for f in dict_fields:
+        if not f.name.startswith("_"):
+            usable_fields.append(f)
+        elif f.name == "_group":
+            group_field = f
+    parsed_fields = [get_dict_from_field(f) for f in usable_fields]
+    help_text = ""
+    if group_field is not None:
+        help_text = group_field.metadata.get("help", "")
+    return [{"desc": help_text, "args": {f["dest"]: f for f in parsed_fields}}]
+
+
+def parse_arg_dict(customizable_class: Any, args: Dict[str, Any]) -> DictConfig:
+    """
+    Get the ArgsClass for a class, then parse the given args using
+    it. Return the DictConfig of the finalized namespace.
+    """
+    return OmegaConf.structured(customizable_class.ArgsClass(**args))


### PR DESCRIPTION
Some merging madness dropped these utilities out of argparse parser and I needed to bring them back. They replace the functionality that argparse parser had for determining relevant arguments of Mephisto abstractions, but now implemented using the data classes.