### PR TITLE
Static Tasks with Generated Assignments

### DIFF
--- a/examples/static_react_task/run_task.py
+++ b/examples/static_react_task/run_task.py
@@ -21,6 +21,7 @@ import hydra
 from omegaconf import DictConfig
 from dataclasses import dataclass, field
 from typing import List, Any
+import time
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 
@@ -78,11 +79,17 @@ def main(cfg: DictConfig) -> None:
     def onboarding_always_valid(onboarding_data):
         return True
 
+    def task_data_generator():
+        for x in range(5):
+            time.sleep(5)
+            yield {"text": f"This text comes from task number {x}"}
+
     shared_state = SharedStaticTaskState(
-        static_task_data=[
-            {"text": "This text is good text!"},
-            {"text": "This text is bad text!"},
-        ],
+        # static_task_data=[
+        #     {"text": "This text is good text!"},
+        #     {"text": "This text is bad text!"},
+        # ],
+        static_task_data=task_data_generator(),
         validate_onboarding=onboarding_always_valid,
     )
 

--- a/examples/static_react_task/run_task.py
+++ b/examples/static_react_task/run_task.py
@@ -21,7 +21,6 @@ import hydra
 from omegaconf import DictConfig
 from dataclasses import dataclass, field
 from typing import List, Any
-import time
 
 TASK_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
 

--- a/examples/static_react_task/run_task.py
+++ b/examples/static_react_task/run_task.py
@@ -79,17 +79,11 @@ def main(cfg: DictConfig) -> None:
     def onboarding_always_valid(onboarding_data):
         return True
 
-    def task_data_generator():
-        for x in range(5):
-            time.sleep(5)
-            yield {"text": f"This text comes from task number {x}"}
-
     shared_state = SharedStaticTaskState(
-        # static_task_data=[
-        #     {"text": "This text is good text!"},
-        #     {"text": "This text is bad text!"},
-        # ],
-        static_task_data=task_data_generator(),
+        static_task_data=[
+            {"text": "This text is good text!"},
+            {"text": "This text is bad text!"},
+        ],
         validate_onboarding=onboarding_always_valid,
     )
 

--- a/mephisto/abstractions/architects/mock_architect.py
+++ b/mephisto/abstractions/architects/mock_architect.py
@@ -259,7 +259,9 @@ class MockServer(tornado.web.Application):
         """
         Start the primary loop for this application
         """
-        self.__server_thread = threading.Thread(target=self.__server_thread_fn)
+        self.__server_thread = threading.Thread(
+            target=self.__server_thread_fn, name="mock-server-thread"
+        )
         self.__server_thread.start()
 
     def shutdown_mock(self):

--- a/mephisto/abstractions/blueprint.py
+++ b/mephisto/abstractions/blueprint.py
@@ -16,7 +16,6 @@ from typing import (
     ClassVar,
     Union,
     Iterable,
-    AsyncIterator,
     Callable,
     Tuple,
     TYPE_CHECKING,
@@ -656,11 +655,11 @@ class Blueprint(ABC):
     @abstractmethod
     def get_initialization_data(
         self,
-    ) -> Union[Iterable["InitializationData"], AsyncIterator["InitializationData"]]:
+    ) -> Iterable["InitializationData"]:
         """
         Get all of the data used to initialize tasks from this blueprint.
         Can either be a simple iterable if all the assignments can
-        be processed at once, or an AsyncIterator if the number
+        be processed at once, or a Generator if the number
         of tasks is unknown or changes based on something running
         concurrently with the job.
         """

--- a/mephisto/abstractions/blueprints/static_html_task/static_html_blueprint.py
+++ b/mephisto/abstractions/blueprints/static_html_task/static_html_blueprint.py
@@ -18,6 +18,7 @@ from mephisto.operations.registry import register_mephisto_abstraction
 import os
 import time
 import csv
+import types
 
 from typing import ClassVar, List, Type, Any, Dict, Iterable, Optional, TYPE_CHECKING
 
@@ -107,6 +108,8 @@ class StaticHTMLBlueprint(StaticBlueprint):
     def assert_task_args(cls, args: DictConfig, shared_state: "SharedTaskState"):
         """Ensure that the data can be properly loaded"""
         blue_args = args.blueprint
+        if isinstance(shared_state.static_task_data, types.GeneratorType):
+            raise AssertionError("You can't launch an HTML static task on a generator")
         if blue_args.get("data_csv", None) is not None:
             csv_file = os.path.expanduser(blue_args.data_csv)
             assert os.path.exists(

--- a/mephisto/abstractions/test/blueprint_tester.py
+++ b/mephisto/abstractions/test/blueprint_tester.py
@@ -221,7 +221,9 @@ class BlueprintTests(unittest.TestCase):
             cast("Agent", u.get_assigned_agent()) for u in assignment.get_units()
         ]
         task_thread = threading.Thread(
-            target=task_runner.launch_assignment, args=(assignment, agents)
+            target=task_runner.launch_assignment,
+            args=(assignment, agents),
+            name="test-task-thread",
         )
         self.assertFalse(self.assignment_is_tracked(task_runner, assignment))
         task_thread.start()

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -364,7 +364,7 @@ def run(
         datalist_update_time = datetime.now()
         finished = False
     else:
-        thread = threading.Thread(target=consume_data)
+        thread = threading.Thread(target=consume_data, name="review-server-thread")
         thread.start()
     print("Running on http://127.0.0.1:{}/ (Press CTRL+C to quit)".format(port))
     sys.stdout.flush()

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -299,7 +299,7 @@ class Operator:
             runs_to_check = list(self._task_runs_tracked.values())
             for tracked_run in runs_to_check:
                 task_run = tracked_run.task_run
-                if not tracked_run.task_launcher.finished_generators:
+                if tracked_run.task_launcher.finished_generators is False:
                     # If the run can still generate assignments, it's
                     # definitely not done
                     continue

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -249,7 +249,7 @@ class Operator:
                 task_run, run_config, shared_state, task_url
             )
 
-            initialization_data_array = blueprint.get_initialization_data()
+            initialization_data_iterable = blueprint.get_initialization_data()
 
             # Link the job together
             job = self.supervisor.register_job(
@@ -273,7 +273,7 @@ class Operator:
         launcher = TaskLauncher(
             self.db,
             task_run,
-            initialization_data_array,
+            initialization_data_iterable,
             max_num_concurrent_units=run_config.task.max_num_concurrent_units,
         )
         launcher.create_assignments()

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -299,6 +299,10 @@ class Operator:
             runs_to_check = list(self._task_runs_tracked.values())
             for tracked_run in runs_to_check:
                 task_run = tracked_run.task_run
+                if not tracked_run.task_launcher.finished_generators:
+                    # If the run can still generate assignments, it's
+                    # definitely not done
+                    continue
                 task_run.update_completion_progress(
                     task_launcher=tracked_run.task_launcher
                 )

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -123,6 +123,7 @@ class TaskLauncher:
                 data = next(self.assignment_data_iterable)
                 self._create_single_assignment(data)
             except StopIteration:
+                print("Generation finished")
                 self.finished_generators = True
                 self.assignment_thread_done = True
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -123,7 +123,6 @@ class TaskLauncher:
                 data = next(self.assignment_data_iterable)
                 self._create_single_assignment(data)
             except StopIteration:
-                print("Generation finished")
                 self.finished_generators = True
                 self.assignment_thread_done = True
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -131,7 +131,7 @@ class TaskLauncher:
     def create_assignments(self) -> None:
         """Create an assignment and associated units for the generated assignment data"""
         self.keep_launching_units = True
-        if self.generator_type == GeneratorType.NONE:
+        if self.generator_type != GeneratorType.ASSIGNMENT:
             for data in self.assignment_data_iterable:
                 self._create_single_assignment(data)
         else:

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -75,6 +75,8 @@ class TaskLauncher:
         if isinstance(self.assignment_data_iterable, types.GeneratorType):
             self.generator_type = GeneratorType.ASSIGNMENT
             self.assignment_thread_done = False
+        elif max_num_concurrent_units != 0:
+            self.generator_type = GeneratorType.UNIT
         else:
             self.generator_type = GeneratorType.NONE
         run_dir = task_run.get_run_dir()
@@ -123,7 +125,6 @@ class TaskLauncher:
                 data = next(self.assignment_data_iterable)
                 self._create_single_assignment(data)
             except StopIteration:
-                self.finished_generators = True
                 self.assignment_thread_done = True
             time.sleep(ASSIGNMENT_GENERATOR_WAIT_SECONDS)
 
@@ -135,7 +136,9 @@ class TaskLauncher:
                 self._create_single_assignment(data)
         else:
             self.assignments_thread = threading.Thread(
-                target=self._try_generating_assignments, args=()
+                target=self._try_generating_assignments,
+                args=(),
+                name="assignment-generator",
             )
             self.assignments_thread.start()
 
@@ -180,18 +183,23 @@ class TaskLauncher:
 
     def _launch_limited_units(self, url: str) -> None:
         """use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
-        while not self.finished_generators:
+        # Continue launching if we haven't pulled the plug, so long as there are currently
+        # units to launch, or more may come in the future.
+        while not self.finished_generators and (
+            len(self.unlaunched_units) > 0 or not self.assignment_thread_done
+        ):
             for unit in self.generate_units():
                 if unit is None:
                     break
                 unit.launch(url)
             if self.generator_type == GeneratorType.NONE:
                 break
+        self.finished_generators = True
 
     def launch_units(self, url: str) -> None:
         """launch any units registered by this TaskLauncher"""
         self.units_thread = threading.Thread(
-            target=self._launch_limited_units, args=(url,)
+            target=self._launch_limited_units, args=(url,), name="unit-generator"
         )
         self.units_thread.start()
 

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -12,6 +12,7 @@ import os
 import tempfile
 import time
 import threading
+from unittest.mock import patch
 
 from mephisto.abstractions.test.utils import get_test_requester
 from mephisto.data_model.constants.assignment_state import AssignmentState
@@ -28,7 +29,7 @@ from mephisto.abstractions.blueprints.mock.mock_blueprint import MockBlueprintAr
 from mephisto.data_model.task_config import TaskConfigArgs
 from omegaconf import OmegaConf
 
-TIMEOUT_TIME = 10
+TIMEOUT_TIME = 15
 
 
 MOCK_TASK_ARGS = TaskConfigArgs(
@@ -87,6 +88,7 @@ class OperatorBaseTest(object):
         """Quick test to ensure that the operator can be initialized"""
         self.operator = Operator(self.db)
 
+    @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_job_concurrent(self):
         """Ensure that the supervisor object can even be created"""
         self.operator = Operator(self.db)
@@ -152,6 +154,7 @@ class OperatorBaseTest(object):
         assignment = task_run.get_assignments()[0]
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
+    @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_job_not_concurrent(self):
         """Ensure that the supervisor object can even be created"""
         self.operator = Operator(self.db)
@@ -217,6 +220,7 @@ class OperatorBaseTest(object):
         assignment = task_run.get_assignments()[0]
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
+    @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_jobs_with_restrictions(self):
         """Ensure allowed_concurrent and maximum_units_per_worker work"""
         self.operator = Operator(self.db)


### PR DESCRIPTION
# Overview
As a partial step towards model-in-the-loop for enqueuing tasks, and more task control, this PR makes it possible to provide a `Generator` to `SharedStaticTaskState.static_task_data` such that Mephisto can run with an indeterminate amount of tasks, generated on the fly. This can be used in the short term by tasks that intend to get a full set of annotations, but have some quality control on what is considered good.

# Implementation
Much of this was already implemented in an earlier PR, but this finishes a few of the threads:
1. Updates `StaticBlueprint` to wrap the `get_initialization_data` method with a generator-friendly version
2. Notes in the `StaticHTMLBlueprint` that this behavior is not supported (as we inject HTML into the task data, and I'm not really interested in keeping full HTML support as it is an onboarding ramp)
3. Updates the `Operator` to not shut down if there are still assignment generators running for a task.

# Testing
I replaced the `static_react_task`'s `static_task_data` with the following generator:
```
    def task_data_generator():
        for x in range(5):
            time.sleep(5)
            yield {"text": f"This text comes from task number {x}"}
            input()
```
And ensured that only one task was available per newline sent in, and that Mephisto didn't shut down when no tasks were available.

This should have a more deliberate test case, but that will be included in the more complete model-in-the-loop update.