### PR TITLE
Ensuring we only set in-task agents to RETURNED

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -171,8 +171,13 @@ class MTurkUnit(Unit):
             ]:
                 # Treat this as a return event, this hit may be doable by someone else
                 agent = self.get_assigned_agent()
-                if agent is not None:
-                    # mark the agent as having returned the HIT, to
+                if agent is not None and agent.get_status() in [
+                    AgentState.STATUS_IN_TASK,
+                    AgentState.STATUS_ONBOARDING,
+                    AgentState.STATUS_WAITING,
+                    AgentState.STATUS_PARTNER_DISCONNECT,
+                ]:
+                    # mark the in-task agent as having returned the HIT, to
                     # free any running tasks and have Blueprint decide on cleanup.
                     agent.update_status(AgentState.STATUS_RETURNED)
                 if external_status == AssignmentState.EXPIRED:


### PR DESCRIPTION
# Overview
Bugfix to ensure that only agents that are currently in a task can make the transition to RETURNED. Realistically we shouldn't _need_ this, but MTurk may update the status of an `Assigned` hit to `Assignable` briefly before marking it `Completed`, meaning if we `get_hit` at that point we may incorrectly mark a completed `Agent` (and `Unit`) as RETURNED.

# Testing
Manually mocked transitions of this, but there's still no great way to test MTurk API things in Mephisto. A Completed agent no longer can move to returned.
Unit tests pass