### PR TITLE
Integrating mephisto review with Mephisto DB

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -32,8 +32,7 @@ def web():
 @click.option("--file", "output_method", flag_value="file", default=True)
 @click.option("--csv-headers/--no-csv-headers", default=False)
 @click.option("--json/--csv", default=False)
-@click.option("--db/--no-db", "database", default=False)
-@click.option("--db-task-name", "database_task_name", type=(str), default="")
+@click.option("--db", "database_task_name", type=(str), default=None)
 @click.option("-d", "--debug", type=(bool), default=False)
 def review(
     review_app_dir,
@@ -42,7 +41,6 @@ def review(
     output_method,
     csv_headers,
     json,
-    database,
     database_task_name,
     debug,
 ):
@@ -53,7 +51,7 @@ def review(
         raise click.UsageError(
             "You must specify an output file via --output=<filename>, unless the --stdout flag is set."
         )
-    if database and database_task_name != "":
+    if database_task_name is not None:
         from mephisto.abstractions.databases.local_database import LocalMephistoDB
         from mephisto.tools.data_browser import DataBrowser as MephistoDataBrowser
 
@@ -62,7 +60,7 @@ def review(
         name_list = mephisto_data_browser.get_task_name_list()
         if database_task_name not in name_list:
             raise click.BadParameter(
-                f'The task name "{database_task_name}" did not exist in MephistoDB.\n\nPerhaps you meant one of these? {", ".join(name_list)}\n\nFlag usage: mephisto review --db --db-task-name [task_name]\n'
+                f'The task name "{database_task_name}" did not exist in MephistoDB.\n\nPerhaps you meant one of these? {", ".join(name_list)}\n\nFlag usage: mephisto review --db [task_name]\n'
             )
 
     run(
@@ -71,7 +69,6 @@ def review(
         output,
         csv_headers,
         json,
-        database,
         database_task_name,
         debug,
     )

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -20,7 +20,6 @@ def run(
     output,
     csv_headers,
     json=False,
-    database=False,
     database_task_name=None,
     debug=False,
 ):
@@ -61,33 +60,14 @@ def run(
             contents = data["data"]
             return f"{data}"
 
-        if database_task_name is None or database_task_name == "":
-            tasks_by_name = []
-            name_list = mephisto_data_browser.get_task_name_list()
-            for task_name in name_list:
-                task_group = []
-                units = mephisto_data_browser.get_units_for_task_name(task_name)
-                for unit in units:
-                    task_group.append(
-                        format_data_for_review(
-                            mephisto_data_browser.get_data_from_unit(unit)
-                        )
-                    )
-                tasks_by_name.append(task_group)
-            for task_group in tasks_by_name:
-                yield task_group
-
-        else:
-            units = mephisto_data_browser.get_units_for_task_name(database_task_name)
-            for unit in units:
-                yield format_data_for_review(
-                    mephisto_data_browser.get_data_from_unit(unit)
-                )
+        units = mephisto_data_browser.get_units_for_task_name(database_task_name)
+        for unit in units:
+            yield format_data_for_review(mephisto_data_browser.get_data_from_unit(unit))
 
     def consume_data():
         global ready_for_next, current_data, finished, counter
 
-        if database:
+        if database_task_name is not None:
             data_source = mephistoDBReader()
         elif json:
             data_source = json_reader(iter(sys.stdin.readline, ""))

--- a/mephisto/tools/data_browser.py
+++ b/mephisto/tools/data_browser.py
@@ -47,6 +47,9 @@ class DataBrowser:
                         units.append(unit)
         return units
 
+    def get_task_name_list(self) -> List[str]:
+        return [task.task_name for task in self.db.find_tasks()]
+
     def get_units_for_task_name(self, task_name: str) -> List[Unit]:
         """
         Return a list of all Units in a terminal completed state from all

--- a/packages/cra-template-mephisto-review/template/src/App.css
+++ b/packages/cra-template-mephisto-review/template/src/App.css
@@ -12,3 +12,7 @@
   font-size: calc(10px + 2vmin);
   color: white;
 }
+
+.App-header > pre {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Prior to this change users could only use ```mephisto review``` via standard input of a ```CSV``` or ```JSON``` file.
This allows users to alternatively provide no standard input and instead source the task information from their ```mephistoDB```.
Users can do this by adding a ```--db``` flag to their ```mephisto review``` command followed by the task name within the db which they wish to review.

Such a command can look like this:
```
mephisto review my-review/build -o results.csv --db task_name
```