### PR TITLE
EC2Architect - Various small improvements

### DIFF
--- a/mephisto/abstractions/architects/ec2/ec2_architect.py
+++ b/mephisto/abstractions/architects/ec2/ec2_architect.py
@@ -43,6 +43,15 @@ FINAL_SERVER_BUILD_DIRECTORY = "routing_server"
 DEPLOY_WAIT_TIME = 3
 
 
+def url_safe_string(in_string: str) -> str:
+    """
+    Produces a domain string that is safe for use
+    in ec2 resources
+    """
+    hyphenated = in_string.replace("_", "-")
+    return re.sub("[^0-9a-zA-Z\-]+", "", hyphenated)
+
+
 @dataclass
 class EC2ArchitectArgs(ArchitectArgs):
     """Additional arguments for configuring a heroku architect"""
@@ -85,7 +94,7 @@ class EC2Architect(Architect):
         with open(DEFAULT_FALLBACK_FILE, "r") as fallback_detail_file:
             self.fallback_details = json.load(fallback_detail_file)
 
-        self.subdomain = args.architect.subdomain
+        self.subdomain = url_safe_string(args.architect.subdomain)
         self.root_domain = self.fallback_details["domain"]
         self.router_name = f"{self.subdomain}-routing-server"
         self.full_domain = f"{self.subdomain}.{self.root_domain}"

--- a/mephisto/abstractions/architects/ec2/ec2_helpers.py
+++ b/mephisto/abstractions/architects/ec2/ec2_helpers.py
@@ -895,7 +895,9 @@ def try_server_push(subprocess_args: List[str], retries=5, sleep_time=10.0):
     """
     while retries > 0:
         try:
-            subprocess.check_call(subprocess_args)
+            subprocess.check_call(
+                subprocess_args, env=dict(os.environ, SSH_AUTH_SOCK="")
+            )
             return
         except subprocess.CalledProcessError:
             retries -= 1
@@ -934,7 +936,6 @@ def deploy_fallback_server(
         dest = f"{remote_server}:/home/ec2-user/"
         try_server_push(
             [
-                "SSH_AUTH_SOCK=",
                 "scp",
                 "-o",
                 "StrictHostKeyChecking=no",
@@ -948,14 +949,14 @@ def deploy_fallback_server(
         os.unlink(password_file_name)
         subprocess.check_call(
             [
-                "SSH_AUTH_SOCK=",
                 "ssh",
                 "-i",
                 keypair_file,
                 remote_server,
                 "bash",
                 "/home/ec2-user/fallback_server/scripts/first_setup.sh",
-            ]
+            ],
+            env=dict(os.environ, SSH_AUTH_SOCK=""),
         )
         detete_instance_address(session, allocation_id, association_id)
     except Exception as e:
@@ -983,7 +984,6 @@ def deploy_to_routing_server(
         dest = f"{remote_server}:/home/ec2-user/"
         try_server_push(
             [
-                "SSH_AUTH_SOCK=",
                 "scp",
                 "-o",
                 "StrictHostKeyChecking=no",
@@ -997,14 +997,14 @@ def deploy_to_routing_server(
 
         subprocess.check_call(
             [
-                "SSH_AUTH_SOCK=",
                 "ssh",
                 "-i",
                 keypair_file,
                 remote_server,
                 "bash",
                 "/home/ec2-user/routing_server/setup/init_server.sh",
-            ]
+            ],
+            env=dict(os.environ, SSH_AUTH_SOCK=""),
         )
         detete_instance_address(session, allocation_id, association_id)
         print("Server setup complete!")


### PR DESCRIPTION
# Overview
In more testing, ran into two primary issues:
1. With `tmux` sessions sometimes the ssh-agent forwarding would become stale and then setting up the server would hang indefinitely. 
2. Determining the priority to use based on the number of rules meant that if some servers shut down (reducing the rule number) and then more were launched, two servers could attempt to be launched with the same rule priority.
3. The subdomain string could contain special characters not allowed by amazon

# Implementation
1. Clearing `SSH_AUTH_SOCK` in the env overwrites use of the ssh-agent for auth (which we don't need as we're referring to the `.pem` keypair anyways), which _should_ resolve `tmux` issues (can't directly reproduce yet).
2. Implements a search over possible priority numbers
3. Runs a regex replace to remove special characters from the provided subdomain
4. Also adds an `Owner` tag to all resources, to make them easier to track


cc @klshuster @ytsheng 