### PR TITLE
Fixing Agent is None state sync issue

### DIFF
--- a/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
@@ -74,6 +74,7 @@ class StaticTaskRunner(TaskRunner):
         # Frontend implicitly asks for the initialization data, so we just need
         # to wait for a response
         agent_act = agent.act(timeout=self.assignment_duration_in_seconds)
+        agent.did_submit.set()
 
     def cleanup_unit(self, unit: "Unit") -> None:
         """There is currently no cleanup associated with killing an incomplete task"""

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -162,6 +162,41 @@ class MTurkDatastore:
                 """,
                 (assignment_id, unit_id, hit_id),
             )
+            conn.commit()
+
+    def clear_hit_from_unit(self, unit_id: str) -> None:
+        """
+        Clear the hit mapping that maps the given unit,
+        if such a unit-hit map exists
+        """
+        with self.table_access_condition:
+            conn = self._get_connection()
+            c = conn.cursor()
+            c.execute(
+                """
+                SELECT * from hits
+                WHERE unit_id = ?
+                """,
+                (unit_id,),
+            )
+            results = c.fetchall()
+            if len(results) == 0:
+                return
+            if len(results) > 1:
+                print(
+                    "WARNING - UNIT HAD MORE THAN ONE HIT MAPPED TO IT!",
+                    unit_id,
+                    [dict(r) for r in results],
+                )
+            result_hit_id = results[0]["hit_id"]
+            c.execute(
+                """UPDATE hits
+                SET assignment_id = ?, unit_id = ?
+                WHERE hit_id = ?
+                """,
+                (None, None, result_hit_id),
+            )
+            conn.commit()
 
     def get_hit_mapping(self, unit_id: str) -> sqlite3.Row:
         """Get the mapping between Mephisto IDs and MTurk ids"""

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -73,16 +73,14 @@ class MTurkUnit(Unit):
         """
         Return the MTurk assignment id associated with this unit
         """
-        if self.mturk_assignment_id is None:
-            self._sync_hit_mapping()
+        self._sync_hit_mapping()
         return self.mturk_assignment_id
 
     def get_mturk_hit_id(self) -> Optional[str]:
         """
         Return the MTurk hit id associated with this unit
         """
-        if self.hit_id is None:
-            self._sync_hit_mapping()
+        self._sync_hit_mapping()
         return self.hit_id
 
     def get_requester(self) -> "MTurkRequester":
@@ -99,7 +97,7 @@ class MTurkUnit(Unit):
         super().clear_assigned_agent()
         mturk_hit_id = self.get_mturk_hit_id()
         if mturk_hit_id is not None:
-            self.datastore.register_assignment_to_hit(mturk_hit_id)
+            self.datastore.clear_hit_from_unit(self.db_id)
             self._sync_hit_mapping()
 
     # Required Unit functions
@@ -220,9 +218,7 @@ class MTurkUnit(Unit):
             unassigned_hit_ids = self.datastore.get_unassigned_hit_ids(self.task_run_id)
 
             if len(unassigned_hit_ids) == 0:
-                logger.warning(
-                    f"Number of unassigned hit IDs more than 1; Potential RACE CONDITION"
-                )
+                self.set_db_status(AssignmentState.EXPIRED)
                 return delay
             hit_id = unassigned_hit_ids[0]
             expire_hit(client, hit_id)


### PR DESCRIPTION
# Overview
Due to a number of interactions between the way that MTurk units update their data, the way that we map MTurk HITs to units, and a bug in the static task runner, it was possible for Mephisto to end up in a state where there was saved data for a task and the `Unit` was marked as `COMPLETED`, but where the unit had no assigned agent. The intended situation is for HIT-Unit pairings to be unique, and for us to not remove an agent that has been marked as completed.

Thanks to @bottler and @mwillwork for logs and comments that helped me trace down what was going on here.

# Implementation
This PR addresses the problem with the following:
1. We no longer rely on cached state for the currently assigned HIT for a `Unit`
2. We explicitly clear assignments for a specific unit, rather than clearing by a HIT, preventing one unit wrongfully removing the pairing of another unit that has received the same HIT id down the line
3. We mark agents as being completed and submitted in the static `TaskRunner`, which prevents accidentally marking them as timed out.

# Testing
Running this locally on MTurk sandbox I could no longer reproduce an `Agent is None` situation (though I've only actually reproduced it once across multiple attempts beforehand). I then launched live, and completed 2000 tasks without any Agent is None, where beforehand I had a few dozen of them over 1000.