### PR TITLE
Rough FAQ doc, plus a script (and some cleanup).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ examples/**/build/*
 **/outputs/*
 .coverage
 
-
 # PyCharm
 .idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "typescript.tsdk": "mephisto/mephisto/webapp/node_modules/typescript/lib"
+  "typescript.tsdk": "mephisto/mephisto/webapp/node_modules/typescript/lib",
+  "python.linting.pylintEnabled": false,
+  "python.linting.mypyEnabled": true,
+  "python.linting.enabled": true
 }

--- a/docs/config_faq.md
+++ b/docs/config_faq.md
@@ -1,0 +1,46 @@
+# Common Configurations and Frequently Asked Questions
+
+This document contains some Mephisto usage patterns that should be fairly common, as well as usage tips and other know-how.
+
+## How do I manage multiple jobs? How do I keep them separate?
+
+Mephisto is designed to be able to aggregate tasks using their `mephisto.task.task_name`. This value is an identifier used to designate when a number of related `TaskRun`s should be reviewed in the same bucket. It is a standard practice amongst our early users to group tasks by related task names, and then be able to query specific setups like the following:
+
+```
+my-new-task-local-testing
+my-new-task-pilot-1
+my-new-task-pilot-2
+my-new-task-jan-2020-runs
+```
+
+You can use `task_name` to provide fairly expressive metadata about a specific run or group of runs, such that it's easy to refer to them later.
+
+At the moment this parameter is used heavily in our review scripts, and future aggregators will rely on either knowing the `task_name` for a group of `TaskRun`s, or a specific `task_run_id` to get a specific `TaskRun`.
+
+## How do I batch tasks to handle server bandwidth limitations?
+
+By default, Mephisto makes all of the `Unit`s in a `TaskRun` available from the moment you launch it, at the same time. This can cause problems if you end up with an influx of thousands of workers hitting the one routing server launched by the `Architect`, or when your backend server is handling many `Assignment`s and their relevant `Blueprint`'s `TaskRunner`s. 
+
+If you have a compute-heavy task, or you want to run in a low resource setup, you can trade bandwidth for uptime by having Mephisto artificially limit the number of `Unit`s that are available simulaneously. This will ensure that not more than a certain number of workers can possibly be accessing your task at a time. This value is controlled via the `mephisto.task.max_num_concurrent_units` hydra argument. By default, it is set to 0, which is unlimited. It is not to be confused with the `mephisto.task.allowed_concurrent` argument, which instead controls the maximum number of `Unit`s that an individual `Worker` can do at once.
+
+At the moment we suggest a limit of 30-50 for Live tasks and 250-500 for static tasks, given the typical setup of a heroku server and a medium-spec machine running Mephisto. You can tweak this limit as you find out the capabilities of your setup.
+
+## How do I shut down manually? How can I clean up after something goes wrong?
+
+Generally, Mephisto handles the clean-up process when things are shutting down normally. In the case of a catastrophic failure (like a power outage) or a situation where you need to kill a job (perhaps you launched with the wrong parameters), there are different things you need to do.
+
+If you want to end a job early, you should be pressing Ctrl-C **ONCE** in almost all cases. This signals to Mephisto that the job should be shutdown, and pulls any available tasks off of the `CrowdProvider`. It will then _wait_ for any jobs that have already been accepted to be either submitted or returned, and _then_ it will shutdown.
+
+If you must end the job even sooner, you *can* (but generally shouldn't) press Ctrl-C again to tell Mephisto to pull things down immediately. This should only be done after Mephisto tells you it is now waiting for jobs to finish before shutting down. This will finish up the clean up job and end in-flight tasks, then shut down the server and everything.
+
+If you happen to press Ctrl-C again, or find things unexpectedly quit for some other reason (like power failure), then it's your responsibility to clean up. We provide scripts to assist in this where possible, like in `mephisto/scripts/mturk/`, but don't yet have all of them together. You may, for instance, find that a Heroku server is still running after being a bit to eager on the shutdown, but for now you'll have to manually shut it down with their CLI or website.
+
+## Why is my TaskRun not finishing? It's running forever but no data is coming in...
+
+If Mephisto is stalling forever, and no data is coming in, it's possible that either Mephisto is stuck with an active job, or that the `CrowdProvider` isn't showing any data. See if is only printing logs about tracking a currently running job, and nothing about requests from new workers or starting new tasks. If this is the case, you should verify that the server deployed by your architect is running, and that the `CrowdProvider` is actually hosting your tasks.
+
+Note, for MTurk tasks, it's not possible to check on MTurk the status of something launched via botocore using their web interface. For this, use the script for finding outstanding hit statuses at `mephisto/scripts/mturk/print_outstanding_hit_status.py`. If no tasks are available or pending, you can safetly shut down the job.
+
+## My question isn't answered here, where should I look for info?
+
+Try using the `mephisto wut` cli tool to dig for more information about specific configuration arguments. If you've read through our documentation so far and haven't found the information you're looking for, feel free to open up an issue! It's possible your question may be our next entry in this list, or at least that we can do a better job directing people to the resources we already have.

--- a/mephisto/data_model/task_config.py
+++ b/mephisto/data_model/task_config.py
@@ -80,6 +80,15 @@ class TaskConfigArgs:
             )
         },
     )
+    max_num_concurrent_units: int = field(
+        default=0,
+        metadata={
+            "help": (
+                "Maximum units that will be released simultaneously, setting a limit "
+                "on concurrent connections to Mephisto overall. (0 is infinite)"
+            )
+        },
+    )
 
 
 class TaskConfig:
@@ -90,8 +99,8 @@ class TaskConfig:
 
     ArgsClass = TaskConfigArgs
 
-    # TODO(#94?) TaskConfigs should probably be immutable, and could ideally separate
-    # the options that come from different parts of the ecosystem
+    # TODO(#94?) TaskConfigs should probably be removed in favor of relying on
+    # just hydra arguments
     def __init__(self, task_run: "TaskRun"):
         self.db = task_run.db
         args = task_run.args

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -267,7 +267,12 @@ class Operator:
                 )
             raise e
 
-        launcher = TaskLauncher(self.db, task_run, initialization_data_array)
+        launcher = TaskLauncher(
+            self.db,
+            task_run,
+            initialization_data_array,
+            max_num_concurrent_units=run_config.task.max_num_concurrent_units,
+        )
         launcher.create_assignments()
         launcher.launch_units(task_url)
 

--- a/mephisto/scripts/mturk/cleanup.py
+++ b/mephisto/scripts/mturk/cleanup.py
@@ -13,6 +13,9 @@ from mephisto.abstractions.providers.mturk.mturk_utils import (
     expire_and_dispose_hits,
 )
 from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from mephisto.abstractions.providers.mturk.mturk_requester import MTurkRequester
+
+from typing import List, Dict, Any, Optional
 
 db = LocalMephistoDB()
 
@@ -32,13 +35,14 @@ while use_name not in r_names:
     )
 
 requester = db.find_requesters(requester_name=use_name)[0]
+assert isinstance(requester, MTurkRequester)
 client = requester._get_client(requester._requester_name)
 
 outstanding_hit_types = get_outstanding_hits(client)
 num_hit_types = len(outstanding_hit_types.keys())
 sum_hits = sum([len(outstanding_hit_types[x]) for x in outstanding_hit_types.keys()])
 
-all_hits = []
+all_hits: List[Dict[str, Any]] = []
 for hit_type in outstanding_hit_types.keys():
     all_hits += outstanding_hit_types[hit_type]
 
@@ -56,7 +60,7 @@ print(
 )
 
 run_type = input("Would you like to cleanup by (t)itle, or just clean up (a)ll?\n>> ")
-use_hits = None
+use_hits: Optional[List[Dict[str, Any]]] = None
 
 while use_hits is None:
     if run_type.lower().startswith("t"):

--- a/mephisto/scripts/mturk/print_outstanding_hit_status.py
+++ b/mephisto/scripts/mturk/print_outstanding_hit_status.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Utility script that finds, HITs associated with a specific task run,
+and tries to get their information
+"""
+
+from mephisto.abstractions.providers.mturk.mturk_datastore import MTurkDatastore
+from mephisto.abstractions.providers.mturk.mturk_requester import MTurkRequester
+from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from mephisto.data_model.task_run import TaskRun
+
+from typing import cast
+
+task_run_id = input("Please enter the task_run_id you'd like to check: ")
+db = LocalMephistoDB()
+task_run = TaskRun(db, task_run_id)
+requester = task_run.get_requester()
+if not isinstance(requester, MTurkRequester):
+    print(
+        "Must be checking a task launched on MTurk, this one uses the following requester:"
+    )
+    print(requester)
+    exit(0)
+
+
+turk_db = db.get_datastore_for_provider("mturk")
+hits = turk_db.get_unassigned_hit_ids(task_run_id)
+
+print(f"Found the following HIT ids unassigned: {hits}")
+
+# print all of the HITs found above
+from mephisto.abstractions.providers.mturk.mturk_utils import get_hit
+
+for hit_id in hits:
+    hit_info = get_hit(requester._get_client(requester._requester_name), hits[0])
+    print(f"MTurk HIT data for {hit_id}:\n{hit_info}\n")

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -40,7 +40,7 @@ MOCK_TASK_ARGS = TaskConfigArgs(
 
 class TestOperator(unittest.TestCase):
     """
-    Unit testing for the Mephisto Supervisor
+    Unit testing for the Mephisto Operator
     """
 
     def setUp(self):


### PR DESCRIPTION
# Overview
Adds a simple FAQ doc for some of the more recent questions we've received frequently, including info on when to be using the `max_num_concurrent_units` option. 

Also includes a script to diagnose bugs that are going on with MTurk, by directly querying the HITs that are not currently assigned and seeing what their MTurk-side status is.

Also updates vscode to use `mypy` for linting Mephisto, as this is the typing system we were set up to use.

# Testing
@ytsheng used the script to diagnose a run that wasn't shutting down.

I've used the mypy configuration changes to fix the MTurk `cleanup.py` script successfully. I'll be gradually committing mypy changes as I touch files elsewhere for a while.