### PR TITLE
Preventing data browser crash, if there is no matching unit

### DIFF
--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -107,7 +107,7 @@ class ParlAIChatAgentState(AgentState):
         }
 
     def save_data(self) -> None:
-        """Save all messages from this agent to """
+        """Save all messages from this agent to"""
         agent_file = self._get_expected_data_file()
         with open(agent_file, "w+") as state_json:
             json.dump(self.get_data(), state_json)

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_blueprint.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_blueprint.py
@@ -128,7 +128,7 @@ class ParlAIChatBlueprintArgs(BlueprintArgs):
 
 @register_mephisto_abstraction()
 class ParlAIChatBlueprint(Blueprint, OnboardingRequired):
-    """Blueprint for a task that runs a parlai chat """
+    """Blueprint for a task that runs a parlai chat"""
 
     AgentStateClass: ClassVar[Type["AgentState"]] = ParlAIChatAgentState
     OnboardingAgentStateClass: ClassVar[Type["AgentState"]] = ParlAIChatAgentState

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -162,6 +162,8 @@ class MTurkUnit(Unit):
         requester = self.get_requester()
         client = self._get_client(requester._requester_name)
         hit = get_hit(client, mturk_hit_id)
+        if not hit:
+            return AssignmentState.SOFT_REJECTED
         hit_data = hit["HIT"]
 
         local_status = self.db_status

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -162,8 +162,8 @@ class MTurkUnit(Unit):
         requester = self.get_requester()
         client = self._get_client(requester._requester_name)
         hit = get_hit(client, mturk_hit_id)
-        if not hit:
-            return AssignmentState.SOFT_REJECTED
+        if hit is None:
+            return AssignmentState.EXPIRED
         hit_data = hit["HIT"]
 
         local_status = self.db_status

--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -554,8 +554,10 @@ def get_hit(client: MTurkClient, hit_id: str) -> Dict[str, Any]:
     hit = None
     try:
         hit = client.get_hit(HITId=hit_id)
-    except ClientError:
-        logger.warning(f"Unable to retrieve HIT {hit_id}. Skipping!")
+    except ClientError as er:
+        logger.warning(
+            f"Skipping HIT {hit_id}. Unable to retrieve due to ClientError: {er}."
+        )
     return hit
 
 
@@ -693,9 +695,7 @@ def get_outstanding_hits(client: MTurkClient) -> Dict[str, List[Dict[str, Any]]]
 
 
 def expire_and_dispose_hits(
-    client: MTurkClient,
-    hits: List[Dict[str, Any]],
-    quiet: bool = False,
+    client: MTurkClient, hits: List[Dict[str, Any]], quiet: bool = False
 ) -> List[Dict[str, Any]]:
     """
     Loops over attempting to expire and dispose any hits in the hits list that can be disposed

--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -551,7 +551,12 @@ def delete_sns_topic(session: boto3.Session, topic_arn: str) -> None:
 
 def get_hit(client: MTurkClient, hit_id: str) -> Dict[str, Any]:
     """Get hit from mturk by hit_id"""
-    return client.get_hit(HITId=hit_id)
+    hit = None
+    try:
+        hit = client.get_hit(HITId=hit_id)
+    except ClientError:
+        logger.warning(f"Unable to retrieve HIT {hit_id}. Skipping!")
+    return hit
 
 
 def get_assignment(client: MTurkClient, assignment_id: str) -> Dict[str, Any]:

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -78,7 +78,7 @@ def run(
             yield mephisto_data_browser.get_data_from_unit(unit)
 
     def consume_data():
-        """ For use in "one-by-one" or default mode. Runs on a seperate thread to consume mephisto review data line by line and update global variables to temporarily store this data """
+        """For use in "one-by-one" or default mode. Runs on a seperate thread to consume mephisto review data line by line and update global variables to temporarily store this data"""
         global ready_for_next, current_data, finished, counter
 
         if database_task_name is not None:

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -258,7 +258,7 @@ class TaskRun(metaclass=MephistoDBBackedMeta):
         }
 
     def update_completion_progress(self, task_launcher=None, status=None) -> None:
-        """ Flag the task run that the assignments' generator has finished """
+        """Flag the task run that the assignments' generator has finished """
         if task_launcher:
             if task_launcher.get_assignments_are_all_created():
                 self.assignments_generator_done = True

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -129,6 +129,7 @@ class TaskRun(metaclass=MephistoDBBackedMeta):
             if not any(is_self_set):
                 units += unit_set
         valid_units = [u for u in units if u.get_status() == AssignmentState.LAUNCHED]
+        logger.debug(f"Found {len(valid_units)} available units")
 
         # Should load cached blueprint for SharedTaskState
         blueprint = self.get_blueprint()
@@ -138,6 +139,7 @@ class TaskRun(metaclass=MephistoDBBackedMeta):
             if blueprint.shared_state.worker_can_do_unit(worker, u)
         ]
 
+        logger.debug(f"This worker is qualified for {len(ret_units)} unit.")
         logger.debug(f"Found {ret_units[:3]} for {worker}.")
         return ret_units
 

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -258,7 +258,7 @@ class TaskRun(metaclass=MephistoDBBackedMeta):
         }
 
     def update_completion_progress(self, task_launcher=None, status=None) -> None:
-        """Flag the task run that the assignments' generator has finished """
+        """Flag the task run that the assignments' generator has finished"""
         if task_launcher:
             if task_launcher.get_assignments_are_all_created():
                 self.assignments_generator_done = True

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -128,7 +128,7 @@ class TaskLauncher:
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
 
     def create_assignments(self) -> None:
-        """Create an assignment and associated units for the generated assignment data """
+        """Create an assignment and associated units for the generated assignment data"""
         self.keep_launching_units = True
         if self.generator_type == GeneratorType.NONE:
             for data in self.assignment_data_iterable:

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -85,7 +85,7 @@ class TaskLauncher:
         self.assignments_thread = None
 
     def _create_single_assignment(self, assignment_data) -> None:
-        """ Create a single assignment in the database using its read assignment_data """
+        """Create a single assignment in the database using its read assignment_data"""
         task_run = self.task_run
         task_config = task_run.get_task_config()
         assignment_id = self.db.new_assignment(
@@ -117,7 +117,7 @@ class TaskLauncher:
                 self.unlaunched_units[unit_id] = Unit(self.db, unit_id)
 
     def _try_generating_assignments(self) -> None:
-        """ Try to generate more assignments from the assignments_data_iterator"""
+        """Try to generate more assignments from the assignments_data_iterator"""
         while not self.finished_generators:
             try:
                 data = next(self.assignment_data_iterable)
@@ -128,7 +128,7 @@ class TaskLauncher:
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
 
     def create_assignments(self) -> None:
-        """ Create an assignment and associated units for the generated assignment data """
+        """Create an assignment and associated units for the generated assignment data """
         self.keep_launching_units = True
         if self.generator_type == GeneratorType.NONE:
             for data in self.assignment_data_iterable:
@@ -179,7 +179,7 @@ class TaskLauncher:
                 break
 
     def _launch_limited_units(self, url: str) -> None:
-        """ use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
+        """use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
         while not self.finished_generators:
             for unit in self.generate_units():
                 if unit is None:


### PR DESCRIPTION
1. While retrieving HITs for an MTurk client, there are situations that `boto` throws and exception because of not being able to retrieve a HIT. This may crash the `data_examiners` that retrieve the assignment units. 
2. (minor) some debug logging message to track available units when a worker requests HITs.