### PR TITLE
Getting complete MTurk pay for individual units

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -13,6 +13,9 @@ from mephisto.abstractions.providers.mturk.mturk_utils import (
     expire_hit,
     get_hit,
     create_hit_with_hit_type,
+    get_bonuses_for_assignment,
+    calculate_mturk_task_fee,
+    calculate_mturk_bonus_fee,
 )
 from mephisto.abstractions.providers.mturk.provider_type import PROVIDER_TYPE
 import time
@@ -122,6 +125,22 @@ class MTurkUnit(Unit):
 
         if self.db_status == AssignmentState.ASSIGNED:
             self.set_db_status(AssignmentState.LAUNCHED)
+
+    def get_pay_amount(self) -> float:
+        """
+        Return the amount that this Unit is costing against the budget,
+        calculating additional fees as relevant
+        """
+        requester = self.get_requester()
+        client = self._get_client(requester._requester_name)
+        task_amount = self.pay_amount
+        task_fee = calculate_mturk_task_fee(self.pay_amount)
+        bonus_amount = get_bonuses_for_assignment(
+            client,
+            self.get_mturk_assignment_id(),
+        )
+        bonus_fee = calculate_mturk_bonus_fee(bonus_amount)
+        return task_amount + task_fee + bonus_amount + bonus_fee
 
     # Required Unit functions
 

--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -129,6 +129,20 @@ def calculate_mturk_bonus_fee(bonus_amount: float) -> float:
     return MTURK_TASK_FEE * bonus_amount
 
 
+def get_bonuses_for_assignment(client: MTurkClient, assignment_id: str) -> float:
+    """
+    Sum the bonus payments associated with this HIT
+    """
+    resp = client.list_bonus_payments(AssignmentId=assignment_id, MaxResults=100)
+    if resp["NumResults"] == 0:
+        return 0.0
+    if len(resp["BonusPayments"]) == 0:
+        return 0.0
+    bonus_array = resp["BonusPayments"]
+    bonus_amounts = [float(b["BonusAmount"]) for b in bonus_array]
+    return sum(bonus_amounts)
+
+
 def get_requester_balance(client: MTurkClient) -> float:
     """Get the balance for the requester associated with this client"""
     return float(client.get_account_balance()["AvailableBalance"])


### PR DESCRIPTION
# Overview
At the moment `MTurkUnit`s are not properly reporting their pay amount.  In order to actually calculate the amount of spend on a particular `Unit`, we need to accommodate both the MTurk fees for the base pay and bonuses, as well as query the assignment for bonuses in the first place. This PR introduces the `get_bonuses_for_assignment` method which returns the sum payment of bonuses for a given assignment, and then uses that in the `MTurkUnit`'s implementation for `get_pay_amount`.