### PR TITLE
[WIP] Print balance (or other arbitrary information) at the start of mTurk runs

### DIFF
--- a/mephisto/abstractions/crowd_provider.py
+++ b/mephisto/abstractions/crowd_provider.py
@@ -123,6 +123,10 @@ class CrowdProvider(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def print_banner_on_start(self) -> str:
+        return ""
+
+    @abstractmethod
     def cleanup_resources_from_task_run(
         self, task_run: "TaskRun", server_url: str
     ) -> None:

--- a/mephisto/abstractions/providers/mock/mock_provider.py
+++ b/mephisto/abstractions/providers/mock/mock_provider.py
@@ -73,6 +73,9 @@ class MockProvider(CrowdProvider):
         """Mocks don't do any initialization"""
         return None
 
+    def print_banner_on_start(self):
+        return f"============================\nStarting mock provider\n============================\n"
+
     def cleanup_resources_from_task_run(
         self, task_run: "TaskRun", server_url: str
     ) -> None:

--- a/mephisto/abstractions/providers/mturk/mturk_provider.py
+++ b/mephisto/abstractions/providers/mturk/mturk_provider.py
@@ -20,6 +20,7 @@ from mephisto.abstractions.providers.mturk.mturk_utils import (
     setup_sns_topic,
     delete_sns_topic,
     delete_qualification,
+    get_requester_balance,
 )
 from mephisto.operations.registry import register_mephisto_abstraction
 from dataclasses import dataclass, field
@@ -132,6 +133,12 @@ class MTurkProvider(CrowdProvider):
         client = self._get_client(requester._requester_name)
         hit_type_id = create_hit_type(client, task_config, qualifications)
         self.datastore.register_run(task_run_id, arn_id, hit_type_id, config_dir)
+
+    def print_banner_on_start(self, task_run: "TaskRun") -> str:
+        requester = cast("MTurkRequester", task_run.get_requester())
+        client = self._get_client(requester._requester_name)
+        balance = get_requester_balance(client)
+        return f"============================\nBalance: {balance}\n============================\n"
 
     def cleanup_resources_from_task_run(
         self, task_run: "TaskRun", server_url: str

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -245,6 +245,7 @@ class Operator:
             provider.setup_resources_for_task_run(
                 task_run, run_config, shared_state, task_url
             )
+            print(provider.print_banner_on_start(task_run))
 
             initialization_data_array = blueprint.get_initialization_data()
 


### PR DESCRIPTION
- Adds an abstract method `print_banner_on_start(self, task_run)` to the `CrowdProvider` class.
- Implements it for the `MTurkProvider` (and via inheritance also `MTurkSandboxProvider`) to print out balance information at the start of a run.

```console
$ python static_test_script.py mephisto/architect=heroku mephisto.provider.requester_name=mturk
...
[2021-01-28 00:22:43,290][sh.command][INFO] - <Command '/bin/rm -rf /Users/tikir/mephisto/data/data/runs/NO_PROJECT/361/build/heroku_server_html-static-task-example_361', pid 40240>: process completed
[2021-01-28 00:22:43,323][botocore.credentials][INFO] - Found credentials in shared credentials file: ~/.aws/credentials
============================
Balance: 32644.93
============================

[2021-01-28 00:22:43,762][mephisto.operations.supervisor][INFO] - Sending alive
[2021-01-28 00:22:43,763][mephisto.operations.supervisor][INFO] - Sending alive
```