### PR TITLE
Added ability to search data during mephisto review in "all" mode

### DIFF
--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -278,6 +278,11 @@ def run(
         This route returns the list of all data being reviewed if the app is in "all" mode.
         Otherwise this route returns the id and data of the item currently being reviewed in "one-by-one" or standard mode.
         The id in the response refers to the index (beginning at 0) of the item being reviewed in the list of all items being reviewed.
+        Params:
+            page: 1 indexed page number for results
+            results_per_page: number of results to show per page, must be positive integer
+            filters: string representing keywords or senteces results must contain.
+                Filters must be comma separated and spaced must be denoted by '%20'
         """
         global counter, current_data, all_data_list, finished
         if all_data:

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -14,6 +14,7 @@ import sys
 import time
 import threading
 import urllib.parse
+import collections
 
 
 def run(
@@ -37,6 +38,10 @@ def run(
     MODE = "ALL" if all_data else "OBO"
     RESULT_SUCCESS = "SUCCESS"
     RESULT_ERROR = "ERROR"
+
+    DataQueryResult = collections.namedtuple(
+        "DataQueryResult", ["data_list", "total_pages"]
+    )
 
     if not debug or output == "":
         # disable noisy logging of flask, https://stackoverflow.com/a/18379764
@@ -100,7 +105,11 @@ def run(
     def consume_all_data(page, results_per_page=RESULTS_PER_PAGE_DEFAULT, filters=None):
         """
         For use in "all" mode.
-        Returns a filtered list of all data or a page of all data.
+        Returns:
+            A DataQueryResult type namedtuple consisting of a filtered list of all data or a page of all data
+            as well as the total pages of data available.
+            The list of data is stored in DataQueryResult.data_list.
+            The total number of pages is stored in DataQueryResult.total_pages.
         Params:
             page: 1 indexed page number integer
             results_per_page: maximum number of results per page
@@ -116,14 +125,6 @@ def run(
 
         first_index = (page - 1) * results_per_page if paginated else 0
 
-        filtered_data_list = all_data_list
-        if type(filters) is list:
-            filtered_data_list = [
-                item
-                for item in all_data_list
-                if all(word.lower() in str(item["data"]).lower() for word in filters)
-            ]
-
         if database_task_name is not None:
             # If differnce in time since the last update to the data list is over 5 minutes, update list again
             # This can only be done for usage with mephistoDB as standard input is exhausted when originally creating the list
@@ -134,18 +135,31 @@ def run(
             ):
                 refresh_all_list_data()
 
+        filtered_data_list = all_data_list
+        if type(filters) is list:
+            filtered_data_list = [
+                item
+                for item in all_data_list
+                if all(word.lower() in str(item["data"]).lower() for word in filters)
+            ]
+        list_len = len(filtered_data_list)
+        total_pages = list_len / results_per_page if paginated else 1
+
         if paginated:
-            list_len = len(filtered_data_list)
             if first_index > list_len - 1:
-                return []
-            results_per_page = (
-                min(first_index + results_per_page, list_len) - first_index
-            )
-            if results_per_page < 0:
-                return []
-            return filtered_data_list[first_index : first_index + results_per_page]
-        else:
-            return filtered_data_list
+                filtered_data_list = []
+            else:
+                results_per_page = (
+                    min(first_index + results_per_page, list_len) - first_index
+                )
+                if results_per_page < 0:
+                    filtered_data_list = []
+                else:
+                    filtered_data_list = filtered_data_list[
+                        first_index : first_index + results_per_page
+                    ]
+
+        return DataQueryResult(filtered_data_list, total_pages)
 
     def refresh_all_list_data():
         """For use in "all" mode. Refreshes all data list when the data source is mephistoDB, allowing for new entries in the db to be included in the review"""
@@ -298,14 +312,13 @@ def run(
                 filters = filters_str.split(",")
                 filters = [filt.strip() for filt in filters]
             try:
-                data_point_list = consume_all_data(page, results_per_page, filters)
-                total_pages = (
-                    len(all_data_list) / results_per_page
-                    if type(page) is int and page > 0
-                    else 1
-                )
+                data = consume_all_data(page, results_per_page, filters)
                 return jsonify(
-                    {"data": data_point_list, "mode": MODE, "total_pages": total_pages}
+                    {
+                        "data": data.data_list,
+                        "mode": MODE,
+                        "total_pages": data.total_pages,
+                    }
                 )
             except AssertionError as ae:
                 print(f"Error: {ae.args[0]}")

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -13,6 +13,7 @@ import csv
 import sys
 import time
 import threading
+import urllib.parse
 
 
 def run(
@@ -293,7 +294,7 @@ def run(
             filters_str = request.args.get("filters", default=None, type=str)
             filters = None
             if type(filters_str) is str:
-                filters_str = filters_str.replace("%20", " ")
+                filters_str = urllib.parse.unquote(filters_str)
                 filters = filters_str.split(",")
                 filters = [filt.strip() for filt in filters]
             try:

--- a/packages/cra-template-mephisto-review/package.json
+++ b/packages/cra-template-mephisto-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mephisto-review",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "react",
     "create-react-app",

--- a/packages/cra-template-mephisto-review/template.json
+++ b/packages/cra-template-mephisto-review/template.json
@@ -3,7 +3,7 @@
     "dependencies": {
       "@blueprintjs/core": "^3.38.1",
       "@blueprintjs/popover2": "^0.2.0",
-      "mephisto-review-hook": "^2.0.0",
+      "mephisto-review-hook": "^2.0.1",
       "react-router-dom": "^5.2.0"
     },
     "scripts": {

--- a/packages/cra-template-mephisto-review/template.json
+++ b/packages/cra-template-mephisto-review/template.json
@@ -2,6 +2,7 @@
   "package": {
     "dependencies": {
       "@blueprintjs/core": "^3.38.1",
+      "@blueprintjs/popover2": "^0.2.0",
       "mephisto-review-hook": "^2.0.0",
       "react-router-dom": "^5.2.0"
     },

--- a/packages/cra-template-mephisto-review/template/src/GridRenderer.css
+++ b/packages/cra-template-mephisto-review/template/src/GridRenderer.css
@@ -12,13 +12,27 @@
   margin-top: 48px;
 }
 
+.grid-renderer-no-data {
+  max-width: 50%;
+  max-height: 300px;
+  margin: 12px 0;
+  overflow: auto;
+}
+
+.search-box {
+  margin: 12px 0;
+  width: 50%;
+}
+
 .grid-container {
   display: grid;
   grid-template-rows: auto;
   grid-template-columns: 100%;
   grid-row-gap: 18px;
   grid-column-gap: 6px;
-  padding: 32px 32px;
+  padding: 12px 32px;
+  margin: 12px 0px;
+  min-width: 75vw;
   max-width: 100vw;
 }
 

--- a/packages/cra-template-mephisto-review/template/src/GridRenderer.css
+++ b/packages/cra-template-mephisto-review/template/src/GridRenderer.css
@@ -30,8 +30,8 @@
   grid-template-columns: 100%;
   grid-row-gap: 18px;
   grid-column-gap: 6px;
-  padding: 12px 32px;
-  margin: 12px 0px;
+  padding: 12px 12px;
+  margin: 12px 12px;
   min-width: 75vw;
   max-width: 100vw;
 }
@@ -53,8 +53,8 @@
 }
 
 .grid-item-text {
-  max-height: 100px;
-  max-width: 100%;
+  height: 100px;
+  width: 100%;
   margin-bottom: 12px;
   overflow: auto;
 }

--- a/packages/cra-template-mephisto-review/template/src/GridRenderer.jsx
+++ b/packages/cra-template-mephisto-review/template/src/GridRenderer.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from "react";
 import { Redirect } from "react-router-dom";
 import { useMephistoReview } from "mephisto-review-hook";
-import { H5, H3, H2, H1 } from "@blueprintjs/core";
+import { H4, H3, H2, H1, InputGroup } from "@blueprintjs/core";
+import { Tooltip2 } from "@blueprintjs/popover2";
 import GridView from "./GridView";
 import Pagination from "./components/Pagination";
 import "./GridRenderer.css";
@@ -9,6 +10,9 @@ import "./GridRenderer.css";
 function GridRenderer() {
   const resultsPerPage = 9;
   const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState("");
+  const [filterTimeout, setFilterTimeout] = useState(null);
+
   const {
     data,
     isFinished,
@@ -16,7 +20,19 @@ function GridRenderer() {
     error,
     mode,
     totalPages,
-  } = useMephistoReview({ page, resultsPerPage });
+  } = useMephistoReview({ page, resultsPerPage, filters });
+
+  const delaySetFilters = (filtersStr) => {
+    if (filterTimeout) {
+      clearTimeout(filterTimeout);
+    }
+
+    setFilterTimeout(
+      setTimeout(() => {
+        setFilters(filtersStr);
+      }, 2000)
+    );
+  };
 
   if (mode === "OBO") return <Redirect to={`/${data && data.id}`} />;
   return (
@@ -32,8 +48,24 @@ function GridRenderer() {
             <H2>
               <b>Welcome to Mephisto Review</b>
             </H2>
-            <H3>Please click on the following data cards to review them:</H3>
+            {data && data.length > 0 && (
+              <H3>Please click on the following data cards to review them:</H3>
+            )}
           </div>
+          <Tooltip2
+            className="search-box"
+            content="Separate multiple filters with commas"
+          >
+            <InputGroup
+              asyncControl={true}
+              leftIcon="search"
+              large={true}
+              round={true}
+              onChange={(event) => delaySetFilters(event.target.value)}
+              placeholder="Filter data..."
+              value={filters}
+            />
+          </Tooltip2>
           {data && data.length > 0 ? (
             <>
               <GridView data={data} />
@@ -44,13 +76,15 @@ function GridRenderer() {
               />
             </>
           ) : (
-            <H5 className="grid-renderer-header">
-              Sorry, no data available. Please provide Mephisto Review with some
-              data by running mephisto review with either standard input of a
-              CSV or JSON file or by using the "--db" flag along with the name
-              of a task in mephistoDB as an argument. The task must have valid
-              review data.
-            </H5>
+            <div className="grid-renderer-no-data">
+              <H4>
+                Sorry, no data available. Please provide Mephisto Review with
+                some data by running mephisto review with either standard input
+                of a CSV or JSON file or by using the "--db" flag along with the
+                name of a task in mephistoDB as an argument. The task must have
+                valid review data.
+              </H4>
+            </div>
           )}
         </>
       )}

--- a/packages/cra-template-mephisto-review/template/src/GridRenderer.jsx
+++ b/packages/cra-template-mephisto-review/template/src/GridRenderer.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Redirect } from "react-router-dom";
 import { useMephistoReview } from "mephisto-review-hook";
-import { H4, H3, H2, H1, InputGroup } from "@blueprintjs/core";
+import { H4, H3, H2, H1, InputGroup, Button } from "@blueprintjs/core";
 import { Tooltip2 } from "@blueprintjs/popover2";
 import GridView from "./GridView";
 import Pagination from "./components/Pagination";
@@ -11,6 +11,7 @@ function GridRenderer() {
   const resultsPerPage = 9;
   const [page, setPage] = useState(1);
   const [filters, setFilters] = useState("");
+  const [filtersBuffer, setFiltersBuffer] = useState("");
   const [filterTimeout, setFilterTimeout] = useState(null);
 
   const {
@@ -23,16 +24,29 @@ function GridRenderer() {
   } = useMephistoReview({ page, resultsPerPage, filters });
 
   const delaySetFilters = (filtersStr) => {
+    setFiltersBuffer(filtersStr);
     if (filterTimeout) {
       clearTimeout(filterTimeout);
     }
-
     setFilterTimeout(
       setTimeout(() => {
         setFilters(filtersStr);
-      }, 2000)
+      }, 3000)
     );
   };
+
+  const setFiltersImmediately = () => {
+    if (filterTimeout) {
+      clearTimeout(filterTimeout);
+    }
+    setFilters(filtersBuffer);
+  };
+
+  const searchButton = (
+    <Button round={true} onClick={setFiltersImmediately}>
+      Search
+    </Button>
+  );
 
   if (mode === "OBO") return <Redirect to={`/${data && data.id}`} />;
   return (
@@ -57,13 +71,16 @@ function GridRenderer() {
             content="Separate multiple filters with commas"
           >
             <InputGroup
-              asyncControl={true}
               leftIcon="search"
               large={true}
               round={true}
               onChange={(event) => delaySetFilters(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") setFiltersImmediately();
+              }}
               placeholder="Filter data..."
-              value={filters}
+              value={filtersBuffer}
+              rightElement={searchButton}
             />
           </Tooltip2>
           {data && data.length > 0 ? (

--- a/packages/cra-template-mephisto-review/template/src/GridView.jsx
+++ b/packages/cra-template-mephisto-review/template/src/GridView.jsx
@@ -6,9 +6,12 @@ function GridView({ data }) {
   return data && data.length > 0 ? (
     <div className="grid-container">
       {data.map((item) => (
-        <Link to={`/${item.id}`} style={{ textDecoration: "none" }}>
+        <Link
+          to={`/${item.id}`}
+          style={{ textDecoration: "none" }}
+          key={item.id}
+        >
           <Card
-            key={item.id}
             interactive={true}
             elevation={Elevation.TWO}
             className="grid-item"

--- a/packages/cra-template-mephisto-review/template/src/components/components.css
+++ b/packages/cra-template-mephisto-review/template/src/components/components.css
@@ -1,3 +1,3 @@
 .pagination {
-  margin-bottom: 36px;
+  margin: 12px 0;
 }

--- a/packages/cra-template-mephisto-review/template/src/index.js
+++ b/packages/cra-template-mephisto-review/template/src/index.js
@@ -7,6 +7,7 @@ import ItemReview from "./ItemRenderer";
 import "normalize.css/normalize.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 
 ReactDOM.render(
   <React.StrictMode>

--- a/packages/mephisto-review-hook/package.json
+++ b/packages/mephisto-review-hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mephisto-review-hook",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "build/bundle.js",
   "scripts": {

--- a/packages/mephisto-review-hook/src/index.js
+++ b/packages/mephisto-review-hook/src/index.js
@@ -24,7 +24,7 @@ function useMephistoReview({
       ? `/data/${taskId}`
       : `/data?${page ? "page=" + page : ""}${
           resultsPerPage ? "&results_per_page=" + resultsPerPage : ""
-        }${filters ? "&filters=" + filters.replace(" ", "%20") : ""}`;
+        }${filters ? "&filters=" + encodeURIComponent(filters) : ""}`;
     setIsLoading(true);
     fetch(DATA_URL, { method: "GET" })
       .catch((err) => setError({ type: "DATA_RETRIEVAL", error: err }))

--- a/packages/mephisto-review-hook/src/index.js
+++ b/packages/mephisto-review-hook/src/index.js
@@ -7,6 +7,7 @@ function useMephistoReview({
   taskId,
   page,
   resultsPerPage,
+  filters,
 } = {}) {
   const [data, setData] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -21,7 +22,9 @@ function useMephistoReview({
     }
     const DATA_URL = taskId
       ? `/data/${taskId}`
-      : `/data?page=${page}&results_per_page=${resultsPerPage}`;
+      : `/data?${page ? "page=" + page : ""}${
+          resultsPerPage ? "&results_per_page=" + resultsPerPage : ""
+        }${filters ? "&filters=" + filters.replace(" ", "%20") : ""}`;
     setIsLoading(true);
     fetch(DATA_URL, { method: "GET" })
       .catch((err) => setError({ type: "DATA_RETRIEVAL", error: err }))
@@ -29,7 +32,7 @@ function useMephistoReview({
       .then((data) => setData(data))
       .catch((err) => setError({ type: "DATA_PARSE", error: err }))
       .then(() => setIsLoading(false));
-  }, [taskId, page, resultsPerPage]);
+  }, [taskId, page, resultsPerPage, filters]);
 
   const submitData = useCallback(
     async (data) => {


### PR DESCRIPTION
### Mephisto review now supports filtering review data by keywords or sentences

The following changes are only applicable when running mephisto review in ```all``` mode.
For example, using a command such as:
```
mephisto review new-review/build -o results.csv --db html-static-task-example --all
```

Mephisto review template has been upgraded to include a search bar:
<img width="1792" alt="all_results" src="https://user-images.githubusercontent.com/13241633/107805110-df796780-6d32-11eb-879f-4253dac39fbf.png">

Results are updated two seconds after the user stops typing, they press the enter key or they press the search button.
<img width="1789" alt="filtered_results" src="https://user-images.githubusercontent.com/13241633/107805157-ef914700-6d32-11eb-9f0a-e88e53473765.png">

Multiple filters can be added by separating filters with commas.

Filtered queries are made by appending a ```filters``` parameter to ```/data``` endpoint on the mephisto review server.
Spaces in the filter parameter must be represented by "%20".

Such a query can look like:
```
/data?page=1&results_per_page=2&filters='unit_id':%20'13'
```