### PR TITLE
Small qualification changes.

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ProfileNotFound
 from botocore.config import Config
 from omegaconf import DictConfig
 
+from mephisto.data_model.qualification import QUAL_EXISTS, QUAL_NOT_EXIST
 from mephisto.operations.logger_core import get_logger
 from mephisto.operations.config_handler import get_config_arg
 
@@ -334,6 +335,7 @@ def convert_mephisto_qualifications(
             converted["IntegerValue"] is None
             and converted["IntegerValues"] is None
             and converted["LocaleValues"] is None
+            and converted["Comparator"] not in [QUAL_EXISTS, QUAL_NOT_EXIST]
         ):
             value = qualification["value"]
             if isinstance(value, list):

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -489,7 +489,7 @@ class Supervisor:
         ), "Should only be registering from onboarding if onboarding is required and set"
         worker_passed = blueprint.validate_onboarding(worker, onboarding_agent)
         worker.grant_qualification(
-            blueprint.onboarding_qualification_name, int(worker_passed), skip_crowd=True
+            blueprint.onboarding_qualification_name, int(worker_passed)
         )
         if not worker_passed:
             worker.grant_qualification(


### PR DESCRIPTION
Qualifications that were of the types `[QUAL_EXISTS, QUAL_NOT_EXIST]` should not have a value associated with them, and the existing code was expecting a value to be there. Now we only search for a default value if the original search conditions are met (no provided special value) and it's not a qualification of these types.

We also now push the positive granted onboarding qualifications to crowdproviders, this way it's possible for people to launch a task that is only available to people who have completed a specific onboarding for a different task.