### PR TITLE
Added creation state track in heroku architect

### DIFF
--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -491,5 +491,5 @@ class HerokuArchitect(Architect):
         Shut down the server launched by this Architect, as stored
         in the db.
         """
-        if self.created: # only delete the server if it's created by us
+        if self.created:  # only delete the server if it's created by us
             self.__delete_heroku_server()

--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -121,6 +121,8 @@ class HerokuArchitect(Architect):
         self.__heroku_executable_path: Optional[str] = None
         self.__heroku_user_identifier: Optional[str] = None
 
+        self.created = False
+
     def _get_socket_urls(self) -> List[str]:
         """Returns the path to the heroku app socket"""
         heroku_app_name = self.__get_app_name()
@@ -361,6 +363,7 @@ class HerokuArchitect(Architect):
                         "{} create {}".format(heroku_executable_path, heroku_app_name)
                     )
                 )
+                self.created = True
         except subprocess.CalledProcessError as e:  # User has too many apps?
             # TODO(#93) check response codes to determine what actually happened
             logger.exception(e, exc_info=True)
@@ -488,4 +491,5 @@ class HerokuArchitect(Architect):
         Shut down the server launched by this Architect, as stored
         in the db.
         """
-        self.__delete_heroku_server()
+        if self.created: # only delete the server if it's created by us
+            self.__delete_heroku_server()


### PR DESCRIPTION
# Description

This PR aims at resolving this issue: #417 .

What it does is to add a creation state tracker to heroku architect. This tracker is only set to be `True` when mephisto actually creates this heroku app. When the heroku architect is shut down, it will delete the heroku app only if creation state is True.

## Type of change

Please check the options that are relevant.

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Proposes a change (non-breaking change that isn't necessarily a bug)
- [ ] Refactor
- [ ] New feature (non-breaking change that adds a new functionality)
- [ ] Breaking change (fix or feature that would break some existing functionality downstream)
- [ ] This is a unit test
- [ ] Documentation only change

## Type of requested review

- [x] I want a thorough review of the implementation.
- [x] I want a high level review. 
- [x] I want a deep design review.

# Before and After

**Before**

When an interrupt happens, mephisto will delete the `test-mephisto` app even it didn't create it.

<img width="938" alt="Screen Shot 2021-03-15 at 5 12 01 PM" src="https://user-images.githubusercontent.com/34047968/111237180-ceca4480-85b1-11eb-8121-fa7f41517351.png">

**After**

When an interrupt happens, mephisto won't delete the `test-mephisto` app because it didn't create it.

<img width="937" alt="Screen Shot 2021-03-15 at 5 13 06 PM" src="https://user-images.githubusercontent.com/34047968/111237192-d558bc00-85b1-11eb-855c-ee240c88a38a.png">


# Testing

Tested and passed.


