### PR TITLE
[FIX] Added single item view route for mephisto review server

### DIFF
--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -324,8 +324,9 @@ def run(
             data = {"data": current_data if not finished else None, "id": counter - 1}
             return jsonify({"data": data, "mode": MODE, "finished": finished})
 
-    @app.route("/")
-    def index():
+    @app.route("/", defaults={"id": 0})
+    @app.route("/<id>")
+    def index(id):
         global index_file
         return send_file(build_dir + "/index.html")
 

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -324,7 +324,7 @@ def run(
             data = {"data": current_data if not finished else None, "id": counter - 1}
             return jsonify({"data": data, "mode": MODE, "finished": finished})
 
-    @app.route("/", defaults={"id": 0})
+    @app.route("/", defaults={"id": None})
     @app.route("/<id>")
     def index(id):
         global index_file


### PR DESCRIPTION
### Bug
Previously when using mephisto review, the review app could not be directly routed to a route to view an individual data point (the URL being "/:id/"). Instead the user would have to go to the root route (the URL being "/") and then use the review app to navigate to the route to view an individual data point. This was because the route for individual data points was not registered on the flask review server.

### Fix
The route for individual data points has been added to the flask review server under the endpoint for the review app.

### Notes
All future routes added to the mephisto review app must also be added to the mephisto review server under the app route.