### PR TITLE
Updating usage to to_yaml to fix some structured config bugs

### DIFF
--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -185,7 +185,7 @@ class Operator:
         new_run_id = self.db.new_task_run(
             task_id,
             requester_id,
-            json.dumps(OmegaConf.to_container(run_config, resolve=True)),
+            json.dumps(OmegaConf.to_yaml(run_config)),
             provider_type,
             blueprint_type,
             requester.is_sandbox(),


### PR DESCRIPTION
# Details
In trying to store configurations into the `MephistoDB` for future use, we had been using `OmegaConf.to_container` which seems to not preserve all of the behaviors that are ideal for nested structured configs (in reconstruction). This PR changes to use `to_yaml`. This change should not effect previously saved runs, as both the results of `to_container` and `to_yaml` are valid parameters for the later `OmegaConf.create()` call.

Following discussion in #399, this also removes the `resolve` portion of writing out the configuration, as downstream tasks may want the interpolation and there's no real risk for us including them. We retain storing the yaml rather than using pickles (and getting type safety) as configuration signatures for specific tasks may change over time, and we want the old ones to be properly loadable/examinable.

@ytsheng please see if this resolves the issue you were having in your setup.

# Testing
Unit testing