### PR TITLE
[review-cli] Show task names when an invalid one is specified

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -35,8 +35,9 @@ def mephisto_db_task_validation(ctx, param, value):
 
         return value
     except AssertionError:
+        name_list = mephisto_data_browser.get_task_name_list()
         raise click.BadParameter(
-            f'The task name "{value}" did not exist in MephistoDB.\nFlag usage: mephisto review --db [task_name]\n'
+            f'The task name "{value}" did not exist in MephistoDB.\n\nPerhaps you meant one of these? {", ".join(name_list)}\n\nFlag usage: mephisto review --db [task_name]\n'
         )
 
 

--- a/mephisto/tools/data_browser.py
+++ b/mephisto/tools/data_browser.py
@@ -47,6 +47,9 @@ class DataBrowser:
                         units.append(unit)
         return units
 
+    def get_task_name_list(self) -> List[str]:
+        return [task.task_name for task in self.db.find_tasks()]
+
     def get_units_for_task_name(self, task_name: str) -> List[Unit]:
         """
         Return a list of all Units in a terminal completed state from all


### PR DESCRIPTION
```
$ mephisto review my-review/build/ --db invalid_task_name --stdout
Usage: mephisto review [OPTIONS] REVIEW_APP_DIR

Error: Invalid value for '--db': The task name "invalid_task_name" did not exist in MephistoDB.

Perhaps you meant one of these? 2, 1, 3, static_task, task name, parlai_chat, react-static-task-example, parlai-chat-example, video-time-segmentation, html-static-task-example

Flag usage: mephisto review --db [task_name]
```