### PR TITLE
Endpoint for users to review all data at once in mephisto review

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -33,6 +33,7 @@ def web():
 @click.option("--csv-headers/--no-csv-headers", default=False)
 @click.option("--json/--csv", default=False)
 @click.option("--db", "database_task_name", type=(str), default=None)
+@click.option("--all/--one-by-one", "all_data", default=False)
 @click.option("-d", "--debug", type=(bool), default=False)
 def review(
     review_app_dir,
@@ -42,6 +43,7 @@ def review(
     csv_headers,
     json,
     database_task_name,
+    all_data,
     debug,
 ):
     """Launch a local review UI server. Reads in rows froms stdin and outputs to either a file or stdout."""
@@ -70,6 +72,7 @@ def review(
         csv_headers,
         json,
         database_task_name,
+        all_data,
         debug,
     )
 

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -85,6 +85,23 @@ def run(
             ready_for_next.wait()
         finished = True
 
+    def consume_all_data():
+
+        if json:
+            data_source = json_reader(iter(sys.stdin.readline, ""))
+        else:
+            data_source = csv.reader(iter(sys.stdin.readline, ""))
+
+        if csv_headers:
+            next(data_source)
+
+        data_point_list = []
+        index = 0
+        for row in data_source:
+            data_point_list[index] = row
+            index += 1
+        return data_point_list
+
     @app.route("/data_for_current_task")
     def data():
         global current_data, finished
@@ -97,6 +114,15 @@ def run(
 
         return jsonify(
             {"finished": finished, "data": current_data if not finished else None}
+        )
+
+    @app.route("/all_data_for_current_task")
+    def data():
+        data_point_list = consume_all_data()
+        return jsonify(
+            {"data_points": data_point_list, "length": data_point_list.length}
+            if data_point_list is not None
+            else {error: "No data points for current task"}
         )
 
     @app.route("/submit_current_task", methods=["GET", "POST"])

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -125,10 +125,7 @@ def run(
     def refresh_all_list_data():
         global all_data_list, datalist_update_time
         data_source = mephistoDBReader()
-        all_data_list = []
-
-        for row in data_source:
-            all_data_list.append(row)
+        all_data_list = list(data_source)
         datalist_update_time = datetime.now()
 
     @app.route("/data_for_current_task")
@@ -221,10 +218,7 @@ def run(
             if csv_headers:
                 next(data_source)
 
-        all_data_list = []
-
-        for row in data_source:
-            all_data_list.append(row)
+        all_data_list = list(data_source)
         datalist_update_time = datetime.now()
 
     if not all_data:

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -91,15 +91,13 @@ def run(
             data_source = json_reader(iter(sys.stdin.readline, ""))
         else:
             data_source = csv.reader(iter(sys.stdin.readline, ""))
-
-        if csv_headers:
-            next(data_source)
+            if csv_headers:
+                print("CSV Headers detected")
+                next(data_source)
 
         data_point_list = []
-        index = 0
         for row in data_source:
-            data_point_list[index] = row
-            index += 1
+            data_point_list.append(row)
         return data_point_list
 
     @app.route("/data_for_current_task")
@@ -117,11 +115,11 @@ def run(
         )
 
     @app.route("/all_data_for_current_task")
-    def data():
+    def all_data():
         data_point_list = consume_all_data()
         return jsonify(
-            {"data_points": data_point_list, "length": data_point_list.length}
-            if data_point_list is not None
+            {"data_points": data_point_list, "length": len(data_point_list)}
+            if data_point_list is not None and len(data_point_list) > 0
             else {error: "No data points for current task"}
         )
 


### PR DESCRIPTION
This feature allows users to pull all data points from a review source at once to their front-end via our ```mephisto review``` server with a new endpoint with the URL ```/all_data```.

For example if the data source consisted the following ```data.csv``` file:
```
This is good text, row1
This is bad text, row2
```
The new endpoint will return the following response when queried:
<img width="296" alt="response" src="https://user-images.githubusercontent.com/13241633/105566973-01b43280-5cfd-11eb-910d-2ea578b2d60e.png">


To access this endpoint users must include a ```--all``` flag in their ```mephisto review``` command.
This can be in conjunction with the ```--db``` flag such as:
```
mephisto review my-review/build -o results.csv --db html-static-task-example --all
```
or in conjunction with standard input such as:
```
cat data.csv | mephisto review my-review/build -o results.csv --all
```

If the ```--all``` flag is not set the endpoint will return an error.
Conversely, If the ```--all``` flag is set and other endpoints for reviewing individual tasks are accessed they will also return error as a safety measure

Users can now query the endpoint ```/all_data``` for a list of all data points related to the task that they are currently reviewing

Users can also add parameters to the query such that they get a paginated result using the params ```page``` and ```results_per_page```

Such a query can look like this: ```/all_data?page=2&results_per_page=3```

If users do not specify a value for results per page the server will default to 10 results per page and if neither parameter is provided the server returns all results.

