### PR TITLE
Adding a post task end hook

### DIFF
--- a/mephisto/abstractions/blueprint.py
+++ b/mephisto/abstractions/blueprint.py
@@ -77,7 +77,7 @@ class SharedTaskState:
     worker_can_do_unit: Callable[["Worker", "Unit"], bool] = field(
         default_factory=lambda: (lambda worker, unit: True)
     )
-    validate_final_unit: Callable[["Unit"], None] = field(
+    on_unit_submitted: Callable[["Unit"], None] = field(
         default_factory=lambda: (lambda unit: None)
     )
 
@@ -208,7 +208,7 @@ class TaskRunner(ABC):
 
             traceback.print_exc()
             self.cleanup_unit(unit)
-        self.shared_state.validate_final_unit(unit)
+        self.shared_state.on_unit_submitted(unit)
         del self.running_units[unit.db_id]
         return
 
@@ -247,7 +247,7 @@ class TaskRunner(ABC):
             traceback.print_exc()
             self.cleanup_assignment(assignment)
         for unit in assignment.get_units():
-            self.shared_state.validate_final_unit(unit)
+            self.shared_state.on_unit_submitted(unit)
         del self.running_assignments[assignment.db_id]
         return
 

--- a/mephisto/abstractions/blueprint.py
+++ b/mephisto/abstractions/blueprint.py
@@ -77,6 +77,9 @@ class SharedTaskState:
     worker_can_do_unit: Callable[["Worker", "Unit"], bool] = field(
         default_factory=lambda: (lambda worker, unit: True)
     )
+    validate_final_unit: Callable[["Unit"], None] = field(
+        default_factory=lambda: (lambda unit: None)
+    )
 
 
 class TaskBuilder(ABC):
@@ -205,6 +208,7 @@ class TaskRunner(ABC):
 
             traceback.print_exc()
             self.cleanup_unit(unit)
+        self.shared_state.validate_final_unit(unit)
         del self.running_units[unit.db_id]
         return
 
@@ -242,6 +246,8 @@ class TaskRunner(ABC):
 
             traceback.print_exc()
             self.cleanup_assignment(assignment)
+        for unit in assignment.get_units():
+            self.shared_state.validate_final_unit(unit)
         del self.running_assignments[assignment.db_id]
         return
 

--- a/mephisto/abstractions/blueprints/README.md
+++ b/mephisto/abstractions/blueprints/README.md
@@ -25,6 +25,12 @@ The `TaskRunner` component of a blueprint is responsible for actually stepping `
 - `cleanup_assignment`: Send any signals to the required thread for the given assignment to tell it to terminate, then clean up any resources that were set within it.
 - `get_data_for_assignment` (optional): Get the data that an assignment is going to use when run. By default, this pulls from `assignment.get_assignment_data()` however if a task has a special storage mechanism or data type, the assignment data can be fetched here. 
 
+### `SharedTaskState`
+A blueprint is able to create a container that handles any shared data that is initialized during a task or modified between tasks, or for function hooks that are used across a run. The following hooks are already provided in the base:
+- `validate_onboarding`: A function that takes in an onboarding agent's `AgentState.get_data()` call, and should always return a boolean of if that state represents a successful onboarding completion.
+- `worker_can_do_unit`: A function that takes in a `Worker` and a `Unit`, and should return a boolean representing if the worker is eligible to work on that particular unit.
+- `validate_final_unit`: A function that takes in a `Unit` after a `TaskRunner` ends, and is able to do any automatic post-processing operations on that unit thata Mephisto user may want.
+
 ## Implementations
 ### `StaticBlueprint`
 The `StaticBlueprint` class allows a replication of the interface that MTurk provides, being able to take a snippet of `HTML` and a `.csv` file and deploy tasks that fill templates of the `HTML` with values from the `.csv`.

--- a/mephisto/abstractions/blueprints/README.md
+++ b/mephisto/abstractions/blueprints/README.md
@@ -29,7 +29,7 @@ The `TaskRunner` component of a blueprint is responsible for actually stepping `
 A blueprint is able to create a container that handles any shared data that is initialized during a task or modified between tasks, or for function hooks that are used across a run. The following hooks are already provided in the base:
 - `validate_onboarding`: A function that takes in an onboarding agent's `AgentState.get_data()` call, and should always return a boolean of if that state represents a successful onboarding completion.
 - `worker_can_do_unit`: A function that takes in a `Worker` and a `Unit`, and should return a boolean representing if the worker is eligible to work on that particular unit.
-- `validate_final_unit`: A function that takes in a `Unit` after a `TaskRunner` ends, and is able to do any automatic post-processing operations on that unit thata Mephisto user may want.
+- `on_unit_submitted`: A function that takes in a `Unit` after a `TaskRunner` ends, and is able to do any automatic post-processing operations on that unit that a Mephisto user may want.
 
 ## Implementations
 ### `StaticBlueprint`


### PR DESCRIPTION
# Overview
This PR introduces a new `SharedTaskState` hook that can now be used to automatically run any arbitrary script after a task has completed. This can be used to run quick post-task validation, or to update local state based on completion of a task.

# Implementation
The implementation is rather simple, just providing the function signature (with a default that is a no-op), and then calling it at the end of every run `Unit` or `Assignment`.

# Testing
I'm using this live in a task with the following function:
```
    def validate_final_unit(unit):
        try:
            u_data = mephisto_data_browser.get_data_from_unit(unit)
        except AssertionError:
            return  # unit was not in a final state, return or timeout
        ratings = u_data['data']['outputs']
        if (...some_validation_on_ratings_fails...):
            worker = unit.get_assigned_agent().get_worker()
            worker.grant_qualification(BLOCKING_QUALIFICATION, 1)
```

# Discussion
I don't think the name `validate_final_unit` properly describes what this hook is for, but I don't really know what better name to give it.