### PR TITLE
Specify heroku app name while setting config args, allow customized app name

### DIFF
--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -115,7 +115,9 @@ class HerokuArchitect(Architect):
         self.heroku_config_args = dict(args.architect.heroku_config_args)
 
         # Cache-able parameters
-        self.__heroku_app_name: Optional[str] = args.architect.get("heroku_app_name", None)
+        self.__heroku_app_name: Optional[str] = args.architect.get(
+            "heroku_app_name", None
+        )
         self.__heroku_executable_path: Optional[str] = None
         self.__heroku_user_identifier: Optional[str] = None
 

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -65,6 +65,9 @@ class HerokuArchitectArgs(ArchitectArgs):
     heroku_team: Optional[str] = field(
         default=MISSING, metadata={"help": "Heroku team to use for this launch"}
     )
+    heroku_app_name: Optional[str] = field(
+        default=MISSING, metadata={"help": "Heroku app name to use for this launch"}
+    )
     heroku_config_args: Dict[str, str] = field(
         default_factory=dict,
         metadata={
@@ -112,7 +115,7 @@ class HerokuArchitect(Architect):
         self.heroku_config_args = dict(args.architect.heroku_config_args)
 
         # Cache-able parameters
-        self.__heroku_app_name: Optional[str] = None
+        self.__heroku_app_name: Optional[str] = args.architect.get("heroku_app_name", None)
         self.__heroku_executable_path: Optional[str] = None
         self.__heroku_user_identifier: Optional[str] = None
 

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -389,7 +389,7 @@ class HerokuArchitect(Architect):
             ]
             full_config_str = " ".join(config_strs)
             subprocess.check_output(
-                shlex.split(f"{heroku_executable_path} config:set {full_config_str}")
+                shlex.split(f"{heroku_executable_path} config:set -a {heroku_app_name} {full_config_str}")
             )
 
         # commit and push to the heroku server

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -389,7 +389,9 @@ class HerokuArchitect(Architect):
             ]
             full_config_str = " ".join(config_strs)
             subprocess.check_output(
-                shlex.split(f"{heroku_executable_path} config:set -a {heroku_app_name} {full_config_str}")
+                shlex.split(
+                    f"{heroku_executable_path} config:set -a {heroku_app_name} {full_config_str}"
+                )
             )
 
         # commit and push to the heroku server


### PR DESCRIPTION
# Overview

@JackUrb 

1. While setting heroku config args, it's required to specify the app name or it will fail. So added '-a APP_NAME' option to heroku cli command.
2. Setting heroku app name is different than setting other config vars. So something like 'heroku config:set APP_NAME=XXX' won't work. So I added `heroku_app_name` field to `HerokuArchitectArgs` and use that field to set `self.__heroku_app_name`. In this way, the heroku app will be created using the name we provided.

This PR is a complement to #411.

# Testing

Tested e2e and it passed.

