### PR TITLE
More debug logging

### DIFF
--- a/mephisto/abstractions/architects/channels/websocket_channel.py
+++ b/mephisto/abstractions/architects/channels/websocket_channel.py
@@ -16,7 +16,7 @@ import time
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 
 class WebsocketChannel(Channel):

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 ARCHITECT_TYPE = "heroku"
 

--- a/mephisto/abstractions/blueprint.py
+++ b/mephisto/abstractions/blueprint.py
@@ -42,6 +42,10 @@ if TYPE_CHECKING:
     from mephisto.data_model.worker import Worker
     from argparse import _ArgumentGroup as ArgumentGroup
 
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
+
 
 @dataclass
 class BlueprintArgs:
@@ -158,10 +162,10 @@ class TaskRunner(ABC):
         """
         onboarding_id = onboarding_agent.get_agent_id()
         if onboarding_id in self.running_onboardings:
-            print(f"Onboarding {onboarding_id} is already running")
+            logger.debug(f"Onboarding {onboarding_id} is already running")
             return
 
-        print(f"Onboarding {onboarding_id} is launching with {onboarding_agent}")
+        logger.debug(f"Onboarding {onboarding_id} is launching with {onboarding_agent}")
 
         # At this point we're sure we want to run Onboarding
         self.running_onboardings[onboarding_id] = onboarding_agent
@@ -189,10 +193,10 @@ class TaskRunner(ABC):
         Validate the unit is prepared to launch, then run it
         """
         if unit.db_id in self.running_units:
-            print(f"Unit {unit.db_id} is already running")
+            logger.debug(f"{unit} is already running")
             return
 
-        print(f"Unit {unit.db_id} is launching with {agent}")
+        logger.debug(f"{unit} is launching with {agent}")
 
         # At this point we're sure we want to run the unit
         self.running_units[unit.db_id] = (unit, agent)
@@ -212,7 +216,7 @@ class TaskRunner(ABC):
                 unit.clear_assigned_agent()
             self.cleanup_unit(unit)
         except Exception as e:
-            print(f"Unhandled exception in unit {unit}: {repr(e)}")
+            logger.exception(f"Unhandled exception in unit {unit}: {repr(e)}")
             import traceback
 
             traceback.print_exc()
@@ -227,10 +231,10 @@ class TaskRunner(ABC):
         Validate the assignment is prepared to launch, then run it
         """
         if assignment.db_id in self.running_assignments:
-            print(f"Assignment {assignment.db_id} is already running")
+            logger.debug(f"Assignment {assignment} is already running")
             return
 
-        print(f"Assignment {assignment.db_id} is launching with {agents}")
+        logger.debug(f"Assignment {assignment} is launching with {agents}")
 
         # At this point we're sure we want to run the assignment
         self.running_assignments[assignment.db_id] = (assignment, agents)
@@ -254,7 +258,9 @@ class TaskRunner(ABC):
                     agent.get_unit().expire()
             self.cleanup_assignment(assignment)
         except Exception as e:
-            print(f"Unhandled exception in assignment {assignment}: {repr(e)}")
+            logger.exception(
+                f"Unhandled exception in assignment {assignment}: {repr(e)}"
+            )
             import traceback
 
             traceback.print_exc()

--- a/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 DATA_FILE = "agent_data.json"
 

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -30,7 +30,7 @@ import threading
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 
 def nonesafe_int(in_string: Optional[str]) -> Optional[int]:

--- a/mephisto/abstractions/providers/mock/mock_unit.py
+++ b/mephisto/abstractions/providers/mock/mock_unit.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 
 class MockUnit(Unit):

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 
 class MTurkUnit(Unit):

--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -22,7 +22,7 @@ from mephisto.data_model.qualification import QUAL_EXISTS, QUAL_NOT_EXIST
 from mephisto.operations.logger_core import get_logger
 from mephisto.operations.config_handler import get_config_arg
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 if TYPE_CHECKING:
     from mephisto.data_model.task_config import TaskConfig

--- a/mephisto/abstractions/providers/mturk/mturk_worker.py
+++ b/mephisto/abstractions/providers/mturk/mturk_worker.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 
 class MTurkWorker(Worker):

--- a/mephisto/data_model/assignment.py
+++ b/mephisto/data_model/assignment.py
@@ -20,6 +20,9 @@ import os
 import json
 from dataclasses import dataclass
 
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
 
 ASSIGNMENT_DATA_FILE = "assign_data.json"
 
@@ -197,6 +200,9 @@ class Assignment:
             sum_cost += unit.get_pay_amount()
         return sum_cost
 
+    def __repr__(self) -> str:
+        return f"Assignment({self.db_id})"
+
     # TODO(100) add helpers to manage retrieving results as well
 
     @staticmethod
@@ -226,4 +232,6 @@ class Assignment:
                 os.path.join(assign_dir, ASSIGNMENT_DATA_FILE), "w+"
             ) as json_file:
                 json.dump(assignment_data, json_file)
-        return Assignment(db, db_id)
+        assignment = Assignment(db, db_id)
+        logger.debug(f"{assignment} created for {task_run}")
+        return assignment

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -103,7 +103,7 @@ class Requester(ABC):
         return False
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.db_id}, {self.db_status})"
+        return f"{self.__class__.__name__}({self.db_id})"
 
     @staticmethod
     def _register_requester(

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from mephisto.data_model.task_run import TaskRun
     from argparse import _ArgumentGroup as ArgumentGroup
 
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
+
 
 @dataclass
 class RequesterArgs:
@@ -98,6 +102,9 @@ class Requester(ABC):
         """
         return False
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.db_id}, {self.db_status})"
+
     @staticmethod
     def _register_requester(
         db: "MephistoDB", requester_id: str, provider_type: str
@@ -106,7 +113,9 @@ class Requester(ABC):
         Create an entry for this requester in the database
         """
         db_id = db.new_requester(requester_id, provider_type)
-        return Requester(db, db_id)
+        requester = Requester(db, db_id)
+        logger.debug(f"Registered new requester {requester}")
+        return requester
 
     # Children classes should implement the following methods
 

--- a/mephisto/operations/hydra_config.py
+++ b/mephisto/operations/hydra_config.py
@@ -22,6 +22,7 @@ class MephistoConfig:
     provider: ProviderArgs = ProviderArgs()
     architect: ArchitectArgs = ArchitectArgs()
     task: TaskConfigArgs = TaskConfigArgs()
+    log_level: str = "info"
 
 
 @dataclass

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -35,10 +35,10 @@ from mephisto.operations.registry import (
 )
 from mephisto.operations.utils import get_mock_requester
 
-from mephisto.operations.logger_core import get_logger
+from mephisto.operations.logger_core import get_logger, set_mephisto_log_level
 from omegaconf import DictConfig, OmegaConf
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -128,6 +128,8 @@ class Operator:
         """
         Parse the given arguments and launch a job.
         """
+        set_mephisto_log_level(level=run_config.get("log_level", "info"))
+
         if shared_state is None:
             shared_state = SharedTaskState()
 

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -323,10 +323,10 @@ class Supervisor:
             f", got {tracked_agent}"
         )
         try:
-            logger.debug(f"Launching onboarding for {agent}")
+            logger.debug(f"Launching onboarding for {tracked_agent}")
             task_runner.launch_onboarding(tracked_agent)
         except Exception as e:
-            logger.warning(f"Onboarding for {agent} failed with exception {e}")
+            logger.warning(f"Onboarding for {tracked_agent} failed with exception {e}")
             import traceback
 
             traceback.print_exc()

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 from mephisto.operations.logger_core import get_logger
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 # This class manages communications between the server
 # and workers, ensures that their status is properly tracked,
@@ -201,12 +201,15 @@ class Supervisor:
     def shutdown(self):
         """Close all of the channels, join threads"""
         channels_to_close = list(self.channels.keys())
+        logger.debug(f"Closing channels {channels_to_close}")
         for channel_id in channels_to_close:
             channel_info = self.channels[channel_id]
             channel_info.job.task_runner.shutdown()
             self.close_channel(channel_id)
+        logger.debug(f"Joining send thread")
         if self.sending_thread is not None:
             self.sending_thread.join()
+        logger.debug(f"Joining agents {self.agents}")
         for agent_info in self.agents.values():
             assign_thread = agent_info.assignment_thread
             if assign_thread is not None:
@@ -253,6 +256,8 @@ class Supervisor:
             return
         agent_info = self.agents[onboarding_id]
         agent = agent_info.agent
+
+        logger.debug(f"{agent} has submitted onboarding: {packet}")
         # Update the request id for the original packet (which has the required
         # registration data) to be the new submission packet (so that we answer
         # back properly under the new request)
@@ -318,8 +323,10 @@ class Supervisor:
             f", got {tracked_agent}"
         )
         try:
+            logger.debug(f"Launching onboarding for {agent}")
             task_runner.launch_onboarding(tracked_agent)
         except Exception as e:
+            logger.warning(f"Onboarding for {agent} failed with exception {e}")
             import traceback
 
             traceback.print_exc()
@@ -549,7 +556,7 @@ class Supervisor:
             )
             logger.debug(
                 f"Found existing agent_registration_id {agent_registration_id}, "
-                f"reconnecting to agent {agent.get_agent_id()}."
+                f"reconnecting to {agent}."
             )
             return
 
@@ -624,8 +631,8 @@ class Supervisor:
                 )
 
                 logger.debug(
-                    f"Worker {worker_id} is starting onboarding thread with "
-                    f"onboarding agent id {onboard_id}."
+                    f"{worker} is starting onboarding thread with "
+                    f"onboarding {onboard_agent}."
                 )
 
                 # Create an onboarding thread

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -31,7 +31,7 @@ import threading
 from mephisto.operations.logger_core import get_logger
 import types
 
-logger = get_logger(name=__name__, verbose=True, level="info")
+logger = get_logger(name=__name__)
 
 UNIT_GENERATOR_WAIT_SECONDS = 10
 ASSIGNMENT_GENERATOR_WAIT_SECONDS = 0.5


### PR DESCRIPTION
As titled: Goes through the full Mephisto codebase and adds more logging calls for potentially important debug information to the appropriate debug logger. Now people can generate clean debug logs for the team and others to investigate using `mephisto.log_level=?` as a command line arg.

Testing:
```
> python parlai_test_script.py mephisto.log_level=debug
[2021-01-20 19:40:25,130][mephisto.operations.operator][INFO] - Creating a task run under task name: parlai-chat-example
npm WARN server@1.0.0 No description
npm WARN server@1.0.0 No repository field.
npm WARN server@1.0.0 No license field.

audited 123 packages in 0.912s
found 1 high severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
[2021-01-20 19:40:26,593][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router'>: starting process
[2021-01-20 19:40:26,601][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router', pid 47142>: process started
[2021-01-20 19:40:26,885][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router', pid 47142>: process completed
Listening on 3000
Server running locally with pid 47169.
[2021-01-20 19:40:29,200][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router'>: starting process
[2021-01-20 19:40:29,209][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router', pid 47178>: process started
Client connected
[2021-01-20 19:40:29,690][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/data/data/runs/NO_PROJECT/1046/build/router', pid 47178>: process completed
[2021-01-20 19:40:29,693][mephisto.operations.supervisor][INFO] - Sending alive
[2021-01-20 19:40:29,693][mephisto.operations.supervisor][INFO] - Sending alive
Client connected
[2021-01-20 19:40:29,695][mephisto.operations.supervisor][INFO] - Sending alive
[2021-01-20 19:40:29,696][mephisto.abstractions.architects.channels.websocket_channel][INFO] - channel open (<websocket._app.WebSocketApp object at 0x7ff2f062ec10>,)
::1
[2021-01-20 19:40:29,999][mephisto.operations.task_launcher][DEBUG] - type of assignment data: <class 'list'>
[2021-01-20 19:40:30,014][mephisto.operations.operator][INFO] - Operator running task ID = 1046
localhost:3000
Mock task launched: localhost:3000 for preview, localhost:3000/?worker_id=x&assignment_id=4305
[2021-01-20 19:40:30,016][mephisto.abstractions.providers.mock.mock_unit][INFO] - Mock task launched: localhost:3000 for preview, localhost:3000/?worker_id=x&assignment_id=4305 for assignment 3165
localhost:3000
Mock task launched: localhost:3000 for preview, localhost:3000/?worker_id=x&assignment_id=4306
[2021-01-20 19:40:30,018][mephisto.abstractions.providers.mock.mock_unit][INFO] - Mock task launched: localhost:3000 for preview, localhost:3000/?worker_id=x&assignment_id=4306 for assignment 3165
Caught socket error, probably closed!
{ Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:111:27) errno: 'ECONNRESET', code: 'ECONNRESET', syscall: 'read' }
[2021-01-20 19:40:42,293][mephisto.operations.supervisor][DEBUG] - Incoming request to register agent 4306-260.
[2021-01-20 19:40:42,294][mephisto.data_model.task_run][DEBUG] - Found [MockUnit(4305, launched), MockUnit(4306, launched)] for MockWorker(260).
[2021-01-20 19:40:42,295][mephisto.operations.supervisor][DEBUG] - Worker 260 is being assigned one of 2 units.
[2021-01-20 19:40:42,295][mephisto.data_model.task_run][DEBUG] - Reserved MockUnit(4305, launched) with unit_res_4305
[2021-01-20 19:40:42,304][mephisto.data_model.agent][DEBUG] - Registered new agent MockAgent(1034, none) for MockUnit(4305, launched).
[2021-01-20 19:40:42,304][mephisto.data_model.agent][DEBUG] - Updating MockAgent(1034, none) to accepted
[2021-01-20 19:40:42,306][mephisto.operations.supervisor][DEBUG] - Created agent MockAgent(1034, accepted), 1034.
[2021-01-20 19:40:42,314][mephisto.data_model.agent][DEBUG] - Updating MockAgent(1034, accepted) to waiting
Client connected
[2021-01-20 19:41:00,015][mephisto.operations.operator][INFO] - Operator running task ID = 1046
[2021-01-20 19:41:18,421][mephisto.operations.supervisor][DEBUG] - Incoming request to register agent 4306-260.
[2021-01-20 19:41:18,422][mephisto.operations.supervisor][DEBUG] - Found existing agent_registration_id 4306-260, reconnecting to MockAgent(1034, waiting).
Client connected
Caught socket error, probably closed!
{ Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:111:27) errno: 'ECONNRESET', code: 'ECONNRESET', syscall: 'read' }
Caught socket error, probably closed!
{ Error: read ECONNRESET
    at TCP.onStreamRead (internal/stream_base_commons.js:111:27) errno: 'ECONNRESET', code: 'ECONNRESET', syscall: 'read' }
[2021-01-20 19:41:27,966][mephisto.operations.supervisor][DEBUG] - Incoming request to register agent 4306-260.
[2021-01-20 19:41:27,966][mephisto.operations.supervisor][DEBUG] - Found existing agent_registration_id 4306-260, reconnecting to MockAgent(1034, waiting).
Client connected
[2021-01-20 19:41:30,026][mephisto.operations.operator][INFO] - Operator running task ID = 1046
[2021-01-20 19:41:34,460][mephisto.operations.supervisor][DEBUG] - Incoming request to register agent 4306-262.
[2021-01-20 19:41:34,465][mephisto.data_model.task_run][DEBUG] - Found [MockUnit(4306, launched)] for MockWorker(262).
[2021-01-20 19:41:34,465][mephisto.operations.supervisor][DEBUG] - Worker 262 is being assigned one of 1 units.
[2021-01-20 19:41:34,466][mephisto.data_model.task_run][DEBUG] - Reserved MockUnit(4306, launched) with unit_res_4306
[2021-01-20 19:41:34,471][mephisto.data_model.agent][DEBUG] - Registered new agent MockAgent(1035, none) for MockUnit(4306, launched).
[2021-01-20 19:41:34,472][mephisto.data_model.agent][DEBUG] - Updating MockAgent(1035, none) to accepted
[2021-01-20 19:41:34,473][mephisto.operations.supervisor][DEBUG] - Created agent MockAgent(1035, accepted), 1035.
[2021-01-20 19:41:34,481][mephisto.data_model.agent][DEBUG] - Updating MockAgent(1034, waiting) to in task
[2021-01-20 19:41:34,482][mephisto.data_model.agent][DEBUG] - Updating MockAgent(1035, accepted) to in task
[2021-01-20 19:41:34,483][mephisto.abstractions.blueprint][DEBUG] - Assignment Assignment(3165) is launching with [MockAgent(1034, in task), MockAgent(1035, in task)]
Client connected
[2021-01-20 19:42:00,038][mephisto.operations.operator][INFO] - Operator running task ID = 1046
[2021-01-20 19:42:07,200][mephisto.data_model.unit][DEBUG] - Updating status for MockUnit(4305, assigned) to completed
[2021-01-20 19:42:10,041][mephisto.data_model.task_run][DEBUG] - Cleared reservation unit_res_4305 for MockUnit(4305, completed)
[2021-01-20 19:42:10,041][mephisto.data_model.task_run][DEBUG] - Cleared reservation unit_res_4306 for MockUnit(4306, assigned)
[2021-01-20 19:42:11,233][mephisto.data_model.unit][DEBUG] - Updating status for MockUnit(4306, assigned) to completed
[2021-01-20 19:42:11,445][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/tmp/local_server_1046/server'>: starting process
[2021-01-20 19:42:11,453][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/tmp/local_server_1046/server', pid 47499>: process started
[2021-01-20 19:42:11,935][sh.command][INFO] - <Command '/bin/rm -rf /Users/jju/mephisto/tmp/local_server_1046/server', pid 47499>: process completed
[2021-01-20 19:42:20,043][mephisto.operations.operator][INFO] - operator shutting down
[2021-01-20 19:42:20,043][mephisto.operations.supervisor][DEBUG] - Closing channels []
[2021-01-20 19:42:20,044][mephisto.operations.supervisor][DEBUG] - Joining send thread
[2021-01-20 19:42:20,045][mephisto.operations.supervisor][DEBUG] - Joining agents {'1034': AgentInfo(agent=MockAgent(1034, in task), used_channel_id='local_channel_1046_0', assignment_thread=<Thread(Assignment-thread-3165, stopped 123145595936768)>), '1035': AgentInfo(agent=MockAgent(1035, in task), used_channel_id='local_channel_1046_0', assignment_thread=<Thread(Assignment-thread-3165, stopped 123145595936768)>)}
```