### PR TITLE
Removing improper agent state transitions

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -100,6 +100,9 @@ class MTurkUnit(Unit):
             self.datastore.clear_hit_from_unit(self.db_id)
             self._sync_hit_mapping()
 
+        if self.db_status == AssignmentState.ASSIGNED:
+            self.set_db_status(AssignmentState.LAUNCHED)
+
     # Required Unit functions
 
     def get_status(self) -> str:
@@ -171,7 +174,8 @@ class MTurkUnit(Unit):
                     # mark the agent as having returned the HIT, to
                     # free any running tasks and have Blueprint decide on cleanup.
                     agent.update_status(AgentState.STATUS_RETURNED)
-            self.set_db_status(external_status)
+            else:
+                self.set_db_status(external_status)
 
         return self.db_status
 

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -58,9 +58,6 @@ class Unit(ABC):
         self.requester_id = row["requester_id"]
         self.worker_id = row["worker_id"]
 
-        # Flag for task runner to set on units used in assignments
-        self._is_concurrent: bool = False
-
         # Deferred loading of related entities
         self.__task: Optional["Task"] = None
         self.__task_run: Optional["TaskRun"] = None

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -58,6 +58,9 @@ class Unit(ABC):
         self.requester_id = row["requester_id"]
         self.worker_id = row["worker_id"]
 
+        # Flag for task runner to set on units used in assignments
+        self._is_concurrent: bool = False
+
         # Deferred loading of related entities
         self.__task: Optional["Task"] = None
         self.__task_run: Optional["TaskRun"] = None
@@ -181,7 +184,7 @@ class Unit(ABC):
 
     def clear_assigned_agent(self) -> None:
         """Clear the agent that is assigned to this unit"""
-        logger.debug(f"Clearing assigned agent {self.__agent} from {self}")
+        logger.debug(f"Clearing assigned agent {self.agent} from {self}")
         self.db.clear_unit_agent_assignment(self.db_id)
         self.get_task_run().clear_reservation(self)
         self.agent_id = None

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -181,7 +181,7 @@ class Unit(ABC):
 
     def clear_assigned_agent(self) -> None:
         """Clear the agent that is assigned to this unit"""
-        logger.debug(f"Clearing assigned agent {self.agent} from {self}")
+        logger.debug(f"Clearing assigned agent {self.agent_id} from {self}")
         self.db.clear_unit_agent_assignment(self.db_id)
         self.get_task_run().clear_reservation(self)
         self.agent_id = None

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -798,18 +798,11 @@ class Supervisor:
             db_status = agent.get_status()
             if agent.has_updated_status.is_set():
                 continue  # Incoming info may be stale if we have new info to send
-            if status == AgentState.STATUS_NONE:
-                # Stale or reconnect, send a status update
-                self._send_status_update(self.agents[agent_id])
-                continue
             if status != db_status:
-                if db_status in AgentState.complete():
-                    logger.info(
-                        f"Got updated status {status} when already final: {agent.db_status}"
-                    )
-                    continue
-                elif status == AgentState.STATUS_COMPLETED:
-                    continue  # COMPLETED can only be marked locally
+                if status != AgentState.STATUS_DISCONNECT:
+                    # Stale or reconnect, send a status update
+                    self._send_status_update(self.agents[agent_id])
+                    continue  # Only DISCONNECT can be marked remotely, rest are mismatch
                 agent.update_status(status)
         pass
 


### PR DESCRIPTION
# Overview
Thanks to @jxmsML, I was able to identify a few state transitions that were occurring that shouldn't have been happening. Each were problematic, and in total they meant that human-human chat tasks would freeze up after the first occurrence of two people leaving a chat at roughly the same time (within 2 mins of each other, the average time for MTurk to mark a return). 

This fix addresses the two following issues:
- The routing server would sometimes have stale information, and this information was getting sent back to the main mephisto server and putting the wrong state up. 
  - Now this is updated to only check for DISCONNECT changes, as this is the only status that the server will ever have that Mephisto needs to read, and anything else causes Mephisto to send a status update to sync the server.
- When a task was returned, the `MTurkUnit` that marked this return would move directly from `ASSIGNED` to `LAUNCHED`, as this is the MTurk HIT status that we use to note a return event in the first place.
  - We now defer the local transition from `ASSIGNED` back to `LAUNCHED`, as the `Blueprint` will decide shortly after the `RETURNED` status is set whether the `Unit` needs to be expired. If it does, the `Unit` will end up in an `EXPIRED` status, otherwise the `Blueprint` will call `clear_assigned_agent` to move the `Unit` from `ASSIGNED` back to `LAUNCHED`

## Testing
I was able to reproduce these state issues before this set of changes, but can no longer recreate them on this branch.