### PR TITLE
add initialization data during onboarding world

### DIFF
--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -164,9 +164,14 @@ class ParlAIChatTaskRunner(TaskRunner):
         """
         opt: Dict[str, Any] = self.shared_state.onboarding_world_opt
         parlai_agent = MephistoAgentWrapper(agent)
-        world = self.parlai_world_module.make_onboarding_world(  # type: ignore
-            opt, parlai_agent
-        )
+        try:
+            world = self.parlai_world_module.make_onboarding_world(  
+                opt, parlai_agent, initialization_data=self.get_init_data_for_agent(agent)
+            )  # type: ignore
+        except TypeError:
+            # make_world doesn't ask for initialization_data
+            world = self.parlai_world_module.make_onboarding_world(opt, parlai_agent)  # type: ignore
+
         world_id = self.get_world_id("onboard", agent.get_agent_id())
         self.id_to_worlds[world_id] = world
         while (


### PR DESCRIPTION
Add initialization data during parlai chat `make_onboarding_world`, similar to https://github.com/facebookresearch/Mephisto/pull/335 and https://github.com/facebookresearch/Mephisto/pull/326

This could be useful, for example to get onboarding data within `MTurkOnboardWorld` without having race condition.