### PR TITLE
[Documentation] Update quick start README with sandbox clarification

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,7 +99,7 @@ $ mephisto register mturk_sandbox \
 Registered successfully.
 ```
 
-Note that registering a sandbox user will not create a new entry in your `~/.aws/credentials` file, as sandbox and prod use the same access keys.
+Note that registering a sandbox user will not create a new entry in your `~/.aws/credentials` file if it's for the same account as your production user, as sandbox and prod use the same access keys.
 
 2. Next, let's run the task script again, but this time we'll override the requester name and change the architect type to use [Heroku](https://www.heroku.com/). (You can find all of the architects currently supported [here](../mephisto/abstractions/architects).)
 


### PR DESCRIPTION
This is a nit to add a note in onboarding that you should only have one set of AWS credentials for sandbox and production. Small change but could prevent confusion for future Mephisto users.