### PR TITLE
Add a Dockerfile to encapsulate Mephisto in a container + add matrix version testing workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/node_modules
+**/.git
+**/.mypy_cache
+**/build/*
+data/*
+**/*.mp4

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -14,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  mephisto-check:
+  check:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -18,6 +18,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # Run all combos, don't skip on failures
       matrix:
         # from: https://hub.docker.com/r/nikolaik/python-nodejs
         python-version: ["3.9", "3.8", "3.7", "3.6"]

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -37,3 +37,8 @@ jobs:
       - name: Check that Mephisto was installed correctly
         run: |
           docker run mephisto
+
+      - name: Run npm install for static_html_task
+        run: |
+          cd /mephisto/mephisto/abstractions/blueprints/static_html_task/source
+          npm install

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -5,6 +5,7 @@ name: Docker Testing Matrix
 # Controls when the action will run.
 on:
   schedule:
+    # Run once a week, in this case on Sundays
     - cron: "0 0 * * 0"
 
   # Allows you to run this workflow manually from the Actions tab
@@ -13,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  mephisto-check:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
@@ -21,7 +22,7 @@ jobs:
         # from: https://hub.docker.com/r/nikolaik/python-nodejs
         python-version: ["3.9", "3.8", "3.7", "3.6"]
         nodejs-version: ["15", "14", "12", "10"]
-        image-prefix: ["", "-slim"]
+        image-suffix: ["", "-slim"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -29,8 +30,8 @@ jobs:
       - uses: actions/checkout@v2
 
       # Runs a single command using the runners shell
-      - name: Build docker image
-        run: docker build -t mephisto --build-arg BASE_TAG=python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-prefix }} .
+      - name: Build docker image - python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-suffix }}
+        run: docker build -t mephisto --build-arg BASE_TAG=python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-suffix }} .
 
       # Runs a set of commands using the runners shell
       - name: Check that Mephisto was installed correctly

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -40,5 +40,4 @@ jobs:
 
       - name: Run npm install for static_html_task
         run: |
-          cd /mephisto/mephisto/abstractions/blueprints/static_html_task/source
-          npm install
+          docker run mephisto bash -c 'cd /mephisto/mephisto/abstractions/blueprints/static_html_task/source && npm install'

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Docker Testing Matrix
+
+# Controls when the action will run.
+on:
+  schedule:
+    - cron: "0 0 * * 0"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # from: https://hub.docker.com/r/nikolaik/python-nodejs
+        python-version: ["3.9", "3.8", "3.7", "3.6"]
+        nodejs-version: ["15", "14", "12", "10"]
+        image-prefix: ["", "-slim"]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Build docker image
+        run: docker build -t mephisto --build-arg BASE_TAG=python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-prefix }} .
+
+      # Runs a set of commands using the runners shell
+      - name: Check that Mephisto was installed correctly
+        run: |
+          docker run mephisto

--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build docker image - python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-suffix }}
         run: docker build -t mephisto --build-arg BASE_TAG=python${{ matrix.python-version }}-nodejs${{ matrix.nodejs-version }}${{ matrix.image-suffix }} .
 
+      - name: Print out version numbers
+        run: docker run mephisto bash -c 'python --version && node --version && npm --version'
+
       # Runs a set of commands using the runners shell
       - name: Check that Mephisto was installed correctly
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ SHELL ["/bin/bash", "-c"]
 RUN echo $'core: \n  main_data_directory: /mephisto/data' >> ~/.mephisto/config.yml
 
 RUN cd /mephisto && pip install -e .
+RUN mephisto check # Run mephisto check so a mock requester gets created
 CMD mephisto check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Using the -slim version below for minimal size. You may want to
 # remove -slim, or switch to -alpine if encountering issues
+ARG BASE_TAG=python3.9-nodejs15-slim
+ARG BASE_IMAGE=nikolaik/python-nodejs:$BASE_TAG
 
-FROM nikolaik/python-nodejs:python3.9-nodejs15-slim
+FROM $BASE_IMAGE
 
 COPY . /mephisto
 RUN mkdir ~/.mephisto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Using the -slim version below for minimal size. You may want to
+# remove -slim, or switch to -alpine if encountering issues
+
+FROM nikolaik/python-nodejs:python3.9-nodejs15-slim
+
+COPY . /mephisto
+RUN mkdir ~/.mephisto
+
+# Write the mephisto config file manually for now to avoid prompt.
+# For bash-style string $ expansion for newlines,
+# we need to switch the shell to bash:
+SHELL ["/bin/bash", "-c"]
+RUN echo $'core: \n  main_data_directory: /mephisto/data' >> ~/.mephisto/config.yml
+
+RUN cd /mephisto && pip install -e .
+CMD mephisto check

--- a/mephisto/abstractions/blueprints/static_html_task/source/package.json
+++ b/mephisto/abstractions/blueprints/static_html_task/source/package.json
@@ -13,9 +13,9 @@
     "bootstrap": "^4.3.1",
     "mephisto-task": "^1.0.14",
     "rc-slider": "^8.6.3",
-    "react": "^16.5.2",
+    "react": "16.13.1",
     "react-bootstrap": "^0.32.4",
-    "react-dom": "^16.5.2",
+    "react-dom": "16.13.1",
     "react-table": "^6.8.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Overview

Adds a `Dockerfile` and a `.dockerignore` file to the repo.

The default base image being used is [nikolaik/python-nodejs](https://hub.docker.com/r/nikolaik/python-nodejs), with the tags for Python 3.9 and Node.JS 15.

One advantage of having this Dockerfile and a containerized setup is that it should allow us to quickly alter the python and node versions and check if Mephisto works across different python/node version numbers. We can conceivably add a matrix of these tests into a periodic testing workflow. [**I've set up a workflow already here**](https://github.com/facebookresearch/Mephisto/actions/runs/514175332). (I think we can have a better assertion at the end, or maybe `mephisto check` as it is is fine).

Another advantage I imagine is that folks can use the Dockerfile to create repro situations for bug reports and tests.

## Usage:

### Setup the image
Note: Using the `.dockerignore` file, I was able to exclude unneeded files from the build context to minimize the the size to around 12.9MB for faster builds. Mainly involved ignore `node_modules`, `.git` folder, and cache folders.

```console
$ docker build -t mephisto .
...
Successfully tagged mephisto:latest
```

### Run Mephisto from within the container

```console
$ docker run mephisto
Mephisto seems to be set up correctly.
```

```console
$ docker run mephisto bash -c 'mephisto requesters'

  requester_id  provider_type    requester_name    registered
--------------  ---------------  ----------------  ------------
             1  mock             MOCK_REQUESTER    False
```

Once #375 is resolved, we can also run tasks directly out of the container, bound to a port on the local machine:

```console
$ docker run -p 3000:3000 mephisto bash -c 'cd /mephisto/examples/simple_static_task && python static_test_script.py'
...
Listening on 3000
...
```