### PR TITLE
Update internal inits

### DIFF
--- a/examples/simple_static_task/examine_results.py
+++ b/examples/simple_static_task/examine_results.py
@@ -35,7 +35,7 @@ else:
 
 def format_for_printing_data(data):
     # Custom tasks can define methods for how to display their data in a relevant way
-    worker_name = Worker(db, data["worker_id"]).worker_name
+    worker_name = Worker.get(db, data["worker_id"]).worker_name
     contents = data["data"]
     duration = contents["times"]["task_end"] - contents["times"]["task_start"]
     metadata_string = (
@@ -50,7 +50,7 @@ def format_for_printing_data(data):
     output_string = f"   Rating: {outputs['rating']}\n"
     found_files = outputs.get("files")
     if found_files is not None:
-        file_dir = Unit(db, data["unit_id"]).get_assigned_agent().get_data_dir()
+        file_dir = Unit.get(db, data["unit_id"]).get_assigned_agent().get_data_dir()
         output_string += f"   Files: {found_files}\n"
         output_string += f"   File directory {file_dir}\n"
     else:

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -356,7 +356,10 @@ class LocalMephistoDB(MephistoDB):
                 (project_name,),
             )
             rows = c.fetchall()
-            return [Project(self, str(r["project_id"]), row=r) for r in rows]
+            return [
+                Project(self, str(r["project_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_task(
         self,
@@ -429,7 +432,9 @@ class LocalMephistoDB(MephistoDB):
                 (task_name, nonesafe_int(project_id), nonesafe_int(parent_task_id)),
             )
             rows = c.fetchall()
-            return [Task(self, str(r["task_id"]), row=r) for r in rows]
+            return [
+                Task(self, str(r["task_id"]), row=r, _used_new_call=True) for r in rows
+            ]
 
     def update_task(
         self,
@@ -554,7 +559,10 @@ class LocalMephistoDB(MephistoDB):
                 (nonesafe_int(task_id), nonesafe_int(requester_id), is_completed),
             )
             rows = c.fetchall()
-            return [TaskRun(self, str(r["task_run_id"]), row=r) for r in rows]
+            return [
+                TaskRun(self, str(r["task_run_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def update_task_run(self, task_run_id: str, is_completed: bool):
         """
@@ -657,7 +665,10 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Assignment(self, str(r["assignment_id"]), row=r) for r in rows]
+            return [
+                Assignment(self, str(r["assignment_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_unit(
         self,
@@ -773,7 +784,9 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Unit(self, str(r["unit_id"]), row=r) for r in rows]
+            return [
+                Unit(self, str(r["unit_id"]), row=r, _used_new_call=True) for r in rows
+            ]
 
     def clear_unit_agent_assignment(self, unit_id: str) -> None:
         """
@@ -885,7 +898,10 @@ class LocalMephistoDB(MephistoDB):
                 (requester_name, provider_type),
             )
             rows = c.fetchall()
-            return [Requester(self, str(r["requester_id"]), row=r) for r in rows]
+            return [
+                Requester(self, str(r["requester_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_worker(self, worker_name: str, provider_type: str) -> str:
         """
@@ -941,7 +957,10 @@ class LocalMephistoDB(MephistoDB):
                 (worker_name, provider_type),
             )
             rows = c.fetchall()
-            return [Worker(self, str(r["worker_id"]), row=r) for r in rows]
+            return [
+                Worker(self, str(r["worker_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_agent(
         self,
@@ -1117,7 +1136,10 @@ class LocalMephistoDB(MephistoDB):
             )
             rows = c.fetchall()
             return [
-                Qualification(self, str(r["qualification_id"]), row=r) for r in rows
+                Qualification(
+                    self, str(r["qualification_id"]), row=r, _used_new_call=True
+                )
+                for r in rows
             ]
 
     def get_qualification(self, qualification_id: str) -> Mapping[str, Any]:

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -1073,7 +1073,10 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Agent(self, str(r["agent_id"]), row=r) for r in rows]
+            return [
+                Agent(self, str(r["agent_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def make_qualification(self, qualification_name: str) -> str:
         """
@@ -1365,6 +1368,8 @@ class LocalMephistoDB(MephistoDB):
             )
             rows = c.fetchall()
             return [
-                OnboardingAgent(self, str(r["onboarding_agent_id"]), row=r)
+                OnboardingAgent(
+                    self, str(r["onboarding_agent_id"]), row=r, _used_new_call=True
+                )
                 for r in rows
             ]

--- a/mephisto/abstractions/providers/mturk/utils/script_utils.py
+++ b/mephisto/abstractions/providers/mturk/utils/script_utils.py
@@ -58,7 +58,7 @@ def get_mturk_ids_from_unit_id(db, unit_id: str) -> Dict[str, Optional[str]]:
     """
     Find the relevant mturk ids from the given mephisto unit id
     """
-    mturk_unit = Unit(db, unit_id)
+    mturk_unit = Unit.get(db, unit_id)
     assignment_id = mturk_unit.get_mturk_assignment_id()
     hit_id = mturk_unit.get_mturk_hit_id()
     agent = mturk_unit.get_assigned_agent()

--- a/mephisto/abstractions/test/architect_tester.py
+++ b/mephisto/abstractions/test/architect_tester.py
@@ -91,7 +91,7 @@ class ArchitectTests(unittest.TestCase):
         database_path = os.path.join(self.data_dir, "mephisto.db")
         self.db = LocalMephistoDB(database_path)
         self.build_dir = tempfile.mkdtemp()
-        self.task_run = TaskRun(self.db, get_test_task_run(self.db))
+        self.task_run = TaskRun.get(self.db, get_test_task_run(self.db))
         builder = MockTaskBuilder(self.task_run, {})
         builder.build_in_dir(self.build_dir)
 

--- a/mephisto/abstractions/test/blueprint_tester.py
+++ b/mephisto/abstractions/test/blueprint_tester.py
@@ -87,7 +87,7 @@ class BlueprintTests(unittest.TestCase):
         database_path = os.path.join(self.data_dir, "mephisto.db")
         self.db = LocalMephistoDB(database_path)
         # TODO(#97) we need to actually pull the task type from the Blueprint
-        self.task_run = TaskRun(self.db, get_test_task_run(self.db))
+        self.task_run = TaskRun.get(self.db, get_test_task_run(self.db))
         # TODO(#97) create a mock agent with the given task type?
         self.TaskRunnerClass = self.BlueprintClass.TaskRunnerClass
         self.AgentStateClass = self.BlueprintClass.AgentStateClass

--- a/mephisto/abstractions/test/crowd_provider_tester.py
+++ b/mephisto/abstractions/test/crowd_provider_tester.py
@@ -149,7 +149,7 @@ class CrowdProviderTests(unittest.TestCase):
         requester = self.get_test_requester()
         WorkerClass = self.CrowdProviderClass.WorkerClass
         test_worker = WorkerClass.new(db, self.get_test_worker_name())
-        test_worker_2 = Worker(db, test_worker.db_id)
+        test_worker_2 = Worker.get(db, test_worker.db_id)
         self.assertEqual(
             test_worker.worker_name,
             test_worker_2.worker_name,

--- a/mephisto/abstractions/test/data_model_database_tester.py
+++ b/mephisto/abstractions/test/data_model_database_tester.py
@@ -752,7 +752,7 @@ class BaseDatabaseTests(unittest.TestCase):
         units = db.find_units(status=AssignmentState.ASSIGNED)
         self.assertEqual(len(units), 1)
 
-        agent = Agent(db, agent_id)
+        agent = Agent.get(db, agent_id)
         self.assertEqual(agent.worker_id, worker_id)
 
         # Check finding for agents
@@ -779,7 +779,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Cant get non-existent entry
         with self.assertRaises(EntryDoesNotExistException):
-            agent = Agent(db, self.get_fake_id("Agent"))
+            agent = Agent.get(db, self.get_fake_id("Agent"))
 
         unit_id = get_test_unit(db)
         worker_name, worker_id = get_test_worker(db)

--- a/mephisto/abstractions/test/data_model_database_tester.py
+++ b/mephisto/abstractions/test/data_model_database_tester.py
@@ -118,7 +118,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertTrue(isinstance(project_id, str))
         project_row = db.get_project(project_id)
         self.assertEqual(project_row["project_name"], project_name)
-        project = Project(db, project_id)
+        project = Project.new(db, project_id)
         self.assertEqual(project.project_name, project_name)
 
         # Check finding for projects
@@ -145,7 +145,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Cant get non-existent entry
         with self.assertRaises(EntryDoesNotExistException):
-            project = Project(db, self.get_fake_id("Project"))
+            project = Project.new(db, self.get_fake_id("Project"))
 
         project_name = "test_project"
         project_id = db.new_project(project_name)
@@ -184,7 +184,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertEqual(task_row["task_type"], task_type)
         self.assertEqual(task_row["project_id"], project_id)
         self.assertIsNone(task_row["parent_task_id"])
-        task = Task(db, task_id_1)
+        task = Task.get(db, task_id_1)
         self.assertEqual(task.task_name, task_name_1)
 
         # Check creation of a task with a parent task, but no project
@@ -197,7 +197,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertEqual(task_row["task_type"], task_type)
         self.assertEqual(task_row["parent_task_id"], task_id_1)
         self.assertIsNone(task_row["project_id"])
-        task = Task(db, task_id_2)
+        task = Task.get(db, task_id_2)
         self.assertEqual(task.task_name, task_name_2)
 
         # Check finding for tasks
@@ -234,7 +234,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Cant get non-existent entry
         with self.assertRaises(EntryDoesNotExistException):
-            task = Task(db, self.get_fake_id("Task"))
+            task = Task.get(db, self.get_fake_id("Task"))
 
         task_name = "test_task"
         task_name_2 = "test_task_2"
@@ -407,7 +407,7 @@ class BaseDatabaseTests(unittest.TestCase):
         worker_row = db.get_worker(worker_id)
         self.assertEqual(worker_row["worker_name"], worker_name)
 
-        worker = Worker(db, worker_id)
+        worker = Worker.get(db, worker_id)
         self.assertEqual(worker.worker_name, worker_name)
 
         # Check finding for workers
@@ -434,7 +434,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Cant get non-existent entry
         with self.assertRaises(EntryDoesNotExistException):
-            worker = Worker(db, self.get_fake_id("Worker"))
+            worker = Worker.get(db, self.get_fake_id("Worker"))
 
         worker_name = "test_worker"
         provider_type = PROVIDER_TYPE
@@ -469,7 +469,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertTrue(isinstance(task_run_id, str))
         task_run_row = db.get_task_run(task_run_id)
         self.assertEqual(task_run_row["init_params"], init_params)
-        task_run = TaskRun(db, task_run_id)
+        task_run = TaskRun.get(db, task_run_id)
         self.assertEqual(task_run.task_id, task_id)
 
         # Check finding for task_runs
@@ -537,7 +537,7 @@ class BaseDatabaseTests(unittest.TestCase):
         db: MephistoDB = self.db
 
         task_run_id = get_test_task_run(db)
-        task_run = TaskRun(db, task_run_id)
+        task_run = TaskRun.get(db, task_run_id)
 
         # Check creation and retrieval of an assignment
         assignment_id = db.new_assignment(
@@ -552,7 +552,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertTrue(isinstance(assignment_id, str))
         assignment_row = db.get_assignment(assignment_id)
         self.assertEqual(assignment_row["task_run_id"], task_run_id)
-        assignment = Assignment(db, assignment_id)
+        assignment = Assignment.get(db, assignment_id)
         self.assertEqual(assignment.task_run_id, task_run_id)
 
         # Check finding for assignments
@@ -578,7 +578,7 @@ class BaseDatabaseTests(unittest.TestCase):
         db: MephistoDB = self.db
 
         task_run_id = get_test_task_run(db)
-        task_run = TaskRun(db, task_run_id)
+        task_run = TaskRun.get(db, task_run_id)
         # Can't create task run with invalid ids
         with self.assertRaises(EntryDoesNotExistException):
             assignment_id = db.new_assignment(
@@ -601,7 +601,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Check creation and retrieval of a unit
         assignment_id = get_test_assignment(db)
-        assignment = Assignment(db, assignment_id)
+        assignment = Assignment.get(db, assignment_id)
         unit_index = 0
         pay_amount = 15.0
         provider_type = PROVIDER_TYPE
@@ -623,7 +623,7 @@ class BaseDatabaseTests(unittest.TestCase):
         self.assertEqual(unit_row["pay_amount"], pay_amount)
         self.assertEqual(unit_row["status"], AssignmentState.CREATED)
 
-        unit = Unit(db, unit_id)
+        unit = Unit.get(db, unit_id)
         self.assertEqual(unit.assignment_id, assignment_id)
 
         # Check finding for units
@@ -652,10 +652,10 @@ class BaseDatabaseTests(unittest.TestCase):
 
         # Cant get non-existent entry
         with self.assertRaises(EntryDoesNotExistException):
-            unit = Unit(db, self.get_fake_id("Unit"))
+            unit = Unit.get(db, self.get_fake_id("Unit"))
 
         assignment_id = get_test_assignment(db)
-        assignment = Assignment(db, assignment_id)
+        assignment = Assignment.get(db, assignment_id)
         unit_index = 0
         pay_amount = 15.0
         provider_type = PROVIDER_TYPE
@@ -730,7 +730,7 @@ class BaseDatabaseTests(unittest.TestCase):
         # Check creation and retrieval of a agent
         worker_name, worker_id = get_test_worker(db)
         unit_id = get_test_unit(db)
-        unit = Unit(db, unit_id)
+        unit = Unit.get(db, unit_id)
 
         agent_id = db.new_agent(
             worker_id,
@@ -783,7 +783,7 @@ class BaseDatabaseTests(unittest.TestCase):
 
         unit_id = get_test_unit(db)
         worker_name, worker_id = get_test_worker(db)
-        unit = Unit(db, unit_id)
+        unit = Unit.get(db, unit_id)
 
         # Can't use invalid worker id
         with self.assertRaises(EntryDoesNotExistException):
@@ -915,7 +915,7 @@ class BaseDatabaseTests(unittest.TestCase):
         db: MephistoDB = self.db
 
         task_run_id = get_test_task_run(db)
-        task_run = TaskRun(db, task_run_id)
+        task_run = TaskRun.get(db, task_run_id)
         task = task_run.get_task()
         worker_name, worker_id = get_test_worker(db)
 
@@ -924,7 +924,7 @@ class BaseDatabaseTests(unittest.TestCase):
         )
         self.assertIsNotNone(onboarding_agent_id)
 
-        onboarding_agent = OnboardingAgent(db, onboarding_agent_id)
+        onboarding_agent = OnboardingAgent.get(db, onboarding_agent_id)
         self.assertIsInstance(onboarding_agent, OnboardingAgent)
 
         found_agents = db.find_onboarding_agents(worker_id=worker_id)

--- a/mephisto/abstractions/test/utils.py
+++ b/mephisto/abstractions/test/utils.py
@@ -175,7 +175,7 @@ def make_completed_unit(db: MephistoDB) -> str:
         task_run.task_type,
         task_run.provider_type,
     )
-    agent = Agent(db, agent_id)
+    agent = Agent.get(db, agent_id)
     agent.mark_done()
     unit = Unit(db, unit_id)
     unit.sync_status()

--- a/mephisto/abstractions/test/utils.py
+++ b/mephisto/abstractions/test/utils.py
@@ -92,7 +92,7 @@ def get_test_task_run(db: MephistoDB) -> str:
 def get_test_assignment(db: MephistoDB) -> str:
     """Helper to create an assignment for tests"""
     task_run_id = get_test_task_run(db)
-    task_run = TaskRun(db, task_run_id)
+    task_run = TaskRun.get(db, task_run_id)
     return db.new_assignment(
         task_run.task_id,
         task_run_id,
@@ -106,7 +106,7 @@ def get_test_unit(db: MephistoDB, unit_index=0) -> str:
     # Check creation and retrieval of a unit
     assignment_id = get_test_assignment(db)
     pay_amount = 15.0
-    assignment = Assignment(db, assignment_id)
+    assignment = Assignment.get(db, assignment_id)
     return db.new_unit(
         assignment.task_id,
         assignment.task_run_id,
@@ -126,7 +126,7 @@ def get_test_agent(db: MephistoDB, unit_id=None) -> str:
         unit_id = get_test_unit(db)
     provider_type = "mock"
     task_type = "mock"
-    unit = Unit(db, unit_id)
+    unit = Unit.get(db, unit_id)
     return db.new_agent(
         worker_id,
         unit.db_id,
@@ -177,6 +177,6 @@ def make_completed_unit(db: MephistoDB) -> str:
     )
     agent = Agent.get(db, agent_id)
     agent.mark_done()
-    unit = Unit(db, unit_id)
+    unit = Unit.get(db, unit_id)
     unit.sync_status()
     return unit.db_id

--- a/mephisto/client/api.py
+++ b/mephisto/client/api.py
@@ -60,7 +60,7 @@ def get_reviewable_task_runs():
     units = db.find_units(status=AssignmentState.COMPLETED)
     reviewable_count = len(units)
     task_run_ids = set([u.get_assignment().get_task_run().db_id for u in units])
-    task_runs = [TaskRun(db, db_id) for db_id in task_run_ids]
+    task_runs = [TaskRun.get(db, db_id) for db_id in task_run_ids]
     dict_tasks = [t.to_dict() for t in task_runs]
     # TODO(OWN) maybe include warning for auto approve date once that's tracked
     return jsonify({"task_runs": dict_tasks, "total_reviewable": reviewable_count})
@@ -175,12 +175,12 @@ def get_submitted_data():
         assignments = []
         assert len(task_names) == 0, "Searching via task names not yet supported"
 
-        task_runs = [TaskRun(db, task_run_id) for task_run_id in task_run_ids]
+        task_runs = [TaskRun.get(db, task_run_id) for task_run_id in task_run_ids]
         for task_run in task_runs:
             assignments += task_run.get_assignments()
 
         assignments += [
-            Assignment(db, assignment_id) for assignment_id in assignment_ids
+            Assignment.get(db, assignment_id) for assignment_id in assignment_ids
         ]
 
         if len(statuses) == 0:
@@ -195,7 +195,7 @@ def get_submitted_data():
         for assignment in assignments:
             units += assignment.get_units()
 
-        units += [Unit(db, unit_id) for unit_id in unit_ids]
+        units += [Unit.get(db, unit_id) for unit_id in unit_ids]
 
         all_unit_data = []
         for unit in units:

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -132,7 +132,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         Return the worker that is using this agent for a task
         """
         if self._worker is None:
-            self._worker = Worker(self.db, self.worker_id)
+            self._worker = Worker.get(self.db, self.worker_id)
         return self._worker
 
     def get_unit(self) -> "Unit":
@@ -142,7 +142,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         if self._unit is None:
             from mephisto.data_model.unit import Unit
 
-            self._unit = Unit(self.db, self.unit_id)
+            self._unit = Unit.get(self.db, self.unit_id)
         return self._unit
 
     def get_assignment(self) -> "Assignment":
@@ -153,7 +153,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             else:
                 from mephisto.data_model.assignment import Assignment
 
-                self._assignment = Assignment(self.db, self.assignment_id)
+                self._assignment = Assignment.get(self.db, self.assignment_id)
         return self._assignment
 
     def get_task_run(self) -> "TaskRun":
@@ -166,7 +166,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             else:
                 from mephisto.data_model.task_run import TaskRun
 
-                self._task_run = TaskRun(self.db, self.task_run_id)
+                self._task_run = TaskRun.get(self.db, self.task_run_id)
         return self._task_run
 
     def get_task(self) -> "Task":
@@ -181,7 +181,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             else:
                 from mephisto.data_model.task import Task
 
-                self._task = Task(self.db, self.task_id)
+                self._task = Task.get(self.db, self.task_id)
         return self._task
 
     def get_data_dir(self) -> str:
@@ -454,7 +454,7 @@ class OnboardingAgent(MephistoDataModelComponentMixin, metaclass=MephistoDBBacke
         Return the worker that is using this agent for a task
         """
         if self._worker is None:
-            self._worker = Worker(self.db, self.worker_id)
+            self._worker = Worker.get(self.db, self.worker_id)
         return self._worker
 
     def get_task_run(self) -> "TaskRun":
@@ -462,7 +462,7 @@ class OnboardingAgent(MephistoDataModelComponentMixin, metaclass=MephistoDBBacke
         if self._task_run is None:
             from mephisto.data_model.task_run import TaskRun
 
-            self._task_run = TaskRun(self.db, self.task_run_id)
+            self._task_run = TaskRun.get(self.db, self.task_run_id)
         return self._task_run
 
     def get_task(self) -> "Task":
@@ -473,7 +473,7 @@ class OnboardingAgent(MephistoDataModelComponentMixin, metaclass=MephistoDBBacke
             else:
                 from mephisto.data_model.task import Task
 
-                self._task = Task(self.db, self.task_id)
+                self._task = Task.get(self.db, self.task_id)
         return self._task
 
     def get_data_dir(self) -> str:

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -235,7 +235,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             unit.task_type,
             provider_type,
         )
-        a = Agent(db, db_id)
+        a = Agent.get(db, db_id)
         logger.debug(f"Registered new agent {a} for {unit}.")
         a.update_status(AgentState.STATUS_ACCEPTED)
         return a
@@ -590,7 +590,7 @@ class OnboardingAgent(MephistoDataModelComponentMixin, metaclass=MephistoDBBacke
         db_id = db.new_onboarding_agent(
             worker.db_id, task_run.task_id, task_run.db_id, task_run.task_type
         )
-        a = OnboardingAgent(db, db_id)
+        a = OnboardingAgent.get(db, db_id)
         logger.debug(f"Registered new {a} for worker {worker}.")
         return a
 

--- a/mephisto/data_model/assignment.py
+++ b/mephisto/data_model/assignment.py
@@ -157,7 +157,7 @@ class Assignment(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta
         Return the task run that this assignment is part of
         """
         if self.__task_run is None:
-            self.__task_run = TaskRun(self.db, self.task_run_id)
+            self.__task_run = TaskRun.get(self.db, self.task_run_id)
         return self.__task_run
 
     def get_task(self) -> Task:
@@ -168,7 +168,7 @@ class Assignment(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta
             if self.__task_run is not None:
                 self.__task = self.__task_run.get_task()
             else:
-                self.__task = Task(self.db, self.task_id)
+                self.__task = Task.get(self.db, self.task_id)
         return self.__task
 
     def get_requester(self) -> Requester:
@@ -248,6 +248,6 @@ class Assignment(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta
                 os.path.join(assign_dir, ASSIGNMENT_DATA_FILE), "w+"
             ) as json_file:
                 json.dump(assignment_data, json_file)
-        assignment = Assignment(db, db_id)
+        assignment = Assignment.get(db, db_id)
         logger.debug(f"{assignment} created for {task_run}")
         return assignment

--- a/mephisto/data_model/project.py
+++ b/mephisto/data_model/project.py
@@ -74,4 +74,4 @@ class Project(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
             project_name != NO_PROJECT_NAME
         ), f"{project_name} is a reserved name that cannot be used as a project name."
         db_id = db.new_project(project_name)
-        return Project(db, db_id)
+        return Project.get(db, db_id)

--- a/mephisto/data_model/task.py
+++ b/mephisto/data_model/task.py
@@ -85,7 +85,7 @@ class Task(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
         Get the project for this task, if it exists
         """
         if self.project_id is not None:
-            return Project(self.db, self.project_id)
+            return Project.get(self.db, self.project_id)
         else:
             return None
 
@@ -181,7 +181,7 @@ class Task(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
         project_id = None if project is None else project.db_id
         parent_task_id = None if parent_task is None else parent_task.db_id
         db_id = db.new_task(task_name, task_type, project_id, parent_task_id)
-        return Task(db, db_id)
+        return Task.get(db, db_id)
 
         def __repr__(self):
             return f"Task-{self.task_name} [{self.task_type}]"

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -221,7 +221,7 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
         if self.__task is None:
             from mephisto.data_model.task import Task
 
-            self.__task = Task(self.db, self.task_id)
+            self.__task = Task.get(self.db, self.task_id)
         return self.__task
 
     def get_task_config(self) -> "TaskConfig":
@@ -356,6 +356,6 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
             requester.provider_type,
             task.task_type,
         )
-        task_run = TaskRun(db, db_id)
+        task_run = TaskRun.get(db, db_id)
         logger.debug(f"Created new task run {task_run}")
         return task_run

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -213,7 +213,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         if self.db_status in AssignmentState.final_unit():
             if self.agent_id is None:
                 return None
-            return Agent(self.db, self.agent_id)
+            return Agent.get(self.db, self.agent_id)
 
         # Query the database to get the most up-to-date assignment, as this can
         # change after instantiation if the Unit status isn't final
@@ -222,7 +222,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         assert row is not None, f"Unit {self.db_id} stopped existing in the db..."
         agent_id = row["agent_id"]
         if agent_id is not None:
-            return Agent(self.db, agent_id)
+            return Agent.get(self.db, agent_id)
         return None
 
     @staticmethod

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -155,7 +155,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         if self.__assignment is None:
             from mephisto.data_model.assignment import Assignment
 
-            self.__assignment = Assignment(self.db, self.assignment_id)
+            self.__assignment = Assignment.get(self.db, self.assignment_id)
         return self.__assignment
 
     def get_task_run(self) -> TaskRun:
@@ -166,7 +166,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             if self.__assignment is not None:
                 self.__task_run = self.__assignment.get_task_run()
             else:
-                self.__task_run = TaskRun(self.db, self.task_run_id)
+                self.__task_run = TaskRun.get(self.db, self.task_run_id)
         return self.__task_run
 
     def get_task(self) -> Task:
@@ -179,7 +179,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             elif self.__task_run is not None:
                 self.__task = self.__task_run.get_task()
             else:
-                self.__task = Task(self.db, self.task_id)
+                self.__task = Task.get(self.db, self.task_id)
         return self.__task
 
     def get_requester(self) -> "Requester":
@@ -246,7 +246,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             provider_type,
             assignment.task_type,
         )
-        unit = Unit(db, db_id)
+        unit = Unit.get(db, db_id)
         logger.debug(f"Registered new unit {unit} for {assignment}.")
         return unit
 

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -114,7 +114,7 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
         Create an entry for this worker in the database
         """
         db_id = db.new_worker(worker_name, provider_type)
-        worker = Worker(db, db_id)
+        worker = Worker.get(db, db_id)
         logger.debug(f"Registered new worker {worker}")
         return worker
 

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -190,7 +190,7 @@ class Operator:
             blueprint_type,
             requester.is_sandbox(),
         )
-        task_run = TaskRun(self.db, new_run_id)
+        task_run = TaskRun.get(self.db, new_run_id)
 
         try:
             # Register the blueprint with args to the task run,

--- a/mephisto/operations/supervisor.py
+++ b/mephisto/operations/supervisor.py
@@ -406,7 +406,7 @@ class Supervisor:
         task_run = channel_info.job.task_runner.task_run
         crowd_provider = channel_info.job.provider
         worker_id = crowd_data["worker_id"]
-        worker = Worker(self.db, worker_id)
+        worker = Worker.get(self.db, worker_id)
 
         logger.debug(
             f"Worker {worker_id} is being assigned one of " f"{len(units)} units."
@@ -570,7 +570,7 @@ class Supervisor:
         task_runner = channel_info.job.task_runner
         task_run = task_runner.task_run
         worker_id = crowd_data["worker_id"]
-        worker = Worker(self.db, worker_id)
+        worker = Worker.get(self.db, worker_id)
 
         # get the list of tentatively valid units
         units = task_run.get_valid_units_for_worker(worker)
@@ -591,7 +591,7 @@ class Supervisor:
 
         # If there's onboarding, see if this worker has already been disqualified
         worker_id = crowd_data["worker_id"]
-        worker = Worker(self.db, worker_id)
+        worker = Worker.get(self.db, worker_id)
         blueprint = task_run.get_blueprint(args=task_runner.args)
         if isinstance(blueprint, OnboardingRequired) and blueprint.use_onboarding:
             if worker.is_disqualified(blueprint.onboarding_qualification_name):

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -96,7 +96,7 @@ class TaskLauncher:
             task_run.provider_type,
             task_run.sandbox,
         )
-        assignment = Assignment(self.db, assignment_id)
+        assignment = Assignment.get(self.db, assignment_id)
         assignment.write_assignment_data(assignment_data)
         self.assignments.append(assignment)
         unit_count = len(assignment_data.unit_data)
@@ -112,9 +112,9 @@ class TaskLauncher:
                 task_run.task_type,
                 task_run.sandbox,
             )
-            self.units.append(Unit(self.db, unit_id))
+            self.units.append(Unit.get(self.db, unit_id))
             with self.unlaunched_units_access_condition:
-                self.unlaunched_units[unit_id] = Unit(self.db, unit_id)
+                self.unlaunched_units[unit_id] = Unit.get(self.db, unit_id)
 
     def _try_generating_assignments(self) -> None:
         """ Try to generate more assignments from the assignments_data_iterator"""

--- a/mephisto/scripts/local_db/load_data_to_mephisto_db.py
+++ b/mephisto/scripts/local_db/load_data_to_mephisto_db.py
@@ -123,7 +123,7 @@ for annotation in test_annotations:
         task_run.provider_type,
         task_run.sandbox,
     )
-    assignment = Assignment(db, assignment_id)
+    assignment = Assignment.get(db, assignment_id)
     assignment.write_assignment_data(
         InitializationData(unit_data={}, shared=annotation["inputs"])
     )
@@ -140,7 +140,7 @@ for annotation in test_annotations:
         task_run.sandbox,
     )
 
-    unit = Unit(db, unit_id)
+    unit = Unit.get(db, unit_id)
     agent = MockAgent.new(db, worker, unit)
     agent.state.state["inputs"] = annotation["inputs"]
     agent.state.state["outputs"] = annotation["outputs"]

--- a/mephisto/scripts/mturk/print_outstanding_hit_status.py
+++ b/mephisto/scripts/mturk/print_outstanding_hit_status.py
@@ -18,7 +18,7 @@ from typing import cast
 
 task_run_id = input("Please enter the task_run_id you'd like to check: ")
 db = LocalMephistoDB()
-task_run = TaskRun(db, task_run_id)
+task_run = TaskRun.get(db, task_run_id)
 requester = task_run.get_requester()
 if not isinstance(requester, MTurkRequester):
     print(

--- a/mephisto/tools/data_browser.py
+++ b/mephisto/tools/data_browser.py
@@ -65,7 +65,7 @@ class DataBrowser:
         Return a list of all Units in a terminal completed state from the
         task run with the given run_id
         """
-        task_run = TaskRun(self.db, run_id)
+        task_run = TaskRun.get(self.db, run_id)
         return self._get_units_for_task_runs([task_run])
 
     def get_data_from_unit(self, unit: Unit) -> Dict[str, Any]:

--- a/test/abstractions/blueprints/test_mock_blueprint.py
+++ b/test/abstractions/blueprints/test_mock_blueprint.py
@@ -94,7 +94,7 @@ class MockBlueprintTests(BlueprintTests):
             task_run.task_type,
             task_run.provider_type,
         )
-        Agent = MockAgent(self.db, agent_id)
+        Agent = MockAgent.get(self.db, agent_id)
         return assign
 
     def assignment_is_tracked(

--- a/test/abstractions/blueprints/test_mock_blueprint.py
+++ b/test/abstractions/blueprints/test_mock_blueprint.py
@@ -71,7 +71,7 @@ class MockBlueprintTests(BlueprintTests):
             task_run.task_type,
             task_run.provider_type,
         )
-        assign = Assignment(self.db, assignment_id)
+        assign = Assignment.get(self.db, assignment_id)
         unit_id = self.db.new_unit(
             task_run.task_id,
             task_run.db_id,
@@ -82,9 +82,9 @@ class MockBlueprintTests(BlueprintTests):
             task_run.provider_type,
             task_run.task_type,
         )
-        unit = MockUnit(self.db, unit_id)
+        unit = MockUnit.get(self.db, unit_id)
         worker_id = self.db.new_worker("MOCK_TEST_WORKER", MOCK_PROVIDER_TYPE)
-        worker = MockWorker(self.db, worker_id)
+        worker = MockWorker.get(self.db, worker_id)
         agent_id = self.db.new_agent(
             worker.db_id,
             unit_id,

--- a/test/abstractions/providers/mturk/test_mturk.py
+++ b/test/abstractions/providers/mturk/test_mturk.py
@@ -43,7 +43,7 @@ class TestMTurkComponents(unittest.TestCase):
         TEST_MTURK_WORKER_ID = "ABCDEFGHIJ"
 
         test_worker = MTurkWorker.new(db, TEST_MTURK_WORKER_ID)
-        test_worker_2 = Worker(db, test_worker.db_id)
+        test_worker_2 = Worker.get(db, test_worker.db_id)
         self.assertEqual(
             test_worker.worker_name,
             test_worker_2.worker_name,

--- a/test/core/test_supervisor.py
+++ b/test/core/test_supervisor.py
@@ -52,7 +52,7 @@ class TestSupervisor(unittest.TestCase):
         self.db = LocalMephistoDB(database_path)
         self.task_id = self.db.new_task("test_mock", MockBlueprint.BLUEPRINT_TYPE)
         self.task_run_id = get_test_task_run(self.db)
-        self.task_run = TaskRun(self.db, self.task_run_id)
+        self.task_run = TaskRun.get(self.db, self.task_run_id)
 
         architect_config = OmegaConf.structured(
             MephistoConfig(architect=MockArchitectArgs(should_run_server=True))

--- a/test/core/test_task_launcher.py
+++ b/test/core/test_task_launcher.py
@@ -50,7 +50,7 @@ class TestTaskLauncher(unittest.TestCase):
         database_path = os.path.join(self.data_dir, "mephisto.db")
         self.db = LocalMephistoDB(database_path)
         self.task_run_id = get_test_task_run(self.db)
-        self.task_run = TaskRun(self.db, self.task_run_id)
+        self.task_run = TaskRun.get(self.db, self.task_run_id)
 
     def tearDown(self):
         self.db.shutdown()


### PR DESCRIPTION
## Overview
Following the steps in #437 to deprecate the old method of initializing, this PR simply updates all of _our_ callsites to use the new version. This is excepting Database calls to the original `__init__` methods, as we assume any requests made _inside_ a database class could be optimized inside if they wanted to, and so the choice to not use `get` is to be respected.

## Implementation details
Ctrl-F for the various inits internally. 

## testing
CI tests