### PR TITLE
Fix frame sync bug

### DIFF
--- a/packages/annotation-toolkit/release-notes.md
+++ b/packages/annotation-toolkit/release-notes.md
@@ -9,12 +9,11 @@
 - **ENHANCEMENT** - Add a getLabel property to MovableRect that adds a label to the box.
 - **NEW** - Add `getInterpolatedFrames(allKeyframes)` helper to convert keyframes into interpolated frames, frame-by-frame. Returns array of: `{frame, value: [x, y, width, height]}`
 - **NEW** `<VideoPlayer />` will now read and execute callback fns from the data prop `renderSteps`. These steps can be defined by client code. The expected format of `renderSteps` is an object as such:
-
-```
-{
-  'render-key-id': (ctx, now, metadata, canvasRef) => {...}
-}
-```
+   ```js
+   {
+     'render-key-id': (ctx, now, metadata, canvasRef) => {...}
+   }
+   ```
 
 ---
 

--- a/packages/annotation-toolkit/release-notes.md
+++ b/packages/annotation-toolkit/release-notes.md
@@ -1,13 +1,3 @@
-# vNext
-
-- **NEW** `<VideoPlayer />` will now read and execute callback fns from the data prop `renderSteps`. These steps can be defined by client code. The expected format of `renderSteps` is an object as such:
-
-```
-{
-  'render-key-id': (ctx, now, metadata, canvasRef) => {...}
-}
-```
-
 # v1.1.2-beta
 - **NEW** Adds in the `<MovableRect />` component with built-in linear interpolation between keyframes. Usage:
    ```js
@@ -18,6 +8,13 @@
 - **ENHANCEMENT** - VideoPlayer playing can be toggled by clicking on the video.
 - **ENHANCEMENT** - Add a getLabel property to MovableRect that adds a label to the box.
 - **NEW** - Add `getInterpolatedFrames(allKeyframes)` helper to convert keyframes into interpolated frames, frame-by-frame. Returns array of: `{frame, value: [x, y, width, height]}`
+- **NEW** `<VideoPlayer />` will now read and execute callback fns from the data prop `renderSteps`. These steps can be defined by client code. The expected format of `renderSteps` is an object as such:
+
+```
+{
+  'render-key-id': (ctx, now, metadata, canvasRef) => {...}
+}
+```
 
 ---
 

--- a/packages/annotation-toolkit/release-notes.md
+++ b/packages/annotation-toolkit/release-notes.md
@@ -1,3 +1,13 @@
+# vNext
+
+- **NEW** `<VideoPlayer />` will now read and execute callback fns from the data prop `renderSteps`. These steps can be defined by client code. The expected format of `renderSteps` is an object as such:
+
+```
+{
+  'render-key-id': (ctx, now, metadata, canvasRef) => {...}
+}
+```
+
 # v1.1.2-beta
 - **NEW** Adds in the `<MovableRect />` component with built-in linear interpolation between keyframes. Usage:
    ```js


### PR DESCRIPTION
Fixes #455

# Overview

Allows annotation layers to have better synchronization with the `<VideoPlayer />` component for cases where frame accuracy is important.

# Usage

```jsx

// Let's say we want to show a bbox rectangle for Frames 1,2,3,4 of the video
const responseFrames = [1,2,3,4]

// This component would be passed into <Layer component={...} />
function AnnotationComponent() {
  const { invoke } = useStore();
  const render = React.useCallback(
    (ctx, now, metadata, canvasRef) => {
      const currentFrame = Math.round(metadata.mediaTime * fps);
      const inFrame = currentFrame in responseFrames;
      if (!inFrame) return null;

      const responseFrame = responseFrames[currentFrame];

      // define the annotation we would like to have happen with the passed in canvas 2d context
      ctx.strokeStyle = "rgba(255,0,0,1)";
      const dim = [100,100,100,100];
      ctx.strokeRect(...dim);
    },
    []
  );

  React.useEffect(() => {
    // we push the render callback into the Video layer's `renderSteps` object with a keyId for reference
    const vidData = dataPathBuilderFor("Video");
    invoke(vidData("renderSteps"), (prev = {}) => ({
      ...prev,
      ...{ [id]: render },
    }));

    return () => {
      // on umount, do some cleanup to remove the key from the `renderSteps` object.
      invoke(vidData("renderSteps"), (prev = {}) => {
        const filtered = Object.keys(prev)
          .filter((key) => key != id)
          .reduce((obj, key) => {
            obj[key] = prev[key];
            return obj;
          }, {});

        return filtered;
      });
    };
  }, []);

  return null;
}
```

# Implementation

The `<VideoPlayer />` component is updated to include `requestVideoFrameCallback` which gets executed each time a new frame is rendered. Upon execution, the VideoPlayer looks up the callbacks registered in its `renderSteps` data object and executes them.

# Testing

Update the VQA review task with these changes. Verified that it works correctly.

https://github.com/fairinternal/mephisto-internal/commit/41da7c27505adb5fe7607ce709e241261b7b9178

# Additional Notes

Overall this seems to work pretty well. We may want to explore a process for integrating in HaloVideoCalibrator in the future if any further issues arise.