### PR TITLE
[FIX] Review server and Review template only serving and rendering string data

### DIFF
--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -15,6 +15,7 @@ import time
 import threading
 import urllib.parse
 import collections
+import math
 
 
 def run(
@@ -72,13 +73,9 @@ def run(
         db = LocalMephistoDB()
         mephisto_data_browser = MephistoDataBrowser(db=db)
 
-        def format_data_for_review(data):
-            contents = data["data"]
-            return f"{data}"
-
         units = mephisto_data_browser.get_units_for_task_name(database_task_name)
         for unit in units:
-            yield format_data_for_review(mephisto_data_browser.get_data_from_unit(unit))
+            yield mephisto_data_browser.get_data_from_unit(unit)
 
     def consume_data():
         """ For use in "one-by-one" or default mode. Runs on a seperate thread to consume mephisto review data line by line and update global variables to temporarily store this data """
@@ -143,7 +140,7 @@ def run(
                 if all(word.lower() in str(item["data"]).lower() for word in filters)
             ]
         list_len = len(filtered_data_list)
-        total_pages = list_len / results_per_page if paginated else 1
+        total_pages = math.ceil(list_len / results_per_page) if paginated else 1
 
         if paginated:
             if first_index > list_len - 1:

--- a/packages/cra-template-mephisto-review/package.json
+++ b/packages/cra-template-mephisto-review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mephisto-review",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/packages/cra-template-mephisto-review/template/src/GridRenderer.css
+++ b/packages/cra-template-mephisto-review/template/src/GridRenderer.css
@@ -9,7 +9,7 @@
 }
 
 .grid-renderer-header {
-  margin-top: 48px;
+  margin-top: 12px;
 }
 
 .grid-renderer-no-data {
@@ -20,7 +20,7 @@
 }
 
 .search-box {
-  margin: 12px 0;
+  margin: 6px 0;
   width: 50%;
 }
 
@@ -30,8 +30,8 @@
   grid-template-columns: 100%;
   grid-row-gap: 18px;
   grid-column-gap: 6px;
-  padding: 12px 12px;
-  margin: 12px 12px;
+  padding: 12px 18px;
+  margin: 6px 0px;
   min-width: 75vw;
   max-width: 100vw;
 }
@@ -53,7 +53,7 @@
 }
 
 .grid-item-text {
-  height: 100px;
+  height: 12vh;
   width: 100%;
   margin-bottom: 12px;
   overflow: auto;

--- a/packages/cra-template-mephisto-review/template/src/GridView.jsx
+++ b/packages/cra-template-mephisto-review/template/src/GridView.jsx
@@ -17,7 +17,7 @@ function GridView({ data }) {
             className="grid-item"
           >
             <div className="grid-item-text">
-              <pre>{item.data}</pre>
+              <pre>{JSON.stringify(item.data)}</pre>
             </div>
             <H4>
               <b>ID: {item.id}</b>

--- a/packages/cra-template-mephisto-review/template/src/ItemRenderer.css
+++ b/packages/cra-template-mephisto-review/template/src/ItemRenderer.css
@@ -9,13 +9,13 @@
 }
 .item {
   margin: 24px 24px;
+  max-width: 75vw;
+  max-height: 75vh;
 }
 
 .item > pre {
   white-space: pre-wrap;
   font-size: 28px;
-  max-width: 100%;
-  max-height: 500px;
   overflow: auto;
 }
 

--- a/packages/cra-template-mephisto-review/template/src/ItemRenderer.jsx
+++ b/packages/cra-template-mephisto-review/template/src/ItemRenderer.jsx
@@ -52,7 +52,7 @@ function App() {
         <>
           <H2>Please review the following data:</H2>
           <Card className="item" elevation={Elevation.TWO}>
-            <pre>{data && data.data}</pre>
+            <pre>{JSON.stringify(data && data.data)}</pre>
           </Card>
           <div className="button-container">
             <Button


### PR DESCRIPTION
Up until now due to recent changes the mephisto review template would only render string data.
This was an issue because when using the --json flag, the server would serve raw json data in its responses and the review app would not render this data.
This issue was not present for csv and mephistoDB data which were served as strings.

Now the review template renders raw json data. As an added bonus mephistoDB data is now served as raw JSON instead of as a string of JSON.