### PR TITLE
Adding assignment-unit cache to singleton DB

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -84,10 +84,7 @@ class MTurkUnit(Unit):
         self.datastore.register_assignment_to_hit(
             hit_id, self.db_id, mturk_assignment_id
         )
-        self.hit_id = hit_id
-        self.mturk_assignment_id = mturk_assignment_id
-        # We made the change, so we can set the sync time.
-        self._last_sync_time = time.monotonic()
+        self._sync_hit_mapping()
 
     def get_mturk_assignment_id(self) -> Optional[str]:
         """

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -48,6 +48,9 @@ if TYPE_CHECKING:
     from argparse import Namespace
 
 
+RUN_STATUS_POLL_TIME = 10
+
+
 class TrackedRun(NamedTuple):
     task_run: TaskRun
     architect: "Architect"
@@ -306,7 +309,7 @@ class Operator:
                     tracked_run.architect.shutdown()
                     tracked_run.task_launcher.shutdown()
                     del self._task_runs_tracked[task_run.db_id]
-            time.sleep(10)
+            time.sleep(RUN_STATUS_POLL_TIME)
 
     def force_shutdown(self, timeout=5):
         """
@@ -460,7 +463,7 @@ class Operator:
                         if time.time() - last_log > log_rate:
                             last_log = time.time()
                             self.print_run_details()
-                    time.sleep(10)
+                    time.sleep(RUN_STATUS_POLL_TIME)
 
             except Exception as e:
                 if skip_input:

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -306,7 +306,7 @@ class Operator:
                     tracked_run.architect.shutdown()
                     tracked_run.task_launcher.shutdown()
                     del self._task_runs_tracked[task_run.db_id]
-            time.sleep(2)
+            time.sleep(10)
 
     def force_shutdown(self, timeout=5):
         """


### PR DESCRIPTION
## Overview
`Assignment.get_units` is currently the largest remaining call in the Mephisto profile when running with `MephistoSingletonDB` This PR looks to remove this chunk by adding a cache for this specific call.
![Screen Shot 2021-04-23 at 5 00 10 PM](https://user-images.githubusercontent.com/1276867/115931693-909a2d80-a459-11eb-81ce-78968bbf9236.png)


## Implementation
Creates a dict in the `MephistoSingletonDB` to hold a mapping between the given `assignment_id`s queried and the returned list of `Unit`s. Also adds a wrapper around `new_unit` to ensure that if a new unit is added to a given `assignment_id` we clear that cached value. Considering we're within a singleton, this is sufficient to ensure that the local units will always be up-to-date.

## Testing
In python shell:
```
>>> from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
>>> db = MephistoSingletonDB()
>>> from mephisto.data_model.task_run import TaskRun
>>> len(TaskRun(db, 1188).get_assignments())
300
>>> TaskRun(db, 1188).get_assignment_statuses()
{'created': 0, 'launched': 2, 'assigned': 0, 'completed': 0, 'accepted': 0, 'mixed': 0, 'rejected': 0, 'soft_rejected': 0, 'expired': 298}
>>> TaskRun(db, 1188).get_assignment_statuses()
{'created': 0, 'launched': 2, 'assigned': 0, 'completed': 0, 'accepted': 0, 'mixed': 0, 'rejected': 0, 'soft_rejected': 0, 'expired': 298}
```
The second call to `get_assignment_statuses()` was instant, where the first took about a second.
