### PR TITLE
Adding max_num_concurrent_units hydra config arg

### DIFF
--- a/mephisto/data_model/task_config.py
+++ b/mephisto/data_model/task_config.py
@@ -80,6 +80,15 @@ class TaskConfigArgs:
             )
         },
     )
+    max_num_concurrent_units: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "Maximum units that will be released simultaneously, setting a limit "
+                "on concurrent connections to Mephisto overall. (0 is infinite)"
+            )
+        },
+    )
 
 
 class TaskConfig:
@@ -90,8 +99,8 @@ class TaskConfig:
 
     ArgsClass = TaskConfigArgs
 
-    # TODO(#94?) TaskConfigs should probably be immutable, and could ideally separate
-    # the options that come from different parts of the ecosystem
+    # TODO(#94?) TaskConfigs should probably be removed in favor of relying on
+    # just hydra arguments
     def __init__(self, task_run: "TaskRun"):
         self.db = task_run.db
         args = task_run.args

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -267,7 +267,12 @@ class Operator:
                 )
             raise e
 
-        launcher = TaskLauncher(self.db, task_run, initialization_data_array)
+        launcher = TaskLauncher(
+            self.db,
+            task_run,
+            initialization_data_array,
+            max_num_concurrent_units=run_config.task.max_num_concurrent_units,
+        )
         launcher.create_assignments()
         launcher.launch_units(task_url)
 

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -40,7 +40,7 @@ MOCK_TASK_ARGS = TaskConfigArgs(
 
 class TestOperator(unittest.TestCase):
     """
-    Unit testing for the Mephisto Supervisor
+    Unit testing for the Mephisto Operator
     """
 
     def setUp(self):


### PR DESCRIPTION
# Overview
The concurrent `Unit` launch cap has been available in-code for a while, but with no way to turn it on other than manually changing the `TaskLauncher` file. Turns out it's pretty simple to just bubble this argument up, even if this isn't the final implementation. There shouldn't be any future changes to how a user toggles this option, even if it turns out we change the way that it's transmitted behind the scenes.

cc @EricMichaelSmith as I know a lot of ParlAI users are using this manually at the moment.
cc @ytsheng as I know this is used in Dynabench as well.

# Testing
Ran a job limiting to 1 unit at a time, asserted that if I opened a second there was nothing to take. Completed the job normally one at a time
```
python static_test_script.py mephisto.task.max_num_concurrent_units=1
```