### PR TITLE
Updating `mephisto web` to load again.

### DIFF
--- a/mephisto/client/api.py
+++ b/mephisto/client/api.py
@@ -11,7 +11,7 @@ from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.data_model.task_run import TaskRun
 from mephisto.data_model.unit import Unit
 from mephisto.data_model.assignment import Assignment
-from mephisto.core.argparse_parser import get_extra_argument_dicts, parse_arg_dict
+from mephisto.operations.utils import parse_arg_dict, get_extra_argument_dicts
 from mephisto.operations.registry import (
     get_blueprint_from_type,
     get_crowd_provider_from_type,
@@ -24,10 +24,6 @@ from mephisto.data_model.task_config import TaskConfig
 import sys, traceback, os
 
 api = Blueprint("api", __name__)
-
-
-def get_extra_argument_dicts(*args):
-    raise NotImplementedError("This hasn't been updated following the hydra migration")
 
 
 @api.route("/requesters")

--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -19,7 +19,7 @@ def cli():
 @cli.command("web")
 def web():
     """Launch a local webserver with the Mephisto UI"""
-    from mephisto.client.server import app
+    from mephisto.client.full.server import app
 
     app.run(debug=False)
 


### PR DESCRIPTION
Part of the hydra and path migration broke the `mephisto web` cli method for launching the webserver, and some of the server components themselves. This fix at least gets the server running again, though more (very) minor work may need to be done to get it up to speed.