### PR TITLE
Added ../mephisto/abstractions/blueprints to the script scope

### DIFF
--- a/scripts/sync_package_version.sh
+++ b/scripts/sync_package_version.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Update the version of a given package in the related package.json file
+# under "./examples" and "../mephisto/abstractions/blueprints"
+# Currently we support the update of the following packages:
+# * mephisto-task
+# * bootstrap-chat
+
+possible_dirs=`find ../mephisto/abstractions/blueprints ../examples -type d \( -name node_modules -o -name tmp -o -name runs -o -name _generated \) -prune -false -o -name 'package.json' -exec dirname {} \;`
+
+
+sync_package_version() {
+    package_name=$1
+    new_version=$2
+
+    for dir in $possible_dirs
+    do
+        (cd "$dir" && pwd && sed -i '' "s/\"$package_name\":.*/\"$package_name\": \"$new_version\",/" package.json)
+    done
+
+    echo -e "All $package_name in the files above are updated to version $new_version"
+    echo
+
+}
+
+while [ -n "$1" ];
+do
+
+	case "$1" in
+
+	mephisto-task)
+        sync_package_version $1 $2
+        shift
+        ;;
+
+	bootstrap-chat)
+        sync_package_version $1 $2
+		shift
+		;;
+
+	*) echo "Package $1 version sync is not supported yet" ;;
+
+	esac
+	shift
+done
+
+exit 0

--- a/scripts/sync_package_version.sh
+++ b/scripts/sync_package_version.sh
@@ -42,8 +42,8 @@ do
 
 	bootstrap-chat)
         sync_package_version $1 $2
-		shift
-		;;
+        shift
+        ;;
 
 	*) echo "Package $1 version sync is not supported yet" ;;
 

--- a/scripts/sync_package_version.sh
+++ b/scripts/sync_package_version.sh
@@ -6,6 +6,14 @@
 # * mephisto-task
 # * bootstrap-chat
 
+# Usage:
+# You can sync one package at a time like this:
+# ./sync_package_version.sh mephisto-task 1.0.13
+# ./sync_package_version.sh bootstrap-chat 1.0.7
+
+# You can also sync all packages together like this:
+# ./sync_package_version.sh mephisto-task 1.0.13 bootstrap-chat 1.0.7
+
 possible_dirs=`find ../mephisto/abstractions/blueprints ../examples -type d \( -name node_modules -o -name tmp -o -name runs -o -name _generated \) -prune -false -o -name 'package.json' -exec dirname {} \;`
 
 
@@ -20,7 +28,6 @@ sync_package_version() {
 
     echo -e "All $package_name in the files above are updated to version $new_version"
     echo
-
 }
 
 while [ -n "$1" ];


### PR DESCRIPTION
**Context:**
This PR is for this issue: https://github.com/facebookresearch/Mephisto/issues/350

This change implemented a new script file which is used to sync some npm package version for all the related package.json files. 

**Usage:**
./sync_package_version.sh package_name_1 version_number_1 package_name_2 version_number_2

- You can sync one package at a time like this:
`./sync_package_version.sh mephisto-task 1.0.13`
`./sync_package_version.sh bootstrap-chat 1.0.7`

- You can also sync all packages together like this:
`./sync_package_version.sh mephisto-task 1.0.13  bootstrap-chat 1.0.7`

**Test Plan**
Run the command under ./scripts
`./sync_package_version.sh mephisto-task 1.0.13  bootstrap-chat 1.0.7`

* You should see the output in your terminal console telling you what has been updated in what files.
* Also, all the files mentioned in the console output should have newly updated version for the packages

Run the command under ./scripts
`./sync_package_version.sh mephisto-task-does-not-exist 1.0.9`

* You should see the error message telling you that the file you input is not supported yet


**Note**
* For now, this script should be only run under the ./scripts directory otherwise you will get directory not found error because the path to the related directories are hardcoded in the `find` command 
* There is no check on the version you pass in

