### PR TITLE
Specifying the SharedTaskState used by a specific blueprint

### DIFF
--- a/mephisto/abstractions/blueprints/abstract/static_task/static_blueprint.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_blueprint.py
@@ -111,6 +111,7 @@ class StaticBlueprint(Blueprint, OnboardingRequired):
     TaskRunnerClass: ClassVar[Type["TaskRunner"]] = StaticTaskRunner
     ArgsClass: ClassVar[Type["BlueprintArgs"]] = StaticBlueprintArgs
     supported_architects: ClassVar[List[str]] = ["mock"]  # TODO update
+    SharedStateClass = SharedStaticTaskState
 
     def __init__(
         self, task_run: "TaskRun", args: "DictConfig", shared_state: "SharedTaskState"

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -133,9 +133,6 @@ class Operator:
         """
         set_mephisto_log_level(level=run_config.get("log_level", "info"))
 
-        if shared_state is None:
-            shared_state = SharedTaskState()
-
         # First try to find the requester:
         requester_name = run_config.provider.requester_name
         requesters = self.db.find_requesters(requester_name=requester_name)
@@ -162,6 +159,9 @@ class Operator:
         BlueprintClass = get_blueprint_from_type(blueprint_type)
         ArchitectClass = get_architect_from_type(architect_type)
         CrowdProviderClass = get_crowd_provider_from_type(provider_type)
+
+        if shared_state is None:
+            shared_state = BlueprintClass.SharedStateClass()
 
         BlueprintClass.assert_task_args(run_config, shared_state)
         ArchitectClass.assert_task_args(run_config, shared_state)


### PR DESCRIPTION
# Overview
The fixes introduced in #480 to allow for static tasks to have generated assignments on the fly introduced a bug when the `SharedTaskState` was not directly specified. By default, `Operator`s were creating a default `SharedTaskState` rather than the `SharedTaskState` that a specific `Blueprint` might specify.

This was surfaced in #488 

# Fix
This simply ensures that `SharedStateClass` is set on all of our blueprints correctly, and asks the `Operator` to generate the correct `SharedTaskState` using this attribute on startup.