### PR TITLE
ParlAIBlueprint - Adding initializationData to make_world

### DIFF
--- a/examples/parlai_chat_task_demo/README.md
+++ b/examples/parlai_chat_task_demo/README.md
@@ -46,7 +46,7 @@ Task worlds implement the following methods:
 - `prep_save_data` (optional) - The `prep_save_data` method is used to add any additional values to the saved conversation data. This data will be accessible later in review.
 
 The world file also needs to implement the following methods:
-- `make_world` - This method should, given world options and a list of agents, return an initialized task world.
+- `make_world` - This method should, given world options and a list of agents, return an initialized task world. It may optionally accept an `initialization_data` keyword argument, which will be provided with the `Assignment`'s `InitializationData` if present.
 - `get_world_params` - This method is used to configure details about your ParlAI world for Mephisto to understand how to initialize your world. In this case the only required configuration parameter is `agent_count`, which specifies the number of human agents Mephisto will provide to your `make_world` function.
 - `make_onboarding_world` (optional) - The `make_onboarding_world` method is called to initialize a world on the very first time a specific worker works on your task. This will only ever be called with a single agent, and it should return the initialized onboarding world.
 - `validate_onboarding` (optional) - When an onboarding world completes, this method is called on the full data collected in the onboarding task. If it returns `True` the worker is allowed to move on to the full task. If this method returns `False`, then the worker is blocked from working on this task in the future.

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -207,7 +207,14 @@ class ParlAIChatTaskRunner(TaskRunner):
             assert agent is not None, "task was not fully assigned"
         opt: Dict[str, Any] = self.shared_state.world_opt
         parlai_agents = [MephistoAgentWrapper(a) for a in agents]
-        world = self.parlai_world_module.make_world(opt, parlai_agents)  # type: ignore
+        try:
+            world = self.parlai_world_module.make_world(
+                opt, parlai_agents, initialization_data=assignment.get_assignment_data()
+            )  # type: ignore
+        except TypeError:
+            # make_world doesn't ask for initialization_data
+            world = self.parlai_world_module.make_world(opt, parlai_agents)  # type: ignore
+
         world_id = self.get_world_id("assignment", assignment.db_id)
         self.id_to_worlds[world_id] = world
         while not world.episode_done() and assignment.db_id in self.running_assignments:


### PR DESCRIPTION
# Overview
Right now it's somewhat nebulous how a ParlAI task world would be able to access the `InitializationData` that is provided for the assignment that world is being built for. As it's likely that this information is useful to the world, this PR adds the ability to pass the argument to the `make_world` function.

Not all world modules will be expecting the new `initialization_data` argument, so it's wrapped in a `try-catch`.

# Testing
Ran a quick demo world that was able to receive this argument, seemed to work fine both with and without the extra argument.