### PR TITLE
Making MTurk agent approve idempotent

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_agent.py
+++ b/mephisto/abstractions/providers/mturk/mturk_agent.py
@@ -81,6 +81,9 @@ class MTurkAgent(Agent):
 
     def approve_work(self) -> None:
         """Approve the work done on this specific Unit"""
+        if self.get_status() == AgentState.STATUS_APPROVED:
+            logging.info(f"Approving already approved agent {self}, skipping")
+            return
         client = self._get_client()
         approve_work(client, self._get_mturk_assignment_id(), override_rejection=True)
         self.update_status(AgentState.STATUS_APPROVED)

--- a/mephisto/abstractions/providers/mturk/mturk_agent.py
+++ b/mephisto/abstractions/providers/mturk/mturk_agent.py
@@ -90,6 +90,9 @@ class MTurkAgent(Agent):
 
     def reject_work(self, reason) -> None:
         """Reject the work done on this specific Unit"""
+        if self.get_status() == AgentState.STATUS_APPROVED:
+            logging.warning(f"Cannot reject {self}, it is already approved")
+            return
         client = self._get_client()
         reject_work(client, self._get_mturk_assignment_id(), reason)
         self.update_status(AgentState.STATUS_REJECTED)


### PR DESCRIPTION
# Overview:
When a task auto-approves, it may end up in a review queue locally, and end up "approved". At that point, it wouldn't be possible to accept or reject again. This PR makes the failure an `info`/`warning` rather than an exception.