### PR TITLE
Static html blueprint fix

### DIFF
--- a/mephisto/abstractions/blueprints/static_html_task/source/package-lock.json
+++ b/mephisto/abstractions/blueprints/static_html_task/source/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "axios": "^0.21.1",
         "bootstrap": "^4.3.1",
-        "mephisto-task": "^1.0.14",
+        "mephisto-task": "^1.0.16",
         "rc-slider": "^8.6.3",
         "react": "16.13.1",
         "react-bootstrap": "^0.32.4",
@@ -4660,9 +4660,9 @@
       }
     },
     "node_modules/mephisto-task": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-1.0.14.tgz",
-      "integrity": "sha512-onqxujBRySBIGYZfjqFAk8kJNDmmAdqFcwhcHxmqPiO9/V4Nicm5RzvPPY9QJnvviVXo4vO29l0KWlLtM2XRew==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-1.0.16.tgz",
+      "integrity": "sha512-16lKIUhao89FELL42W6WqmyEhQqe0RuSbOSYprGKFTE7FtUsi3csoYzj3uzCW3P0zwAVbq6J/lV57QoLT7yzoQ==",
       "dependencies": {
         "axios": "^0.21.1",
         "babel-eslint": "10.x",
@@ -11143,9 +11143,9 @@
       }
     },
     "mephisto-task": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-1.0.14.tgz",
-      "integrity": "sha512-onqxujBRySBIGYZfjqFAk8kJNDmmAdqFcwhcHxmqPiO9/V4Nicm5RzvPPY9QJnvviVXo4vO29l0KWlLtM2XRew==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/mephisto-task/-/mephisto-task-1.0.16.tgz",
+      "integrity": "sha512-16lKIUhao89FELL42W6WqmyEhQqe0RuSbOSYprGKFTE7FtUsi3csoYzj3uzCW3P0zwAVbq6J/lV57QoLT7yzoQ==",
       "requires": {
         "axios": "^0.21.1",
         "babel-eslint": "10.x",

--- a/mephisto/abstractions/blueprints/static_html_task/static_html_blueprint.py
+++ b/mephisto/abstractions/blueprints/static_html_task/static_html_blueprint.py
@@ -10,6 +10,7 @@ from mephisto.abstractions.blueprints.abstract.static_task.static_blueprint impo
 )
 from dataclasses import dataclass, field
 from omegaconf import MISSING, DictConfig
+from mephisto.abstractions.blueprint import Blueprint
 from mephisto.abstractions.blueprints.static_html_task.static_html_task_builder import (
     StaticHTMLTaskBuilder,
 )


### PR DESCRIPTION
# Overview
FIxes #593. Somehow I dropped this in #582. This import should have been made as part of the changes to mixins.

# Observation
I need to get `mypy` working on commit again...

Hotfix merging without review.