### PR TITLE
Silencing direct inits from Database classes

### DIFF
--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -356,7 +356,10 @@ class LocalMephistoDB(MephistoDB):
                 (project_name,),
             )
             rows = c.fetchall()
-            return [Project(self, str(r["project_id"]), row=r) for r in rows]
+            return [
+                Project(self, str(r["project_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_task(
         self,
@@ -429,7 +432,9 @@ class LocalMephistoDB(MephistoDB):
                 (task_name, nonesafe_int(project_id), nonesafe_int(parent_task_id)),
             )
             rows = c.fetchall()
-            return [Task(self, str(r["task_id"]), row=r) for r in rows]
+            return [
+                Task(self, str(r["task_id"]), row=r, _used_new_call=True) for r in rows
+            ]
 
     def update_task(
         self,
@@ -554,7 +559,10 @@ class LocalMephistoDB(MephistoDB):
                 (nonesafe_int(task_id), nonesafe_int(requester_id), is_completed),
             )
             rows = c.fetchall()
-            return [TaskRun(self, str(r["task_run_id"]), row=r) for r in rows]
+            return [
+                TaskRun(self, str(r["task_run_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def update_task_run(self, task_run_id: str, is_completed: bool):
         """
@@ -657,7 +665,10 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Assignment(self, str(r["assignment_id"]), row=r) for r in rows]
+            return [
+                Assignment(self, str(r["assignment_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_unit(
         self,
@@ -773,7 +784,9 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Unit(self, str(r["unit_id"]), row=r) for r in rows]
+            return [
+                Unit(self, str(r["unit_id"]), row=r, _used_new_call=True) for r in rows
+            ]
 
     def clear_unit_agent_assignment(self, unit_id: str) -> None:
         """
@@ -885,7 +898,10 @@ class LocalMephistoDB(MephistoDB):
                 (requester_name, provider_type),
             )
             rows = c.fetchall()
-            return [Requester(self, str(r["requester_id"]), row=r) for r in rows]
+            return [
+                Requester(self, str(r["requester_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_worker(self, worker_name: str, provider_type: str) -> str:
         """
@@ -941,7 +957,10 @@ class LocalMephistoDB(MephistoDB):
                 (worker_name, provider_type),
             )
             rows = c.fetchall()
-            return [Worker(self, str(r["worker_id"]), row=r) for r in rows]
+            return [
+                Worker(self, str(r["worker_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def new_agent(
         self,
@@ -1073,7 +1092,10 @@ class LocalMephistoDB(MephistoDB):
                 ),
             )
             rows = c.fetchall()
-            return [Agent(self, str(r["agent_id"]), row=r) for r in rows]
+            return [
+                Agent(self, str(r["agent_id"]), row=r, _used_new_call=True)
+                for r in rows
+            ]
 
     def make_qualification(self, qualification_name: str) -> str:
         """
@@ -1114,7 +1136,10 @@ class LocalMephistoDB(MephistoDB):
             )
             rows = c.fetchall()
             return [
-                Qualification(self, str(r["qualification_id"]), row=r) for r in rows
+                Qualification(
+                    self, str(r["qualification_id"]), row=r, _used_new_call=True
+                )
+                for r in rows
             ]
 
     def get_qualification(self, qualification_id: str) -> Mapping[str, Any]:
@@ -1365,6 +1390,8 @@ class LocalMephistoDB(MephistoDB):
             )
             rows = c.fetchall()
             return [
-                OnboardingAgent(self, str(r["onboarding_agent_id"]), row=r)
+                OnboardingAgent(
+                    self, str(r["onboarding_agent_id"], _used_new_call=True), row=r
+                )
                 for r in rows
             ]

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -1391,7 +1391,7 @@ class LocalMephistoDB(MephistoDB):
             rows = c.fetchall()
             return [
                 OnboardingAgent(
-                    self, str(r["onboarding_agent_id"], _used_new_call=True), row=r
+                    self, str(r["onboarding_agent_id"]), row=r, _used_new_call=True
                 )
                 for r in rows
             ]


### PR DESCRIPTION
# Overview
Missed out on merging this change from #438 into #437, including again to silence warnings coming out of _correct_ use of raw Mephisto data model element initialization within our `LocalMephistoDB` class.