### PR TITLE
Add optional assets flag (-a / --assets) to `mephisto review`

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -60,6 +60,7 @@ def config(identifier, value):
 @click.argument("review_app_dir", type=click.Path(exists=True))
 @click.option("-p", "--port", type=(int), default=5000)
 @click.option("-o", "--output", type=(str), default="")
+@click.option("-a", "--assets", "assets_dir", type=(str), default=None)
 @click.option("--stdout", "output_method", flag_value="stdout")
 @click.option("--file", "output_method", flag_value="file", default=True)
 @click.option("--csv-headers/--no-csv-headers", default=False)
@@ -77,6 +78,7 @@ def review(
     database_task_name,
     all_data,
     debug,
+    assets_dir,
 ):
     """Launch a local review UI server. Reads in rows froms stdin and outputs to either a file or stdout."""
     from mephisto.client.review.review_server import run
@@ -106,6 +108,7 @@ def review(
         database_task_name,
         all_data,
         debug,
+        assets_dir,
     )
 
 

--- a/mephisto/client/review/review_server.py
+++ b/mephisto/client/review/review_server.py
@@ -27,6 +27,7 @@ def run(
     database_task_name=None,
     all_data=False,
     debug=False,
+    assets_dir=None,
 ):
     global index_file, app
     global ready_for_next, current_data, finished, index_file
@@ -59,6 +60,15 @@ def run(
         static_url_path="/static",
         static_folder=build_dir + "/static",
     )
+
+    if assets_dir:
+        assets_blueprint = Blueprint(
+            "additional_assets",
+            __name__,
+            static_url_path="/assets",
+            static_folder=assets_dir,
+        )
+        app.register_blueprint(assets_blueprint)
 
     def json_reader(f):
         import json


### PR DESCRIPTION
### Overview:

Allows users of the `mephisto review` CLI command to specify a folder which the review server will be able to access in order to retrieve static assets, e.g. video files.

### Usage:

```bash
$ ls ~/my-videos
video.mp4

$ cat data.json | mephisto review build/ --json --stdout --assets ~/my-videos
```

**The review server can now access the video at `/assets/video.mp4`.**

### Details:

The default Flask app already serves a static folder at `/static` for any `static` folder listed under the build directory. In the example above, this would be `build/static`. This is useful for out-of-the-box create-react-app based apps since they follow this scheme.

Along with `/static`, which we assume to hold static build files (e.g., js+css), we add an additional static folder under `/assets` to host additional non-build specific files. This is for semantic separation so that a separate folder unrelated to the build can be used to host assets, although technically it follows a similar static_dir concept as the above. In order to be able to host another static directory, we use a [Flask blueprint](https://stackoverflow.com/a/9516694).