### PR TITLE
Resolve MTurkUnit expiration bugs

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -175,6 +175,9 @@ class MTurkUnit(Unit):
                     # mark the agent as having returned the HIT, to
                     # free any running tasks and have Blueprint decide on cleanup.
                     agent.update_status(AgentState.STATUS_RETURNED)
+                if external_status == AssignmentState.EXPIRED:
+                    # If we're expired, then it won't be doable, and we should update
+                    self.set_db_status(external_status)
             else:
                 self.set_db_status(external_status)
 


### PR DESCRIPTION
# Overview
A combination of two bugs was leading to improper outcomes when expiring a task with `Ctrl-C`. First, `MTurkUnit` wasn't properly updating from the `CREATED` status to the `ASSIGNED` status unless a db status load occurred elsewhere. The second issue was that moving from `ASSIGNED` to `EXPIRED` didn't trigger the same return event that it did when moving from `ASSIGNED` to `LAUNCHED`, preventing running assignments from marking and exiting properly. The combination of these two bugs led to some completed tasks being locally marked as expired, and preventing some workers from being able to submit complete work after a `Ctrl-C` was triggered.

# Resolution
To resolve the lack of `CREATED` state change, `MTurkUnit`'s `get_status` method now calls the super method in when currently in `CREATED`, forcing that refresh using the base logic.
For triggering a `RETURNED` event, the logic for this is extended to include the transition from `ASSIGNED` to `EXPIRED`, however the new transition should still set the unit's db status (rather than deferring to the blueprint to decide whether to expire or make available again) as we know the outcome is `EXPIRED`.

# Testing
Launched tasks in MTurk sandbox, noted I could now get a proper return event after expiring hits, and could properly exit on a double-return event. Unit tests still passing