### PR TITLE
Adding ping-pong disconnect to node router

### DIFF
--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -258,6 +258,11 @@ class Unit(metaclass=MephistoDBBackedABCMeta):
         from mephisto.abstractions.blueprint import AgentState
 
         db_status = self.db_status
+
+        # Expiration is a terminal state, and shouldn't be changed
+        if db_status == AssignmentState.EXPIRED:
+            return db_status
+
         computed_status = AssignmentState.LAUNCHED
 
         agent = self.get_assigned_agent()


### PR DESCRIPTION
# Overview

The node server running on Heroku hasn't been able to detect disconnects in the same way that it does when running locally. This leads to delays on marking tasks as disconnected, expiring tasks, and generally a mismatch between `Agent` and `Unit` status on MTurk compared to Mephisto.

This PR moves to record ping times on the router to allow it to determine without a hard disconnect whether an agent has disconnected, currently set to not having received a heartbeat in 15 seconds.

Resolves #485.

# Implementation details
- Added `last_ping` to the `LocalAgentState` of the node router, and update it whenever a `HEARTBEAT` is received.
- Check liveliness on the router during the periodic status checks from the main Mephisto server, updating relevant agents to `STATUS_DISCONNECT` when relevant.

Additionally, found and resolved the following bugs:
- Disconnect events which led to expiring tasks would prevent Mephisto from shutting down, even if there were no tasks left (as the task had expired). This is cleaned up by ensuring that, after a `Unit` transitions to `EXPIRED` it cannot move back to `ASSIGNED`.
- Fixed reconnecting to the node router after a disconnect and receiving the correct status

# Testing
Launched a server on Heroku with the parlai chat task, connected to it as two different agents, and then disconnected one. Ensured that, while this disconnect wasn't detected before, it is now.

Launched a static react task to ensure connection functionality on this hadn't changed (as no heartbeats are sent). Connected, and found myself still connected after 15 seconds.

Ensured both tasks shut down properly when completed.