### PR TITLE
Setting cache invalidation for sync_hit_mapping

### DIFF
--- a/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
@@ -9,6 +9,7 @@ from mephisto.abstractions.blueprint import AgentState
 import os
 import json
 import time
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -38,7 +39,7 @@ class StaticAgentState(AgentState):
         Static agent states should store
         input dict -> output dict pairs to disc
         """
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         self.state: Dict[str, Optional[Dict[str, Any]]] = self._get_empty_state()
         self.load_data()
 

--- a/mephisto/abstractions/blueprints/mock/mock_agent_state.py
+++ b/mephisto/abstractions/blueprints/mock/mock_agent_state.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Dict, Any, TYPE_CHECKING
 from mephisto.abstractions.blueprint import AgentState
 import os
 import json
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -21,7 +22,7 @@ class MockAgentState(AgentState):
 
     def __init__(self, agent: "Agent"):
         """Mock agent states keep everything in local memory"""
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         self.state: Dict[str, Any] = {}
         self.init_state: Any = None
 

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -13,6 +13,7 @@ from mephisto.data_model.packet import (
 import os
 import json
 import time
+import weakref
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent
@@ -31,7 +32,7 @@ class ParlAIChatAgentState(AgentState):
 
         Initialize with an existing file if it exists.
         """
-        self.agent = agent
+        self.agent = weakref.proxy(agent)
         data_file = self._get_expected_data_file()
         if os.path.exists(data_file):
             self.load_data()

--- a/mephisto/abstractions/database.py
+++ b/mephisto/abstractions/database.py
@@ -92,6 +92,22 @@ class MephistoDB(ABC):
             provider = ProviderClass(self)
             provider.cleanup_qualification(qualification_name)
 
+    def optimized_load(
+        self,
+        target_cls,
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+    ):
+        """
+        Load the given class in an optimized fashion, if this DB has a more
+        efficient way of storing and managing the data
+        """
+        return None
+
+    def cache_result(self, target_cls, value) -> None:
+        """Opportunity to store the result class from a load"""
+        return None
+
     @abstractmethod
     def shutdown(self) -> None:
         """Do whatever is required to shut this server off"""

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -28,7 +28,10 @@ from mephisto.data_model.qualification import Qualification, GrantedQualificatio
 import sqlite3
 from sqlite3 import Connection, Cursor
 import threading
-from weakref import WeakValueDictionary
+
+# We should be using WeakValueDictionary rather than a full dict once
+# we're better able to trade-off between memory and space.
+# from weakref import WeakValueDictionary
 
 from mephisto.operations.logger_core import get_logger
 
@@ -64,7 +67,7 @@ class MephistoSingletonDB(LocalMephistoDB):
         super().__init__(database_path=database_path)
 
         # Create singleton dictionaries for entries
-        self._singleton_cache = {k: WeakValueDictionary() for k in self._cached_classes}
+        self._singleton_cache = {k: dict() for k in self._cached_classes}
 
     def shutdown(self) -> None:
         """Close all open connections"""

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -95,3 +95,33 @@ class MephistoSingletonDB(LocalMephistoDB):
                 self._singleton_cache[stored_class][value.db_id] = value
                 break
         return None
+
+    def new_agent(
+        self,
+        worker_id: str,
+        unit_id: str,
+        task_id: str,
+        task_run_id: str,
+        assignment_id: str,
+        task_type: str,
+        provider_type: str,
+    ) -> str:
+        """
+        Wrapper around the new_agent call that finds and updates the unit locally
+        too, as this isn't guaranteed otherwise but is an important part of the singleton
+        """
+        agent_id = super().new_agent(
+            worker_id,
+            unit_id,
+            task_id,
+            task_run_id,
+            assignment_id,
+            task_type,
+            provider_type,
+        )
+        agent = Agent(self, agent_id)
+        unit = agent.get_unit()
+        unit.agent_id = agent_id
+        unit.db_status = AssignmentState.ASSIGNED
+        unit.worker_id = agent.worker_id
+        return agent_id

--- a/mephisto/abstractions/databases/local_singleton_database.py
+++ b/mephisto/abstractions/databases/local_singleton_database.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from mephisto.abstractions.database import (
+    MephistoDB,
+    MephistoDBException,
+    EntryAlreadyExistsException,
+    EntryDoesNotExistException,
+)
+from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from typing import Mapping, Optional, Any, List, Dict
+from mephisto.operations.utils import get_data_dir
+from mephisto.operations.registry import get_valid_provider_types
+from mephisto.data_model.agent import Agent, AgentState, OnboardingAgent
+from mephisto.data_model.unit import Unit
+from mephisto.data_model.assignment import Assignment, AssignmentState
+from mephisto.data_model.constants import NO_PROJECT_NAME
+from mephisto.data_model.project import Project
+from mephisto.data_model.requester import Requester
+from mephisto.data_model.task import Task
+from mephisto.data_model.task_run import TaskRun
+from mephisto.data_model.worker import Worker
+from mephisto.data_model.qualification import Qualification, GrantedQualification
+
+import sqlite3
+from sqlite3 import Connection, Cursor
+import threading
+from weakref import WeakValueDictionary
+
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
+
+# Note: This class could be a generic factory around any MephistoDB, converting
+# the system to a singleton implementation. It requires all of the data being
+# updated locally though, so binding to LocalMephistoDB makes sense for now.
+class MephistoSingletonDB(LocalMephistoDB):
+    """
+    Class that creates a singleton storage for all accessed data.
+
+    Tries to keep the data usage down with weak references, but it's
+    still subject to memory leaks.
+
+    This is a tradeoff to have more speed for not making db queries from disk
+    """
+
+    # All classes cached by this DB, in order of expected references
+    _cached_classes = [
+        Agent,
+        Unit,
+        Assignment,
+        Worker,
+        OnboardingAgent,
+        Qualification,
+        TaskRun,
+        Task,
+        Project,
+    ]
+
+    def __init__(self, database_path=None):
+        super().__init__(database_path=database_path)
+
+        # Create singleton dictionaries for entries
+        self._singleton_cache = {k: WeakValueDictionary() for k in self._cached_classes}
+
+    def shutdown(self) -> None:
+        """Close all open connections"""
+        with self.table_access_condition:
+            curr_thread = threading.get_ident()
+            self.conn[curr_thread].close()
+            del self.conn[curr_thread]
+
+    def optimized_load(
+        self,
+        target_cls,
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+    ):
+        """
+        Load the given class in an optimized fashion, if this DB has a more
+        efficient way of storing and managing the data
+        """
+        for stored_class in self._cached_classes:
+            if issubclass(target_cls, stored_class):
+                return self._singleton_cache[stored_class].get(db_id)
+        return None
+
+    def cache_result(self, target_cls, value) -> None:
+        """Store the result of a load for caching reasons"""
+        for stored_class in self._cached_classes:
+            if issubclass(target_cls, stored_class):
+                self._singleton_cache[stored_class][value.db_id] = value
+                break
+        return None

--- a/mephisto/abstractions/providers/mturk/mturk_agent.py
+++ b/mephisto/abstractions/providers/mturk/mturk_agent.py
@@ -72,9 +72,8 @@ class MTurkAgent(Agent):
         Wrapper around the new method that allows registering additional
         bookkeeping information from a crowd provider for this agent
         """
-        datastore: "MTurkDatastore" = db.get_datastore_for_provider(cls.PROVIDER_TYPE)
-        datastore.register_assignment_to_hit(
-            provider_data["hit_id"], unit.db_id, provider_data["assignment_id"]
+        unit.register_from_provider_data(
+            provider_data["hit_id"], provider_data["assignment_id"]
         )
         return super().new_from_provider_data(db, worker, unit, provider_data)
 

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -130,6 +130,7 @@ class MTurkDatastore:
                 ) VALUES (?, ?);""",
                 (hit_id, run_id),
             )
+            self._last_hit_mapping_update_time = time.time()
 
     def get_unassigned_hit_ids(self, run_id: str):
         """

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -60,7 +60,7 @@ class MTurkUnit(Unit):
 
     def _sync_hit_mapping(self) -> None:
         """Sync with the datastore to see if any mappings have updated"""
-        if self.datastore.is_hit_mapping_in_sync(self._last_sync_time):
+        if self.datastore.is_hit_mapping_in_sync(self.db_id, self._last_sync_time):
             return
         try:
             mapping = dict(self.datastore.get_hit_mapping(self.db_id))
@@ -76,6 +76,18 @@ class MTurkUnit(Unit):
         # to reduce the risk of a race condition caching an old
         # value the moment it's registered
         self._last_sync_time = time.monotonic() - 1
+
+    def register_from_provider_data(
+        self, hit_id: str, mturk_assignment_id: str
+    ) -> None:
+        """Update the datastore and local information from this registration"""
+        self.datastore.register_assignment_to_hit(
+            hit_id, self.db_id, mturk_assignment_id
+        )
+        self.hit_id = hit_id
+        self.mturk_assignment_id = mturk_assignment_id
+        # We made the change, so we can set the sync time.
+        self._last_sync_time = time.monotonic()
 
     def get_mturk_assignment_id(self) -> Optional[str]:
         """

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -15,6 +15,7 @@ from mephisto.abstractions.providers.mturk.mturk_utils import (
     create_hit_with_hit_type,
 )
 from mephisto.abstractions.providers.mturk.provider_type import PROVIDER_TYPE
+import time
 from typing import List, Optional, Tuple, Mapping, Dict, Any, Type, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -47,6 +48,7 @@ class MTurkUnit(Unit):
             self.PROVIDER_TYPE
         )
         self.hit_id: Optional[str] = None
+        self._last_sync_time = 0.0
         self._sync_hit_mapping()
         self.__requester: Optional["MTurkRequester"] = None
 
@@ -58,6 +60,8 @@ class MTurkUnit(Unit):
 
     def _sync_hit_mapping(self) -> None:
         """Sync with the datastore to see if any mappings have updated"""
+        if self.datastore.is_hit_mapping_in_sync(self._last_sync_time):
+            return
         try:
             mapping = dict(self.datastore.get_hit_mapping(self.db_id))
             self.hit_id = mapping["hit_id"]
@@ -68,6 +72,7 @@ class MTurkUnit(Unit):
             self.hit_id = None
             self.mturk_assignment_id = None
             self.assignment_time_in_seconds = -1
+        self._last_sync_time = time.time()
 
     def get_mturk_assignment_id(self) -> Optional[str]:
         """

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -72,7 +72,10 @@ class MTurkUnit(Unit):
             self.hit_id = None
             self.mturk_assignment_id = None
             self.assignment_time_in_seconds = -1
-        self._last_sync_time = time.time()
+        # We update to a time slightly earlier than now, in order
+        # to reduce the risk of a race condition caching an old
+        # value the moment it's registered
+        self._last_sync_time = time.time() - 1
 
     def get_mturk_assignment_id(self) -> Optional[str]:
         """

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -75,7 +75,7 @@ class MTurkUnit(Unit):
         # We update to a time slightly earlier than now, in order
         # to reduce the risk of a race condition caching an old
         # value the moment it's registered
-        self._last_sync_time = time.time() - 1
+        self._last_sync_time = time.monotonic() - 1
 
     def get_mturk_assignment_id(self) -> Optional[str]:
         """

--- a/mephisto/abstractions/test/data_model_database_tester.py
+++ b/mephisto/abstractions/test/data_model_database_tester.py
@@ -49,6 +49,8 @@ class BaseDatabaseTests(unittest.TestCase):
     of the MephistoDB class.
     """
 
+    is_base = True
+
     db: Optional[MephistoDB] = None
 
     @classmethod
@@ -69,6 +71,8 @@ class BaseDatabaseTests(unittest.TestCase):
         Generally this means initializing a database somewhere
         temporary and setting self.db
         """
+        if self.is_base:
+            raise unittest.SkipTest("Skip BaseDatabaseTests tests, it's a base class")
         raise NotImplementedError()
 
     def tearDown(self) -> None:

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 from abc import ABC, abstractmethod, abstractstaticmethod
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.worker import Worker
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from mephisto.data_model.exceptions import (
     AgentReturnedError,
     AgentDisconnectedError,
@@ -33,7 +34,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class Agent(ABC):
+class Agent(metaclass=MephistoDBBackedABCMeta):
     """
     This class encompasses a worker as they are working on an individual assignment.
     It maintains details for the current task at hand such as start and end time,

--- a/mephisto/data_model/assignment.py
+++ b/mephisto/data_model/assignment.py
@@ -10,6 +10,7 @@ from mephisto.data_model.task import Task
 from mephisto.data_model.task_run import TaskRun
 from mephisto.data_model.agent import Agent
 from mephisto.data_model.requester import Requester
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from typing import List, Optional, Mapping, Dict, Any, TYPE_CHECKING, IO
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ class InitializationData:
         )
 
 
-class Assignment:
+class Assignment(metaclass=MephistoDBBackedMeta):
     """
     This class tracks an individual run of a specific task, and handles state management
     for the set of units within via abstracted database helpers

--- a/mephisto/data_model/db_backed_meta.py
+++ b/mephisto/data_model/db_backed_meta.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Optional, Tuple, Mapping, Dict, Any, TYPE_CHECKING
+
+from abc import ABCMeta
+
+if TYPE_CHECKING:
+    from mephisto.abstractions.database import MephistoDB
+
+
+def base_db_backed_call(my_super, cls, a, kw):
+    """
+    Metaclass __call__ method, pulled out so we can have separate
+    versions with and without ABCMeta.
+
+    Checks the database first for an optimized load, then loads
+    normally, then caches the result if desired
+    """
+    db = a[0]
+    db_id = a[1]
+    row = kw.get("row")
+    loaded_val = db.optimized_load(cls, db_id, row)
+    if loaded_val is None:
+        loaded_val = my_super.__call__(*a, **kw)
+        db.cache_result(cls, loaded_val)
+    else:
+        print("Loaded cached val", loaded_val)
+    return loaded_val
+
+
+class MephistoDBBackedABCMeta(ABCMeta):
+    """
+    Metaclass that overrides `call` to allow the current `MephistoDB` an
+    opportunity to do an optimized load if desired. Provides more control
+    over the creation of objects than normal.
+
+    Extends ABCMeta, so that we can use this for the abstract classes
+    """
+
+    def __call__(cls, *a, **kw):
+        return base_db_backed_call(super(), cls, a, kw)
+
+
+class MephistoDBBackedMeta(type):
+    """
+    Metaclass that overrides `call` to allow the current `MephistoDB` an
+    opportunity to do an optimized load if desired. Provides more control
+    over the creation of objects than normal.
+    """
+
+    def __call__(cls, *a, **kw):
+        return base_db_backed_call(super(), cls, a, kw)

--- a/mephisto/data_model/db_backed_meta.py
+++ b/mephisto/data_model/db_backed_meta.py
@@ -27,8 +27,6 @@ def base_db_backed_call(my_super, cls, a, kw):
     if loaded_val is None:
         loaded_val = my_super.__call__(*a, **kw)
         db.cache_result(cls, loaded_val)
-    else:
-        print("Loaded cached val", loaded_val)
     return loaded_val
 
 

--- a/mephisto/data_model/project.py
+++ b/mephisto/data_model/project.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from mephisto.data_model.constants import NO_PROJECT_NAME
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 
 from typing import List, Mapping, Any, Optional, TYPE_CHECKING
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from mephisto.data_model.task import Task
 
 
-class Project:
+class Project(metaclass=MephistoDBBackedMeta):
     """
     High level project that many crowdsourcing tasks may be related to. Useful
     for budgeting and grouping tasks for a review perspective.

--- a/mephisto/data_model/qualification.py
+++ b/mephisto/data_model/qualification.py
@@ -9,6 +9,7 @@ from mephisto.operations.registry import (
     get_crowd_provider_from_type,
     get_valid_provider_types,
 )
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 
 from typing import List, Optional, Mapping, Dict, TYPE_CHECKING, Any
 
@@ -162,7 +163,7 @@ def make_qualification_dict(
     return as_valid_qualification_dict(qual_dict)
 
 
-class Qualification:
+class Qualification(metaclass=MephistoDBBackedMeta):
     """Simple convenience wrapper for Qualifications in the data model"""
 
     def __init__(

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from abc import ABC, abstractmethod, abstractstaticmethod
+from abc import abstractmethod, abstractstaticmethod
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from dataclasses import dataclass, field
 from omegaconf import MISSING, DictConfig
 
@@ -33,7 +34,7 @@ class RequesterArgs:
     )
 
 
-class Requester(ABC):
+class Requester(metaclass=MephistoDBBackedABCMeta):
     """
     High level class representing a requester on some kind of crowd provider. Sets some default
     initializations, but mostly should be extended by the specific requesters for crowd providers

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -9,6 +9,7 @@ import os
 from shutil import copytree
 
 from mephisto.data_model.project import Project
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from mephisto.operations.utils import (
     get_dir_for_task,
     ensure_user_confirm,
@@ -44,7 +45,7 @@ def assert_task_is_valid(dir_name, task_type) -> None:
 # executable and becoming just storage for other information.
 
 
-class Task:
+class Task(metaclass=MephistoDBBackedMeta):
     """
     This class contains all of the required tidbits for launching a set of
     assignments, primarily by leveraging a blueprint. It also takes the

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -11,6 +11,7 @@ import json
 from mephisto.data_model.requester import Requester
 from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.data_model.task_config import TaskConfig
+from mephisto.data_model.db_backed_meta import MephistoDBBackedMeta
 from mephisto.operations.utils import get_dir_for_run
 
 from omegaconf import OmegaConf
@@ -32,7 +33,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class TaskRun:
+class TaskRun(metaclass=MephistoDBBackedMeta):
     """
     This class tracks an individual run of a specific task, and handles state management
     for the set of assignments within

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -202,12 +202,10 @@ class Unit(metaclass=MephistoDBBackedABCMeta):
 
         # Query the database to get the most up-to-date assignment, as this can
         # change after instantiation if the Unit status isn't final
-        # TODO(#101) this may not be particularly efficient
-        row = self.db.get_unit(self.db_id)
-        assert row is not None, f"Unit {self.db_id} stopped existing in the db..."
-        agent_id = row["agent_id"]
-        if agent_id is not None:
-            return Agent(self.db, agent_id)
+        unit_copy = Unit(self.db, self.db_id)
+        self.agent_id = unit_copy.agent_id
+        if self.agent_id is not None:
+            return Agent(self.db, self.agent_id)
         return None
 
     @staticmethod

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -10,6 +10,7 @@ from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.data_model.task import Task
 from mephisto.data_model.task_run import TaskRun
 from mephisto.data_model.agent import Agent
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.requester import Requester
 from typing import Optional, Mapping, Dict, Any, Type, TYPE_CHECKING
@@ -27,7 +28,7 @@ from mephisto.operations.logger_core import get_logger
 logger = get_logger(name=__name__)
 
 
-class Unit(ABC):
+class Unit(metaclass=MephistoDBBackedABCMeta):
     """
     This class tracks the status of an individual worker's contribution to a
     higher level assignment. It is the smallest 'unit' of work to complete

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -7,6 +7,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from mephisto.abstractions.blueprint import AgentState
+from mephisto.data_model.db_backed_meta import MephistoDBBackedABCMeta
 from typing import Any, List, Optional, Mapping, Tuple, Dict, Type, Tuple, TYPE_CHECKING
 from mephisto.operations.logger_core import get_logger
 
@@ -37,7 +38,7 @@ class WorkerArgs:
     )
 
 
-class Worker(ABC):
+class Worker(metaclass=MephistoDBBackedABCMeta):
     """
     This class represents an individual - namely a person. It maintains components of ongoing identity for a user.
     """

--- a/mephisto/operations/hydra_config.py
+++ b/mephisto/operations/hydra_config.py
@@ -17,11 +17,17 @@ config = ConfigStoreWithProvider("mephisto")
 
 
 @dataclass
+class DatabaseArgs:
+    _database_type: str = "local"  # default DB is local
+
+
+@dataclass
 class MephistoConfig:
     blueprint: BlueprintArgs = BlueprintArgs()
     provider: ProviderArgs = ProviderArgs()
     architect: ArchitectArgs = ArchitectArgs()
     task: TaskConfigArgs = TaskConfigArgs()
+    database: DatabaseArgs = DatabaseArgs()
     log_level: str = "info"
 
 

--- a/mephisto/tools/scripts.py
+++ b/mephisto/tools/scripts.py
@@ -8,6 +8,7 @@ Utilities that are useful for Mephisto-related scripts.
 """
 
 from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
 from mephisto.operations.utils import get_mock_requester, get_root_data_dir
 
 from omegaconf import DictConfig, OmegaConf
@@ -49,7 +50,15 @@ def get_db_from_config(cfg: DictConfig) -> "MephistoDB":
         datapath = get_root_data_dir()
 
     database_path = os.path.join(datapath, "database.db")
-    return LocalMephistoDB(database_path=database_path)
+
+    database_type = cfg.mephisto.database._database_type
+
+    if database_type == "local":
+        return LocalMephistoDB(database_path=database_path)
+    elif database_type == "singleton":
+        return MephistoSingletonDB(database_path=database_path)
+    else:
+        raise AssertionError(f"Provided database_type {database_type} is not valid")
 
 
 def augment_config_from_db(script_cfg: DictConfig, db: "MephistoDB") -> DictConfig:

--- a/test/abstractions/databases/test_local_database.py
+++ b/test/abstractions/databases/test_local_database.py
@@ -21,6 +21,8 @@ class TestLocalMephistoDB(BaseDatabaseTests):
     writes no additional tests.
     """
 
+    is_base = False
+
     def setUp(self):
         self.data_dir = tempfile.mkdtemp()
         database_path = os.path.join(self.data_dir, "mephisto.db")

--- a/test/abstractions/databases/test_singleton_database.py
+++ b/test/abstractions/databases/test_singleton_database.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+import shutil
+import os
+import tempfile
+
+from mephisto.abstractions.test.data_model_database_tester import BaseDatabaseTests
+from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
+
+
+class TestMephistoSingletonDB(BaseDatabaseTests):
+    """
+    Unit testing for the MephistoSingletonDB
+
+    Inherits all tests directly from BaseDataModelTests, and
+    writes no additional tests.
+    """
+
+    is_base = False
+
+    def setUp(self):
+        self.data_dir = tempfile.mkdtemp()
+        database_path = os.path.join(self.data_dir, "mephisto.db")
+        self.db = MephistoSingletonDB(database_path)
+
+    def tearDown(self):
+        self.db.shutdown()
+        shutil.rmtree(self.data_dir)
+
+    # TODO(#97) are there any other unit tests we'd like to have?
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview
As it's important for us not to assign two Units the same HIT id, we have a lock around the database reads for the `MTurkDatastore`. Unfortunately, this means that every time we check the status of a HIT-Unit pairing in this DB, we're locked. We tend to do these syncs in a sequential fashion, so this turns out to be a rather large time lock.

We _could_ do something with read/write specific locks, but I feel that overcomplicates the setup - luckily we don't do the writes very often, so we can instead move to a model where readers can skip the read (and the lock) entirely so long as they've synced more recently than the most recent invalidation. 

## Implementation
`MTurkUnit`s now keep track of their `_last_sync_time`, which corresponds to the last time they got their `hit_id` and `assignment_id` from the db. When asked to sync, if this time is more recent than the last invalidation, they skip the sync.

The `MTurkDatastore` now also keeps a time for the last time a change was made to the table corresponding to this table, and as such the `MTurkUnit` can query `is_hit_mapping_in_sync` to ensure it's still valid.

## Testing
1. Ran local tests
2. Launched and completed an MTurk sandbox job.