### PR TITLE
Creation of the SingletonMephistoDB

### DIFF
--- a/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
@@ -9,6 +9,7 @@ from mephisto.abstractions.blueprint import AgentState
 import os
 import json
 import time
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -38,7 +39,7 @@ class StaticAgentState(AgentState):
         Static agent states should store
         input dict -> output dict pairs to disc
         """
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         self.state: Dict[str, Optional[Dict[str, Any]]] = self._get_empty_state()
         self.load_data()
 

--- a/mephisto/abstractions/blueprints/mock/mock_agent_state.py
+++ b/mephisto/abstractions/blueprints/mock/mock_agent_state.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Dict, Any, TYPE_CHECKING
 from mephisto.abstractions.blueprint import AgentState
 import os
 import json
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -21,7 +22,7 @@ class MockAgentState(AgentState):
 
     def __init__(self, agent: "Agent"):
         """Mock agent states keep everything in local memory"""
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         self.state: Dict[str, Any] = {}
         self.init_state: Any = None
 

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -13,6 +13,7 @@ from mephisto.data_model.packet import (
 import os
 import json
 import time
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -31,7 +32,7 @@ class ParlAIChatAgentState(AgentState):
 
         Initialize with an existing file if it exists.
         """
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         data_file = self._get_expected_data_file()
         if os.path.exists(data_file):
             self.load_data()

--- a/mephisto/abstractions/database.py
+++ b/mephisto/abstractions/database.py
@@ -92,6 +92,22 @@ class MephistoDB(ABC):
             provider = ProviderClass(self)
             provider.cleanup_qualification(qualification_name)
 
+    def optimized_load(
+        self,
+        target_cls,
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+    ):
+        """
+        Load the given class in an optimized fashion, if this DB has a more
+        efficient way of storing and managing the data
+        """
+        return None
+
+    def cache_result(self, target_cls, value) -> None:
+        """Opportunity to store the result class from a load"""
+        return None
+
     @abstractmethod
     def shutdown(self) -> None:
         """Do whatever is required to shut this server off"""

--- a/mephisto/abstractions/databases/README.md
+++ b/mephisto/abstractions/databases/README.md
@@ -1,5 +1,10 @@
 # MephistoDB implementations
-This folder contains implementations of the `MephistoDB` abstraction. 
+This folder contains implementations of the `MephistoDB` abstraction. Databases can currently be configured using the `mephisto.database._database_type` flag, though all databases other than `local` are considered to be in BETA at this point.
 
 ## `LocalMephistoDB`
 An implementation of the Mephisto Data Model outlined in `MephistoDB`. This database stores all of the information locally via SQLite. Some helper functions are included to make the implementation cleaner by abstracting away SQLite error parsing and string formatting, however it's pretty straightforward from the requirements of MephistoDB.
+
+## `SingletonMephistoDB` <BETA>
+Activated with `mephisto.database._database_type=singleton`. This database is best used for high performance runs on a single machine, where direct access to the underlying database isn't necessary during the runtime. It makes no guarantees on the rate of writing state or status to disk, as much of it is stored locally and in caches to keep IO locks down. Using this, you'll likely be able to get up on `max_num_concurrent_units` to 150-300 on live tasks, and upwards from 500 on static tasks.
+
+At the moment this DB acts as a wrapper around the `LocalMephistoDB`, and trades off Mephisto memory consumption for writing time. All of the data model accesses that occur are cached into a library of singletons, so large enough tasks may have memory risks. This allows us to make clearer assertions about the synced nature of the data model members, but obviously requires active memory to do so.

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -28,7 +28,10 @@ from mephisto.data_model.qualification import Qualification, GrantedQualificatio
 import sqlite3
 from sqlite3 import Connection, Cursor
 import threading
-from weakref import WeakValueDictionary
+
+# We should be using WeakValueDictionary rather than a full dict once
+# we're better able to trade-off between memory and space.
+# from weakref import WeakValueDictionary
 
 from mephisto.operations.logger_core import get_logger
 
@@ -64,7 +67,7 @@ class MephistoSingletonDB(LocalMephistoDB):
         super().__init__(database_path=database_path)
 
         # Create singleton dictionaries for entries
-        self._singleton_cache = {k: WeakValueDictionary() for k in self._cached_classes}
+        self._singleton_cache = {k: dict() for k in self._cached_classes}
 
     def shutdown(self) -> None:
         """Close all open connections"""

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -95,3 +95,33 @@ class MephistoSingletonDB(LocalMephistoDB):
                 self._singleton_cache[stored_class][value.db_id] = value
                 break
         return None
+
+    def new_agent(
+        self,
+        worker_id: str,
+        unit_id: str,
+        task_id: str,
+        task_run_id: str,
+        assignment_id: str,
+        task_type: str,
+        provider_type: str,
+    ) -> str:
+        """
+        Wrapper around the new_agent call that finds and updates the unit locally
+        too, as this isn't guaranteed otherwise but is an important part of the singleton
+        """
+        agent_id = super().new_agent(
+            worker_id,
+            unit_id,
+            task_id,
+            task_run_id,
+            assignment_id,
+            task_type,
+            provider_type,
+        )
+        agent = Agent(self, agent_id)
+        unit = agent.get_unit()
+        unit.agent_id = agent_id
+        unit.db_status = AssignmentState.ASSIGNED
+        unit.worker_id = agent.worker_id
+        return agent_id

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.abstractions.database import (
+    MephistoDB,
+    MephistoDBException,
+    EntryAlreadyExistsException,
+    EntryDoesNotExistException,
+)
+from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from typing import Mapping, Optional, Any, List, Dict
+from mephisto.operations.utils import get_data_dir
+from mephisto.operations.registry import get_valid_provider_types
+from mephisto.data_model.agent import Agent, AgentState, OnboardingAgent
+from mephisto.data_model.unit import Unit
+from mephisto.data_model.assignment import Assignment, AssignmentState
+from mephisto.data_model.constants import NO_PROJECT_NAME
+from mephisto.data_model.project import Project
+from mephisto.data_model.requester import Requester
+from mephisto.data_model.task import Task
+from mephisto.data_model.task_run import TaskRun
+from mephisto.data_model.worker import Worker
+from mephisto.data_model.qualification import Qualification, GrantedQualification
+
+import sqlite3
+from sqlite3 import Connection, Cursor
+import threading
+from weakref import WeakValueDictionary
+
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
+
+# Note: This class could be a generic factory around any MephistoDB, converting
+# the system to a singleton implementation. It requires all of the data being
+# updated locally though, so binding to LocalMephistoDB makes sense for now.
+class MephistoSingletonDB(LocalMephistoDB):
+    """
+    Class that creates a singleton storage for all accessed data.
+
+    Tries to keep the data usage down with weak references, but it's
+    still subject to memory leaks.
+
+    This is a tradeoff to have more speed for not making db queries from disk
+    """
+
+    # All classes cached by this DB, in order of expected references
+    _cached_classes = [
+        Agent,
+        Unit,
+        Assignment,
+        Worker,
+        OnboardingAgent,
+        Qualification,
+        TaskRun,
+        Task,
+        Project,
+    ]
+
+    def __init__(self, database_path=None):
+        super().__init__(database_path=database_path)
+
+        # Create singleton dictionaries for entries
+        self._singleton_cache = {k: WeakValueDictionary() for k in self._cached_classes}
+
+    def shutdown(self) -> None:
+        """Close all open connections"""
+        with self.table_access_condition:
+            curr_thread = threading.get_ident()
+            self.conn[curr_thread].close()
+            del self.conn[curr_thread]
+
+    def optimized_load(
+        self,
+        target_cls,
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+    ):
+        """
+        Load the given class in an optimized fashion, if this DB has a more
+        efficient way of storing and managing the data
+        """
+        for stored_class in self._cached_classes:
+            if issubclass(target_cls, stored_class):
+                return self._singleton_cache[stored_class].get(db_id)
+        return None
+
+    def cache_result(self, target_cls, value) -> None:
+        """Store the result of a load for caching reasons"""
+        for stored_class in self._cached_classes:
+            if issubclass(target_cls, stored_class):
+                self._singleton_cache[stored_class][value.db_id] = value
+                break
+        return None

--- a/mephisto/abstractions/test/data_model_database_tester.py
+++ b/mephisto/abstractions/test/data_model_database_tester.py
@@ -49,6 +49,8 @@ class BaseDatabaseTests(unittest.TestCase):
     of the MephistoDB class.
     """
 
+    is_base = True
+
     db: Optional[MephistoDB] = None
 
     @classmethod
@@ -69,6 +71,8 @@ class BaseDatabaseTests(unittest.TestCase):
         Generally this means initializing a database somewhere
         temporary and setting self.db
         """
+        if self.is_base:
+            raise unittest.SkipTest("Skip BaseDatabaseTests tests, it's a base class")
         raise NotImplementedError()
 
     def tearDown(self) -> None:

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from abc import ABC, abstractmethod, abstractstaticmethod
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.worker import Worker
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from mephisto.data_model.exceptions import (
     AgentReturnedError,
     AgentDisconnectedError,
@@ -33,7 +34,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class Agent(ABC):
+class Agent(metaclass=MephistoDBBackedABCMeta):
     """
     This class encompasses a worker as they are working on an individual assignment.
     It maintains details for the current task at hand such as start and end time,

--- a/mephisto/data_model/assignment.py
+++ b/mephisto/data_model/assignment.py
@@ -10,6 +10,7 @@ from mephisto.data_model.task import Task
 from mephisto.data_model.task_run import TaskRun
 from mephisto.data_model.agent import Agent
 from mephisto.data_model.requester import Requester
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from typing import List, Optional, Mapping, Dict, Any, TYPE_CHECKING, IO
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ class InitializationData:
         )
 
 
-class Assignment:
+class Assignment(metaclass=MephistoDBBackedMeta):
     """
     This class tracks an individual run of a specific task, and handles state management
     for the set of units within via abstracted database helpers

--- a/mephisto/data_model/db_backed_meta.py
+++ b/mephisto/data_model/db_backed_meta.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple, Mapping, Dict, Any, TYPE_CHECKING
+
+from abc import ABCMeta
+
+if TYPE_CHECKING:
+    from mephisto.abstractions.database import MephistoDB
+
+
+def base_db_backed_call(my_super, cls, a, kw):
+    """
+    Metaclass __call__ method, pulled out so we can have separate
+    versions with and without ABCMeta.
+
+    Checks the database first for an optimized load, then loads
+    normally, then caches the result if desired
+    """
+    db = a[0]
+    db_id = a[1]
+    row = kw.get("row")
+    loaded_val = db.optimized_load(cls, db_id, row)
+    if loaded_val is None:
+        loaded_val = my_super.__call__(*a, **kw)
+        db.cache_result(cls, loaded_val)
+    else:
+        print("Loaded cached val", loaded_val)
+    return loaded_val
+
+
+class MephistoDBBackedABCMeta(ABCMeta):
+    """
+    Metaclass that overrides `call` to allow the current `MephistoDB` an
+    opportunity to do an optimized load if desired. Provides more control
+    over the creation of objects than normal.
+
+    Extends ABCMeta, so that we can use this for the abstract classes
+    """
+
+    def __call__(cls, *a, **kw):
+        return base_db_backed_call(super(), cls, a, kw)
+
+
+class MephistoDBBackedMeta(type):
+    """
+    Metaclass that overrides `call` to allow the current `MephistoDB` an
+    opportunity to do an optimized load if desired. Provides more control
+    over the creation of objects than normal.
+    """
+
+    def __call__(cls, *a, **kw):
+        return base_db_backed_call(super(), cls, a, kw)

--- a/mephisto/data_model/db_backed_meta.py
+++ b/mephisto/data_model/db_backed_meta.py
@@ -27,8 +27,6 @@ def base_db_backed_call(my_super, cls, a, kw):
     if loaded_val is None:
         loaded_val = my_super.__call__(*a, **kw)
         db.cache_result(cls, loaded_val)
-    else:
-        print("Loaded cached val", loaded_val)
     return loaded_val
 
 

--- a/mephisto/data_model/project.py
+++ b/mephisto/data_model/project.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from mephisto.data_model.constants import NO_PROJECT_NAME
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 
 from typing import List, Mapping, Any, Optional, TYPE_CHECKING
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from mephisto.data_model.task import Task
 
 
-class Project:
+class Project(metaclass=MephistoDBBackedMeta):
     """
     High level project that many crowdsourcing tasks may be related to. Useful
     for budgeting and grouping tasks for a review perspective.

--- a/mephisto/data_model/qualification.py
+++ b/mephisto/data_model/qualification.py
@@ -9,6 +9,7 @@ from mephisto.operations.registry import (
     get_crowd_provider_from_type,
     get_valid_provider_types,
 )
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 
 from typing import List, Optional, Mapping, Dict, TYPE_CHECKING, Any
 
@@ -162,7 +163,7 @@ def make_qualification_dict(
     return as_valid_qualification_dict(qual_dict)
 
 
-class Qualification:
+class Qualification(metaclass=MephistoDBBackedMeta):
     """Simple convenience wrapper for Qualifications in the data model"""
 
     def __init__(

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import ABC, abstractmethod, abstractstaticmethod
+from abc import abstractmethod, abstractstaticmethod
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from dataclasses import dataclass, field
 from omegaconf import MISSING, DictConfig
 
@@ -33,7 +34,7 @@ class RequesterArgs:
     )
 
 
-class Requester(ABC):
+class Requester(metaclass=MephistoDBBackedABCMeta):
     """
     High level class representing a requester on some kind of crowd provider. Sets some default
     initializations, but mostly should be extended by the specific requesters for crowd providers

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -9,6 +9,7 @@ import os
 from shutil import copytree
 
 from mephisto.data_model.project import Project
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from mephisto.operations.utils import (
     get_dir_for_task,
     ensure_user_confirm,
@@ -44,7 +45,7 @@ def assert_task_is_valid(dir_name, task_type) -> None:
 # executable and becoming just storage for other information.
 
 
-class Task:
+class Task(metaclass=MephistoDBBackedMeta):
     """
     This class contains all of the required tidbits for launching a set of
     assignments, primarily by leveraging a blueprint. It also takes the

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -11,6 +11,7 @@ import json
 from mephisto.data_model.requester import Requester
 from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.data_model.task_config import TaskConfig
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from mephisto.operations.utils import get_dir_for_run
 
 from omegaconf import OmegaConf
@@ -32,7 +33,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class TaskRun:
+class TaskRun(metaclass=MephistoDBBackedMeta):
     """
     This class tracks an individual run of a specific task, and handles state management
     for the set of assignments within

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -202,12 +202,10 @@ class Unit(metaclass=MephistoDBBackedABCMeta):
 
         # Query the database to get the most up-to-date assignment, as this can
         # change after instantiation if the Unit status isn't final
-        # TODO(#101) this may not be particularly efficient
-        row = self.db.get_unit(self.db_id)
-        assert row is not None, f"Unit {self.db_id} stopped existing in the db..."
-        agent_id = row["agent_id"]
-        if agent_id is not None:
-            return Agent(self.db, agent_id)
+        unit_copy = Unit(self.db, self.db_id)
+        self.agent_id = unit_copy.agent_id
+        if self.agent_id is not None:
+            return Agent(self.db, self.agent_id)
         return None
 
     @staticmethod

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -10,6 +10,7 @@ from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.data_model.task import Task
 from mephisto.data_model.task_run import TaskRun
 from mephisto.data_model.agent import Agent
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.requester import Requester
 from typing import Optional, Mapping, Dict, Any, Type, TYPE_CHECKING
@@ -27,7 +28,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class Unit(ABC):
+class Unit(metaclass=MephistoDBBackedABCMeta):
     """
     This class tracks the status of an individual worker's contribution to a
     higher level assignment. It is the smallest 'unit' of work to complete

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -7,6 +7,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from mephisto.abstractions.blueprint import AgentState
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from typing import Any, List, Optional, Mapping, Tuple, Dict, Type, Tuple, TYPE_CHECKING
 from mephisto.operations.logger_core import get_logger
 
@@ -37,7 +38,7 @@ class WorkerArgs:
     )
 
 
-class Worker(ABC):
+class Worker(metaclass=MephistoDBBackedABCMeta):
     """
     This class represents an individual - namely a person. It maintains components of ongoing identity for a user.
     """

--- a/mephisto/operations/hydra_config.py
+++ b/mephisto/operations/hydra_config.py
@@ -17,11 +17,17 @@ config = ConfigStoreWithProvider("mephisto")
 
 
 @dataclass
+class DatabaseArgs:
+    _database_type: str = "local"  # default DB is local
+
+
+@dataclass
 class MephistoConfig:
     blueprint: BlueprintArgs = BlueprintArgs()
     provider: ProviderArgs = ProviderArgs()
     architect: ArchitectArgs = ArchitectArgs()
     task: TaskConfigArgs = TaskConfigArgs()
+    database: DatabaseArgs = DatabaseArgs()
     log_level: str = "info"
 
 

--- a/mephisto/tools/scripts.py
+++ b/mephisto/tools/scripts.py
@@ -8,6 +8,7 @@ Utilities that are useful for Mephisto-related scripts.
 """
 
 from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
 from mephisto.operations.utils import get_mock_requester, get_root_data_dir
 
 from omegaconf import DictConfig, OmegaConf
@@ -49,7 +50,15 @@ def get_db_from_config(cfg: DictConfig) -> "MephistoDB":
         datapath = get_root_data_dir()
 
     database_path = os.path.join(datapath, "database.db")
-    return LocalMephistoDB(database_path=database_path)
+
+    database_type = cfg.mephisto.database._database_type
+
+    if database_type == "local":
+        return LocalMephistoDB(database_path=database_path)
+    elif database_type == "singleton":
+        return MephistoSingletonDB(database_path=database_path)
+    else:
+        raise AssertionError(f"Provided database_type {database_type} is not valid")
 
 
 def augment_config_from_db(script_cfg: DictConfig, db: "MephistoDB") -> DictConfig:

--- a/test/abstractions/databases/test_local_database.py
+++ b/test/abstractions/databases/test_local_database.py
@@ -21,6 +21,8 @@ class TestLocalMephistoDB(BaseDatabaseTests):
     writes no additional tests.
     """
 
+    is_base = False
+
     def setUp(self):
         self.data_dir = tempfile.mkdtemp()
         database_path = os.path.join(self.data_dir, "mephisto.db")

--- a/test/abstractions/databases/test_singleton_database.py
+++ b/test/abstractions/databases/test_singleton_database.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import shutil
+import os
+import tempfile
+
+from mephisto.abstractions.test.data_model_database_tester import BaseDatabaseTests
+from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
+
+
+class TestMephistoSingletonDB(BaseDatabaseTests):
+    """
+    Unit testing for the MephistoSingletonDB
+
+    Inherits all tests directly from BaseDataModelTests, and
+    writes no additional tests.
+    """
+
+    is_base = False
+
+    def setUp(self):
+        self.data_dir = tempfile.mkdtemp()
+        database_path = os.path.join(self.data_dir, "mephisto.db")
+        self.db = MephistoSingletonDB(database_path)
+
+    def tearDown(self):
+        self.db.shutdown()
+        shutil.rmtree(self.data_dir)
+
+    # TODO(#97) are there any other unit tests we'd like to have?
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview
In order to increase the speed of Mephisto, this PR trades off active memory (and eventual memory leaks) for speed. All data model accesses will refer to cached objects in the `SingletonMephistoDB`, such that object initialization (which accounts for a _surprising_ amount of Mephisto's runtime, more on this later) is minimized. This database is only particularly useful in a running mode with an `Operator`, and direct database changes are pushed to the database, but the actual data model objects will all be singletons during use. Thus, when Mephisto later needs to "load all the units" to get their status, they're all already loaded. 

### Usage
You can use this feature with the `mephisto.database._database_type=singleton` hydra arg. At the moment this is to be considered a beta feature, and is subject to some change.

## Implementation
1. Add the `optimized_load` and `cache_result` method to the `MephistoDB` class. These methods provide an anchor for which a `MephistoDB` setup can produce faster results based on a local (or external) cache than a regular `__new__` and `__init__` call that python would generally do.
2. Creates the `MephistoDBBackedMeta` and `MephistoDBBackedABCMeta` metaclasses. These metaclasses will ensure that during initialization (like calling `Agent(db, "800")`) will first check the `MephistoDB`'s `optimized_load` method before doing a default call, and will store results via `cache_result`. We assume we only need to manually call `cache_result` if `optimized_load` didn't return a value, as the underlying `MephistoDB` could have cached locally otherwise.
3. Update all of the Mephisto data model objects (conveniently all with the same init signature of `(db: MephistoDB, db_id: str)`) to extend these metaclasses. The `ABC` version extends the `ABCMeta` metaclass, this way the data model classes that used to extend `ABC` can still maintain their abstract nature. 
4. Create the `SingletonMephistoDB`. This class is a wrapper around the `LocalMephistoDB`, but it utilizes the `optimized_load` and `cache_result` methods. When loading from the DB, now we check to see if there's a cached version first and return that if it exists. All of these cache entries are stored with `WeakValueDictionary`s, this way we can do _some_ garbage collection where possible.
5. `weakref` backwards edges in `AgentState` classes. This allows the `SingletonMephistoDB` to clean up agents when no longer referenced outside of circular reference cases.
6. Adds `mephisto.database._database_type` as a hydra argument to be able to configure to use `singleton`. Default is `local`.

Note that step 5 here doesn't actually cover nearly all of the possible `weakref`-relevant cases: more experimentation can be done to update the vertical path of the datamodel to `weakref` the upwards references that currently exist, like `<agent>._unit`.
## Testing
1. Added `TestMephistoSingletonDB`, which passes the base Database Tests.
2. Can successfully run example task using the singleton DB:
`python static_test_script.py mephisto.database._database_type=singleton`
3. Original testing passes.
