### PR TITLE
Updated pre-commit-config to reference the latest version of the prettier library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
     hooks:
       - id: black
         language_version: python3.6
-  - repo: https://github.com/prettier/prettier
-    rev: "2.1.2"
+  - repo: https://github.com/prettier/pre-commit
+    rev: "v2.1.2"
     hooks:
       - id: prettier
         files: "\\.(\


### PR DESCRIPTION
Prettier has migrated from 'https://github.com/prettier/prettier' to 'https://github.com/prettier/pre-commit' and the version attribute has changed in format.

Change is referenced in this issue on the Prettier repo: https://github.com/prettier/prettier/issues/9459 