### PR TITLE
Fixing race condition for MTurk qualification creation

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -258,7 +258,9 @@ class MTurkDatastore:
     ) -> None:
         """
         Create a mapping between mephisto qualification name and mturk
-        qualification details in the local datastore
+        qualification details in the local datastore.
+
+        Repeat entries with the same `qualification_name` will be idempotent
         """
         try:
             with self.table_access_condition, self._get_connection() as conn:
@@ -280,6 +282,7 @@ class MTurkDatastore:
                 return None
         except sqlite3.IntegrityError as e:
             if is_unique_failure(e):
+                # Ignore attempt to add another mapping for an existing key
                 qual = self.get_qualification_mapping(qualification_name)
                 logger.debug(
                     f"Multiple mturk mapping creations for qualification {qualification_name}. "

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -14,8 +14,13 @@ from datetime import datetime
 
 from botocore.exceptions import ClientError
 from botocore.exceptions import ProfileNotFound
+from mephisto.abstractions.databases.local_database import is_unique_failure
 
 from typing import Dict, Any, Optional
+
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
 
 MTURK_REGION_NAME = "us-east-1"
 
@@ -255,23 +260,47 @@ class MTurkDatastore:
         Create a mapping between mephisto qualification name and mturk
         qualification details in the local datastore
         """
-        with self.table_access_condition, self._get_connection() as conn:
-            c = conn.cursor()
-            c.execute(
-                """INSERT INTO qualifications(
-                    qualification_name,
-                    requester_id,
-                    mturk_qualification_name,
-                    mturk_qualification_id
-                ) VALUES (?, ?, ?, ?);""",
-                (
-                    qualification_name,
-                    requester_id,
-                    mturk_qualification_name,
-                    mturk_qualification_id,
-                ),
-            )
-            return None
+        try:
+            with self.table_access_condition, self._get_connection() as conn:
+                c = conn.cursor()
+                c.execute(
+                    """INSERT INTO qualifications(
+                        qualification_name,
+                        requester_id,
+                        mturk_qualification_name,
+                        mturk_qualification_id
+                    ) VALUES (?, ?, ?, ?);""",
+                    (
+                        qualification_name,
+                        requester_id,
+                        mturk_qualification_name,
+                        mturk_qualification_id,
+                    ),
+                )
+                return None
+        except sqlite3.IntegrityError as e:
+            if is_unique_failure(e):
+                qual = self.get_qualification_mapping(qualification_name)
+                logger.debug(
+                    f"Multiple mturk mapping creations for qualification {qualification_name}. "
+                    f"Found existing one: {qual}. "
+                )
+                cur_requester_id = qual["requester_id"]
+                cur_mturk_qualification_name = qual["mturk_qualification_name"]
+                cur_mturk_qualification_id = qual["mturk_qualification_id"]
+                if cur_requester_id != requester_id:
+                    logger.warn(
+                        f"MTurk Qualification mapping create for {qualification_name} under requester "
+                        f"{requester_id}, already exists under {cur_requester_id}."
+                    )
+                if cur_mturk_qualification_name != mturk_qualification_name:
+                    logger.warn(
+                        f"MTurk Qualification mapping create for {qualification_name} with mturk name "
+                        f"{mturk_qualification_name}, already exists under {cur_mturk_qualification_name}."
+                    )
+                return None
+            else:
+                raise e
 
     def get_qualification_mapping(
         self, qualification_name: str

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -289,12 +289,12 @@ class MTurkDatastore:
                 cur_mturk_qualification_name = qual["mturk_qualification_name"]
                 cur_mturk_qualification_id = qual["mturk_qualification_id"]
                 if cur_requester_id != requester_id:
-                    logger.warn(
+                    logger.warning(
                         f"MTurk Qualification mapping create for {qualification_name} under requester "
                         f"{requester_id}, already exists under {cur_requester_id}."
                     )
                 if cur_mturk_qualification_name != mturk_qualification_name:
-                    logger.warn(
+                    logger.warning(
                         f"MTurk Qualification mapping create for {qualification_name} with mturk name "
                         f"{mturk_qualification_name}, already exists under {cur_mturk_qualification_name}."
                     )


### PR DESCRIPTION
# Overview
A race condition exists if creating a new qualification for the first time live, when no worker has been assigned the qualification before. This became evident in @mojtaba-komeili's run, wherein a qualification is assigned the moment a worker accepts a task for the first time. Multiple workers accepting the task all at once would lead Mephisto to think it needed to create multiple qualifications. This was never surfaced before, as most qualification flows would grant at the end of onboarding or the task, and that made it much less likely the first few workers to get the qualification would get it at the exact same time.

# Implementation
If the insert fails due to a uniqueness break, we now treat it as a no-op, and warn the user if there's any strong differences between the inserted qual and the one that's actually stored. As we expect that Mephisto users will be assigning by the given `qualification_name` and not using the mturk qualification ids directly (in that we don't even expose these without asking for them), it's likely that this is the desired behavior under all circumstances.

# Testing
Added a test for idempotency, as well as other things for qualification mappings.