### PR TITLE
Make expire fast for completed units

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -210,7 +210,10 @@ class MTurkUnit(Unit):
         otherwise just return the maximum assignment duration
         """
         delay = 0
-        if self.get_status() == AssignmentState.ASSIGNED:
+        status = self.get_status()
+        if status in [AssignmentState.EXPIRED, AssignmentState.COMPLETED]:
+            return delay
+        if status == AssignmentState.ASSIGNED:
             # The assignment is currently being worked on,
             # so we will set the wait time to be the
             # amount of time we granted for working on this assignment


### PR DESCRIPTION
As I mentioned in https://github.com/facebookresearch/Mephisto/issues/431, we don't need to contact boto to expire a hit if it is already expired or completed.