### PR TITLE
[BUG FIX] Fixes bug when searching mephisto review with multiple pages of data

### DIFF
--- a/packages/cra-template-mephisto-review/template/src/AllItemView.jsx
+++ b/packages/cra-template-mephisto-review/template/src/AllItemView.jsx
@@ -36,7 +36,7 @@ function AllItemView({
   } = useMephistoReview({ page, resultsPerPage, filters });
 
   const setFiltersAndResetPage = (filtersStr) => {
-    if (page != null && page != 1) setPage(1);
+    if (page !== null && page !== 1) setPage(1);
     setFilters(filtersStr);
   };
 

--- a/packages/cra-template-mephisto-review/template/src/AllItemView.jsx
+++ b/packages/cra-template-mephisto-review/template/src/AllItemView.jsx
@@ -35,6 +35,11 @@ function AllItemView({
     totalPages,
   } = useMephistoReview({ page, resultsPerPage, filters });
 
+  const setFiltersAndResetPage = (filtersStr) => {
+    if (page != null && page != 1) setPage(1);
+    setFilters(filtersStr);
+  };
+
   const delaySetFilters = (filtersStr) => {
     setFiltersBuffer(filtersStr);
     if (filterTimeout) {
@@ -42,7 +47,7 @@ function AllItemView({
     }
     setFilterTimeout(
       setTimeout(() => {
-        setFilters(filtersStr);
+        setFiltersAndResetPage(filtersStr);
       }, 3000)
     );
   };
@@ -51,7 +56,7 @@ function AllItemView({
     if (filterTimeout) {
       clearTimeout(filterTimeout);
     }
-    setFilters(filtersBuffer);
+    setFiltersAndResetPage(filtersBuffer);
   };
 
   const searchButton = (


### PR DESCRIPTION
### Bug
Small bug fix. Previously, when using mephisto review app with multiple pages of data, if a search query was made on the nth page of all data (n is greater than 1), the query would be made for the nth page of filtered data and for some search queries, would not return any data as there were less than n pages of filtered data.

### Fix
Now app resets the page parameter of a data request upon a new search query if the page parameter is not already equal to 1.