### PR TITLE
Some improvements for ParlAI chat blueprint and bootstrap-chat

### DIFF
--- a/examples/parlai_chat_task_demo/README.md
+++ b/examples/parlai_chat_task_demo/README.md
@@ -61,11 +61,12 @@ ParlAI chat tasks have a number of arguments set up, primarily via Hydra but als
 - `mephisto.task.task_name` - This task name will be used to consolidate your data across runs. Generally we suggest using `descriptive-string-pilot-#` when piloting and `descriptive-task-string` for your main collection. More details on this are in the (TODO) Mephisto argument instructions.
 - `mephisto.blueprint.onboarding_qualification` (optional) - The qualification to grant to a worker when they have completed onboarding, such that they no longer need to do onboarding in future tasks where you specify the same qualification name. Specifying this qualification will make mephisto attempt to run onboarding for new workers, and ommitting it will skip onboarding for all workers.
 #### ParlAI-specific arguments
-- `mephisto.blueprint.world_file` - Path to the python file containing your worlds. Detailed requirements of this file in the "The worlds file" section.
+- `mephisto.blueprint.world_file` - Optional path to the python file containing your worlds. Detailed requirements of this file in the "The worlds file" section. If you already know what world module you intend to use for a specific run, it's generally a better practice to import that module directly in your run script, and then pass it as `SharedParlAITaskState.world_module`.
 - `mephisto.blueprint.task_description_file` - Path to an HTML file containing the task preview and basic instructions for your task. If you use a custom built frontend, you can omit this argument and directly edit the `TaskPreviewView` in `app.jsx` instead. 
 - `mephisto.blueprint.num_conversations` - Number of conversations to have. This currently leads to `num_conversations` * `agent_count` tasks being launched for workers to do. Incomplete tasks are _currently_ not relaunched.
 - `mephisto.blueprint.custom_source_dir` - Path to a folder containing, at the very least, a `main.js` for a custom ParlAI frontend view. Can also contain an updated `package.json` if that file imports anything outside of the defaults used in `server/blueprints/parlai_chat/webapp/package.json`. Providing this flag will make Mephisto build that frontend in a `_generated` directory, and refer to that build when launching your task. Mephisto will only rebuild when the source files in the provided `custom_source_dir` are updated.
 - `mephisto.blueprint.custom_source_bundle` - Path to a custom built source bundle to deploy to the frontend instead of the standard ParlAI view. For this task we specify a build in the `webapp` directory, but you'll need to run `npm install; npm run dev` in that directory the first time you use a bundle (and whenever you make changes to the `src` that you want to be picked up)
+- `SharedParlAITaskState.world_module` - The world file module that you want to provide for this run.
 - `SharedParlAITaskState.world_opt` - The world option will be passed to the `make_world` function as the first argument. Passing contents through `world_opt` is the preferred way to share important state between different calls to `make_world`, as this dict will be shared amongst all calls.
 - `SharedParlAITaskState.onboarding_world_opt` - The world option will be passed to the `make_onboarding_world` function as the first argument. 
 
@@ -77,6 +78,7 @@ Using the `mephisto.blueprint.custom_source_dir` option, it's possible to specif
 
 The automated build process looks for three special paths:
 - `[custom_source_dir]/main.js` : this should contain your main application code, and is the only required file in the custom source directory. It should probably end with `ReactDOM.render(<MainApp />, document.getElementById("app"));`
+- `[custom_source_dir]/style.css` : this can contain any style files that alter the way that your chat application looks. You can later reference this file by including `import "./style.css";` in your `main.js` file.
 - `[custom_source_dir]/components/`: This is a special directory that can contain additional elements that your `main.js` file references (using relative paths)
 - `[custom_source_dir]/package.json`: If you want additional dependencies, you can specify them in a `package.json` file. We suggest copying the one present at `mephisto/abstractions/blueprints/parlai_chat/webapp/package.json`.
 

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_builder.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_builder.py
@@ -65,8 +65,11 @@ class ParlAIChatTaskBuilder(TaskBuilder):
 
         Check dates to only go through this build process when files have changes
         """
-        # TODO add custom component directories, and recursively check those
-        TARGET_BUILD_FILES = {"main.js": "src/main.js", "package.json": "package.json"}
+        TARGET_BUILD_FILES = {
+            "main.js": "src/main.js",
+            "package.json": "package.json",
+            "style.css": "src/style.css",
+        }
         TARGET_BUILD_FOLDERS = {"components": "src/components"}
 
         prebuild_path = os.path.join(custom_src_dir, CUSTOM_BUILD_DIRNAME)

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -128,11 +128,15 @@ class ParlAIChatTaskRunner(TaskRunner):
         self, task_run: "TaskRun", args: "DictConfig", shared_state: "SharedTaskState"
     ):
         super().__init__(task_run, args, shared_state)
-        world_file_path = os.path.expanduser(args.blueprint.world_file)
-        world_module_dir = os.path.dirname(world_file_path)
-        sys.path.append(world_module_dir)
-        world_module_name = os.path.basename(world_file_path)[:-3]
-        self.parlai_world_module = import_module(world_module_name)
+        if shared_state.world_module is None:
+            world_file_path = os.path.expanduser(args.blueprint.world_file)
+            world_module_dir = os.path.dirname(world_file_path)
+            sys.path.append(world_module_dir)
+            world_module_name = os.path.basename(world_file_path)[:-3]
+            world_module = import_module(world_module_name)
+        else:
+            world_module = shared_state.world_module
+        self.parlai_world_module = world_module
         world_params = self.parlai_world_module.get_world_params()
         self.is_concurrent = world_params["agent_count"] > 1
         self.id_to_worlds: Dict[str, Any] = {}

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -131,7 +131,7 @@ The arguments for this render prop are the same as for `renderTextResponse`, wit
 
 A callback that will get called any time a new message is received. The callback will receive as an argument all messages received thus far.
 
-### `propAppSettings`
+### `defaultAppSettings`
 
 This optional prop lets you provide some initial app settings for the `ChatApp`, setting some default values for `appContext.appSettings`.
 

--- a/packages/bootstrap-chat/README.md
+++ b/packages/bootstrap-chat/README.md
@@ -131,6 +131,10 @@ The arguments for this render prop are the same as for `renderTextResponse`, wit
 
 A callback that will get called any time a new message is received. The callback will receive as an argument all messages received thus far.
 
+### `propAppSettings`
+
+This optional prop lets you provide some initial app settings for the `ChatApp`, setting some default values for `appContext.appSettings`.
+
 ### The `mephistoContext` argument
 
 All render props will receive the `mephistoContext` argument.

--- a/packages/bootstrap-chat/src/composed/ChatApp.jsx
+++ b/packages/bootstrap-chat/src/composed/ChatApp.jsx
@@ -33,7 +33,7 @@ function ChatApp({
   renderTextResponse,
   renderResponse,
   onMessagesChange,
-  propAppSettings = emptyAppSettings,
+  defaultAppSettings = emptyAppSettings,
 }) {
   const [taskContext, updateContext] = React.useReducer(
     (oldContext, newContext) => Object.assign(oldContext, newContext),
@@ -58,7 +58,7 @@ function ChatApp({
     volume: 1,
     isReview: false,
     isCoverPage: false,
-    ...propAppSettings,
+    ...defaultAppSettings,
   };
   const [appSettings, setAppSettings] = React.useReducer(
     (prevSettings, newSettings) => Object.assign(prevSettings, newSettings),

--- a/packages/bootstrap-chat/src/composed/ChatApp.jsx
+++ b/packages/bootstrap-chat/src/composed/ChatApp.jsx
@@ -18,6 +18,7 @@ import BaseFrontend from "./BaseFrontend.jsx";
 /* ================= Application Components ================= */
 
 const AppContext = React.createContext({});
+const emptyAppSettings = {};
 
 const INPUT_MODE = {
   WAITING: "waiting",
@@ -32,6 +33,7 @@ function ChatApp({
   renderTextResponse,
   renderResponse,
   onMessagesChange,
+  propAppSettings = emptyAppSettings,
 }) {
   const [taskContext, updateContext] = React.useReducer(
     (oldContext, newContext) => Object.assign(oldContext, newContext),
@@ -52,7 +54,12 @@ function ChatApp({
     }
   }, [messages]);
 
-  const initialAppSettings = { volume: 1, isReview: false, isCoverPage: false };
+  const initialAppSettings = {
+    volume: 1,
+    isReview: false,
+    isCoverPage: false,
+    ...propAppSettings,
+  };
   const [appSettings, setAppSettings] = React.useReducer(
     (prevSettings, newSettings) => Object.assign(prevSettings, newSettings),
     initialAppSettings
@@ -62,7 +69,9 @@ function ChatApp({
   function playNotifSound() {
     let audio = new Audio("./notif.mp3");
     audio.volume = appSettings.volume;
-    audio.play();
+    if (audio.volume != 0) {
+      audio.play();
+    }
   }
 
   function trackAgentName(agentName) {


### PR DESCRIPTION
Title. Included improvements/fixes:

1. Adding a style file to the auto-build script for simple ParlAI frontend builds. This standardizes the method for updating style for an app. @mojtaba-komeili 
2. Fixes specifying the world module via `SharedParlAITaskState.world_module`. Code written with this style is more easily used internally.
3. Makes it possible to set default settings for the `ChatApp`. I wanted to at least be able to set volume, but as we may expand some of the settings in the future I thought I'd just make a way to initialize the whole thing. @pringshia is this a good way to do this? Or was there an alternate method for doing this already present somehow?

I included updates to the READMEs for all of these. 