### PR TITLE
Adding configuration for launching Flask routers, and functionality for using them on Heroku apps

### DIFF
--- a/mephisto/abstractions/architect.py
+++ b/mephisto/abstractions/architect.py
@@ -23,6 +23,18 @@ class ArchitectArgs:
     """Base class for arguments to configure architects"""
 
     _architect_type: str = MISSING
+    server_type: str = field(
+        default="node", metadata={"Help": "Type of server to run, `node` or `flask`"}
+    )
+    server_source_path: str = field(
+        default=MISSING,
+        metadata={
+            "help": (
+                "Optional path to a prepared server directory containing everything "
+                "needed to run a server of the given type. Overrides server type. "
+            )
+        },
+    )
 
 
 class Architect(ABC):

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -100,6 +100,8 @@ class HerokuArchitect(Architect):
         self.task_run = task_run
         self.deploy_name = f"{task_run.get_task().task_name}_{task_run.db_id}"
         self.build_dir = build_dir_root
+        self.server_type = args.architect.server_type
+        self.server_source_path = args.architect.get("server_source_path", None)
 
         # Cache-able parameters
         self.__heroku_app_name: Optional[str] = None
@@ -303,8 +305,11 @@ class HerokuArchitect(Architect):
         print("Building server files...")
         heroku_server_development_root = self.__get_build_directory()
         os.makedirs(heroku_server_development_root)
-        heroku_server_development_path = build_router(
-            heroku_server_development_root, self.task_run
+        heroku_server_development_path = self.server_dir = build_router(
+            heroku_server_development_root,
+            self.task_run,
+            version=self.server_type,
+            server_source_path=self.server_source_path,
         )
         return heroku_server_development_path
 

--- a/mephisto/abstractions/architects/local_architect.py
+++ b/mephisto/abstractions/architects/local_architect.py
@@ -43,9 +43,6 @@ class LocalArchitectArgs(ArchitectArgs):
         default="localhost", metadata={"help": "Addressible location of the server"}
     )
     port: str = field(default="3000", metadata={"help": "Port to launch the server on"})
-    server_type: str = field(
-        default="node", metadata={"Help": "Type of server to run, `node` or `flask`"}
-    )
 
 
 @register_mephisto_abstraction()
@@ -80,6 +77,7 @@ class LocalArchitect(Architect):
         self.port: Optional[str] = args.architect.port
         self.cleanup_called = False
         self.server_type = args.architect.server_type
+        self.server_source_path = args.architect.get("server_source_path", None)
 
     def _get_socket_urls(self) -> List[str]:
         """Return the path to the local server socket"""
@@ -133,7 +131,12 @@ class LocalArchitect(Architect):
 
     def prepare(self) -> str:
         """Mark the preparation call"""
-        self.server_dir = build_router(self.build_dir, self.task_run, self.server_type)
+        self.server_dir = build_router(
+            self.build_dir,
+            self.task_run,
+            version=self.server_type,
+            server_source_path=self.server_source_path,
+        )
         return self.server_dir
 
     def deploy(self) -> str:

--- a/mephisto/abstractions/architects/router/README.md
+++ b/mephisto/abstractions/architects/router/README.md
@@ -2,9 +2,7 @@
 This directory contains all of the Mephisto code regarding setting up and deploying and endpoint that can handle interfacing with the `mephisto-task` package. As of now there are two implementations, a node server in `deploy` and a Flask server in `flask`. Each of these can be extended upon such that you can deploy your own server (with whatever logic you may need) but still have mephisto routing functionality.
 
 ## `build_router.py`
-This file contains code to be able to initialize the required build files for a server, assuming that they're set up properly. With the routers available in this directory, they should work out-of-the-box, but more configuration 
-
-**TODO** Actually need to implement specifying a folder outside of those in the `router` directory as a target for `build_router.py`.
+This file contains code to be able to initialize the required build files for a server, assuming that they're set up properly. With the routers available in this directory, they should work out-of-the-box, but more configuration. If you want to specify your own build, you should start from the given servers, then provide the `architect.server_source_root` and `architect.server_type` arguments as appropriate with your server directory and the kind of server you're running.
 
 # Router Types
 ## deploy
@@ -15,8 +13,8 @@ This folder contains a Flask Blueprint (not to be confused with a Mephisto Bluep
 
 Key notes: you'll need to import the blueprint and the websocket server, and register the app alongside the websocket server. You'll also need to use `monkey.patch_all()` to ensure that the threading of the websockets and the main Flask server are able to interleave.
 
-**TODO** right now this is hard coded to operate on port 3000, this needs to be updated to work via a configuration argument for usage in `LocalArchitect` and via environment variables for working via the `HerokuArchitect`.
-
 # Routing implementation, functionality, and gotchas
+
+In short, the Mephisto protocol for routing requests from clients down to the Mephisto main server is somewhat complicated. There are a number of endpoints that need to retain the behavior that's captured in the comments of the Flask implementation's `mephisto_flask_blueprint.py` file. These should be enumerated further here.
 
 **TODO** Document the requirements for a Mephisto Router to be running properly, including keeping track of local agent states, converting HTTP POST requests to websocket messages, and the heartbeat protocols.

--- a/mephisto/abstractions/architects/router/build_router.py
+++ b/mephisto/abstractions/architects/router/build_router.py
@@ -12,7 +12,7 @@ import shlex
 import subprocess
 import json
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from mephisto.data_model.task_run import TaskRun
@@ -64,13 +64,21 @@ def build_flask_router(build_dir: str, task_run: "TaskRun") -> str:
     return FLASK_SERVER_SOURCE_ROOT
 
 
-def build_router(build_dir: str, task_run: "TaskRun", version="node") -> str:
+def build_router(
+    build_dir: str,
+    task_run: "TaskRun",
+    version: str = "node",
+    server_source_path: Optional[str] = None,
+) -> str:
     """
     Copy expected files from the router source into the build dir,
     using existing files in the build dir as replacements for the
     defaults if available
     """
-    if version == "node":
+    if server_source_path is not None:
+        # Giving a server source takes precedence over the build
+        server_source_directory_path = server_source_path
+    elif version == "node":
         server_source_directory_path = build_node_router(build_dir, task_run)
     elif version == "flask":
         server_source_directory_path = build_flask_router(build_dir, task_run)

--- a/mephisto/abstractions/architects/router/flask/Procfile
+++ b/mephisto/abstractions/architects/router/flask/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --log-file - app:app --preload --log-level DEBUG
+web: python app.py

--- a/mephisto/abstractions/architects/router/flask/app.py
+++ b/mephisto/abstractions/architects/router/flask/app.py
@@ -8,22 +8,31 @@ from gevent import monkey
 
 monkey.patch_all()
 
-from mephisto.abstractions.architects.router.flask.mephisto_flask_blueprint import (
-    MephistoRouter,
-    mephisto_router,
-)
+try:
+    from mephisto.abstractions.architects.router.flask.mephisto_flask_blueprint import (
+        MephistoRouter,
+        mephisto_router,
+    )
+except:
+    from mephisto_flask_blueprint import (
+        MephistoRouter,
+        mephisto_router,
+    )
 from geventwebsocket import WebSocketServer, Resource
 from werkzeug.debug import DebuggedApplication
 
 
 from flask import Flask
+import os
+
+port = int(os.environ.get("PORT", 3000))
 
 flask_app = Flask(__name__)
 flask_app.register_blueprint(mephisto_router, url_prefix=r"/")
 
 if __name__ == "__main__":
     WebSocketServer(
-        ("", 3000),
+        ("", port),
         Resource([("^/.*", MephistoRouter), ("^/.*", DebuggedApplication(flask_app))]),
         debug=False,
     ).serve_forever()

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -185,7 +185,7 @@ class Operator:
         new_run_id = self.db.new_task_run(
             task_id,
             requester_id,
-            json.dumps(OmegaConf.to_yaml(run_config)),
+            json.dumps(OmegaConf.to_yaml(run_config, resolve=True)),
             provider_type,
             blueprint_type,
             requester.is_sandbox(),


### PR DESCRIPTION
# Overview
Finishes the work in #398 by providing configuration arguments for the PORT, ensuring that the flask router can be launched via the `HerokuArchitect`, and making it possible to set a configuration directory other than the defaults (to use a custom build) with `architect.server_source_root`.

# Testing

```
# in static_react_task example directory
> python run_task.py mephisto.architect.server_type=flask 
> python run_task.py mephisto.architect.server_type=flask mephisto.architect.port=3030 
> python run_task.py mephisto.architect.server_type=flask mephisto.architect.server_source_path=/Users/jju/mephisto/mephisto/abstractions/architects/router/flask_copy/
> python run_task.py mephisto.architect.server_type=flask mephisto/architect=heroku
```
![Screen Shot 2021-02-25 at 6 21 01 PM](https://user-images.githubusercontent.com/1276867/109233532-0c4c6680-7798-11eb-86cd-db6a59d97acd.png)
![Screen Shot 2021-02-25 at 6 21 17 PM](https://user-images.githubusercontent.com/1276867/109233579-1f5f3680-7798-11eb-8078-29c885ef1a95.png)
