### PR TITLE
Consistently clean shutdown

### DIFF
--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -15,6 +15,7 @@ from mephisto.data_model.exceptions import (
     AgentReturnedError,
     AgentDisconnectedError,
     AgentTimeoutError,
+    AgentShutdownError,
 )
 
 from typing import List, Optional, Tuple, Mapping, Dict, Any, TYPE_CHECKING
@@ -59,6 +60,7 @@ class Agent(ABC):
         self.task_run_id = row["task_run_id"]
         self.task_id = row["task_id"]
         self.did_submit = threading.Event()
+        self.is_shutdown = False
 
         # Deferred loading of related entities
         self._worker: Optional["Worker"] = None
@@ -248,6 +250,8 @@ class Agent(ABC):
             self.has_action.wait(timeout)
 
         if len(self.pending_actions) == 0:
+            if self.is_shutdown:
+                raise AgentShutdownError(self.db_id)
             # various disconnect cases
             status = self.get_status()
             if status == AgentState.STATUS_DISCONNECT:
@@ -282,6 +286,14 @@ class Agent(ABC):
                 self.has_updated_status.set()
             self.db_status = row["status"]
         return self.db_status
+
+    def shutdown(self) -> None:
+        """
+        Force the given agent to end any polling threads and throw an AgentShutdownError
+        from any acts called on it, ensuring tasks using this agent can be cleaned up.
+        """
+        self.has_action.set()
+        self.is_shutdown = True
 
     # Children classes should implement the following methods
 
@@ -361,6 +373,7 @@ class OnboardingAgent(ABC):
         self.task_run_id = row["task_run_id"]
         self.task_id = row["task_id"]
         self.did_submit = threading.Event()
+        self.is_shutdown = False
 
         # Deferred loading of related entities
         self._worker: Optional["Worker"] = None
@@ -465,6 +478,8 @@ class OnboardingAgent(ABC):
 
         if len(self.pending_actions) == 0:
             # various disconnect cases
+            if self.is_shutdown:
+                raise AgentShutdownError(self.db_id)
             status = self.get_status()
             if status == AgentState.STATUS_DISCONNECT:
                 raise AgentDisconnectedError(self.db_id)
@@ -508,6 +523,14 @@ class OnboardingAgent(ABC):
             AgentState.STATUS_REJECTED,
         ]:
             self.update_status(AgentState.STATUS_WAITING)
+
+    def shutdown(self) -> None:
+        """
+        Force the given agent to end any polling threads and throw an AgentShutdownError
+        from any acts called on it, ensuring tasks using this agent can be cleaned up.
+        """
+        self.has_action.set()
+        self.is_shutdown = True
 
     @staticmethod
     def new(db: "MephistoDB", worker: Worker, task_run: "TaskRun") -> "OnboardingAgent":

--- a/mephisto/data_model/exceptions.py
+++ b/mephisto/data_model/exceptions.py
@@ -34,3 +34,10 @@ class AgentReturnedError(AbsentAgentError):
 
     def __init__(self, agent_id):
         super().__init__(f"Agent returned task", agent_id)
+
+
+class AgentShutdownError(AbsentAgentError):
+    """Exception for when a task is shutdown but agents are still in a task"""
+
+    def __init__(self, agent_id):
+        super().__init__(f"This agent has been forced to shut down", agent_id)

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -15,7 +15,6 @@ import threading
 import shlex
 import traceback
 import signal
-import logging
 
 from argparse import ArgumentParser
 

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -14,6 +14,8 @@ import time
 import threading
 import shlex
 import traceback
+import signal
+import logging
 
 from argparse import ArgumentParser
 
@@ -300,13 +302,67 @@ class Operator:
                     del self._task_runs_tracked[task_run.db_id]
             time.sleep(2)
 
+    def force_shutdown(self, timeout=5):
+        """
+        Force a best-effort shutdown of everything, letting no individual
+        shutdown step suspend for more than the timeout before moving on.
+
+        Skips waiting for in-flight assignments to rush the shutdown.
+
+        ** Should only be used in sandbox or test environments. **
+        """
+        self.is_shutdown = True
+
+        def end_launchers_and_expire_units():
+            for tracked_run in self._task_runs_tracked.values():
+                tracked_run.task_launcher.shutdown()
+                tracked_run.task_launcher.expire_units()
+
+        def end_architects():
+            for tracked_run in self._task_runs_tracked.values():
+                tracked_run.architect.shutdown()
+
+        def shutdown_supervisor():
+            if self.supervisor is not None:
+                self.supervisor.shutdown()
+
+        tasks = {
+            "expire-units": end_launchers_and_expire_units,
+            "kill-architects": end_architects,
+            "fire-supervisor": shutdown_supervisor,
+        }
+
+        for tname, t in tasks.items():
+            shutdown_thread = threading.Thread(target=t, name=f"force-shutdown-{tname}")
+            shutdown_thread.start()
+            start_time = time.time()
+            while time.time() - start_time < timeout and shutdown_thread.is_alive():
+                time.sleep(0.5)
+            if not shutdown_thread.is_alive():
+                # Only join if the shutdown fully completed
+                shutdown_thread.join()
+
     def shutdown(self, skip_input=True):
         logger.info("operator shutting down")
         self.is_shutdown = True
-        for tracked_run in self._task_runs_tracked.values():
-            logger.info("expiring units")
-            tracked_run.task_launcher.shutdown()
+        for run_id, tracked_run in self._task_runs_tracked.items():
+            logger.info(f"Expiring units for task run {run_id}.")
+            try:
+                tracked_run.task_launcher.shutdown()
+            except (KeyboardInterrupt, SystemExit) as e:
+                logger.info(
+                    f"Skipping waiting for launcher threads to join on task run {run_id}."
+                )
+
+            def cant_cancel_expirations(self, sig, frame):
+                logging.warn(
+                    "Ignoring ^C during unit expirations. ^| if you NEED to exit and you will "
+                    "clean up units that hadn't been expired afterwards."
+                )
+
+            old_handler = signal.signal(signal.SIGINT, cant_cancel_expirations)
             tracked_run.task_launcher.expire_units()
+            signal.signal(signal.SIGINT, old_handler)
         try:
             remaining_runs = self._task_runs_tracked.values()
             while len(remaining_runs) > 0:
@@ -318,7 +374,8 @@ class Operator:
                         next_runs.append(tracked_run)
                 if len(next_runs) > 0:
                     logger.info(
-                        f"Waiting on {len(remaining_runs)} task runs, Ctrl-C ONCE to FORCE QUIT"
+                        f"Waiting on {len(remaining_runs)} task runs with assignments in-flight "
+                        f"Ctrl-C ONCE to kill running tasks and FORCE QUIT."
                     )
                     time.sleep(30)
                 remaining_runs = next_runs
@@ -334,6 +391,9 @@ class Operator:
                 "Skipping waiting for outstanding task completions, shutting down servers now!"
             )
             for tracked_run in remaining_runs:
+                logger.info(
+                    f"Shutting down Architect for task run {tracked_run.task_run.db_id}"
+                )
                 tracked_run.architect.shutdown()
         finally:
             self.supervisor.shutdown()

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -202,9 +202,15 @@ class Supervisor:
         """Close all of the channels, join threads"""
         channels_to_close = list(self.channels.keys())
         for channel_id in channels_to_close:
+            channel_info = self.channels[channel_id]
+            channel_info.job.task_runner.shutdown()
             self.close_channel(channel_id)
         if self.sending_thread is not None:
             self.sending_thread.join()
+        for agent_info in self.agents.values():
+            assign_thread = agent_info.assignment_thread
+            if assign_thread is not None:
+                assign_thread.join()
 
     def _send_alive(self, channel_info: ChannelInfo) -> bool:
         logger.info("Sending alive")

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -215,6 +215,7 @@ class TaskLauncher:
         """Clean up running threads for generating assignments and units"""
         self.assignment_thread_done = True
         self.keep_launching_units = False
+        self.finished_generators = True
         if self.assignments_thread is not None:
             self.assignments_thread.join()
         self.units_thread.join()


### PR DESCRIPTION
# Overview
Mephisto shutdown has been a little... finicky up until now. Sometimes when an assignment thread was still running, the shutdown would halt with no messaging, leading to some amount of frustration, likely a number of repeated Ctrl-C's, and more. Due to this, a wrong Ctrl-C could lead things to become in some incomplete states, like HITs remaining live, or a heroku server not shutdown (or a local thread running as a phantom in the background). This PR seeks to resolve the issue by improving the manual shutdown process and blocking off important shutdown parts.

This also includes a new `force_shutdown` method that will run through the motions that a human could on shutting down, but for use in tests to (mostly) ensure that all resources are cleaned between executions. (@EricMichaelSmith).

The end result is a system wherein live tasks will always be able to be shut down with one Ctrl-C (two for emergencies, potentially cutting off someone who is in-task), and test tasks can shutdown cleanly with one call.

# Implementation
On the safety side, I've added a signal wrapper around the expiration segment, to prevent people from trying to interrupt this stage. People having HITs up that are not expired is the most common issue in Mephisto, so this extra step should help prevent this from surfacing.

On the completion side, I found that incomplete Unit and Assignment threads were the biggest thing causing the system to hang during an incomplete shutdown (as the threads would suspend resources while waiting to close), so additional tracking has been added to the `TaskRunner` component to track this stuff down and end it. Much of that implementation surrounds adding a new shutdown-based error to Agents to ensure that they release their threads.