### PR TITLE
Ensuring proper shutdown with limited unit launch

### DIFF
--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -182,6 +182,8 @@ class TaskLauncher:
         """ use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
         while not self.finished_generators:
             for unit in self.generate_units():
+                if unit is None:
+                    break
                 unit.launch(url)
             if self.generator_type == GeneratorType.NONE:
                 break
@@ -211,6 +213,8 @@ class TaskLauncher:
 
     def shutdown(self) -> None:
         """Clean up running threads for generating assignments and units"""
+        self.assignment_thread_done = True
+        self.keep_launching_units = False
         if self.assignments_thread is not None:
             self.assignments_thread.join()
         self.units_thread.join()


### PR DESCRIPTION
# Overview
A small bug in the ordering between when `shutdown` and `expire_units` are called by an `Operator` (units are expired after shutdown), tasks launched using a unit limit would hang indefinitely when shutting down early. This fixes that detail by ensuring that `shutdown` will trigger closing of the unit launching thread.