### PR TITLE
Extract all annotation-toolkit css into a single file at `build/main.css`

### DIFF
--- a/packages/annotation-toolkit/package.json
+++ b/packages/annotation-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "annotation-toolkit",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "build/bundle.js",
   "scripts": {
@@ -34,6 +34,7 @@
     "eslint-plugin-react-hooks": "2.x",
     "file-loader": "^6.2.0",
     "global-context-store": "^1.0.1",
+    "mini-css-extract-plugin": "^1.4.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-player": "^2.9.0",

--- a/packages/annotation-toolkit/webpack.config.js
+++ b/packages/annotation-toolkit/webpack.config.js
@@ -6,6 +6,7 @@
 
 var path = require("path");
 var webpack = require("webpack");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
   entry: "./src/index.js",
@@ -27,6 +28,11 @@ module.exports = {
     net: "empty",
     dns: "empty",
   },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "build/[name].css",
+    }),
+  ],
   module: {
     rules: [
       {
@@ -36,8 +42,8 @@ module.exports = {
         options: { presets: ["@babel/env"] },
       },
       {
-        test: /\.css$/,
-        loader: "style-loader!css-loader",
+        test: /\.*css$/,
+        use: [MiniCssExtractPlugin.loader, "css-loader"],
       },
       {
         test: /\.(svg|png|jpe?g|ttf)$/,


### PR DESCRIPTION
This is a webpack build update to extract all css for the annotation toolkit into a single file @ `/build/main.css`.
This is useful for single imports and CDN style imports (e.g. with iframe usage).

This is important to get iframe usage working internally with `react-frame-component`.