### PR TITLE
[ParlAI] Pushing timestamps into the messages too

### DIFF
--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -83,7 +83,7 @@ class ParlAIChatAgentState(AgentState):
         init_data = self.init_data
         save_data = None
         for m in self.messages:
-            m["data"]['timestamp'] = m['timestamp']
+            m["data"]["timestamp"] = m["timestamp"]
 
         messages = [
             m["data"]

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -82,6 +82,9 @@ class ParlAIChatAgentState(AgentState):
         """Return the formatted input, conversations, and final data"""
         init_data = self.init_data
         save_data = None
+        for m in self.messages:
+            m["data"]['timestamp'] = m['timestamp']
+
         messages = [
             m["data"]
             for m in self.messages


### PR DESCRIPTION
Like #555, I think it's relevant to have timestamps in the messages themselves. Currently using this in a review script for LIGHT that I think is really a useful metric for automated evals. 

@EricMichaelSmith this will probably be a key that you'll have to drop as well in your PR that can clean this data for test purposes.