### PR TITLE
Allow useMephistoReview hook to be used without an arg by providing a default

### DIFF
--- a/packages/mephisto-review-hook/package.json
+++ b/packages/mephisto-review-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mephisto-review-hook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "build/bundle.js",
   "scripts": {

--- a/packages/mephisto-review-hook/package.json
+++ b/packages/mephisto-review-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mephisto-review-hook",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "build/bundle.js",
   "scripts": {

--- a/packages/mephisto-review-hook/src/index.js
+++ b/packages/mephisto-review-hook/src/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-function useMephistoReview({ useMock, mock }) {
+function useMephistoReview({ useMock, mock } = {}) {
   if (mock !== undefined && (useMock === undefined || useMock === true)) {
     return mock;
   }


### PR DESCRIPTION
When support for mock args was added to `useMephistoReview`, a default was not added. This causes the object destructuring syntax in the arguments section of the function definition to error out.

The args object now has a default of an empty object, so the destructuring still works when no object is passed in during usage.

For example:

```jsx
// this still works as normal:
useMephistoReview({mock: mockPayload})

// this now works as expected, whereas it errored out before:
useMephistoReview()

// this was the temporary workaround that had to be used, before this PR was put up:
useMephistoReview({})
```