### PR TITLE
Small fix to avoid region lock on makeup hits

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -397,6 +397,7 @@ def create_hit_type(
     task_config: "TaskConfig",
     qualifications: List[Dict[str, Any]],
     auto_approve_delay: Optional[int] = 7 * 24 * 3600,  # default 1 week
+    skip_locale_qual=False,
 ) -> str:
     """Create a HIT type to be used to generate HITs of the requested params"""
     hit_title = task_config.task_title
@@ -409,7 +410,7 @@ def create_hit_type(
     # If the user hasn't specified a location qualification, we assume to
     # restrict the HIT to some english-speaking countries.
     locale_requirements: List[Any] = []
-    has_locale_qual = False
+    has_locale_qual = skip_locale_qual
     if existing_qualifications is not None:
         for q in existing_qualifications:
             if q["QualificationTypeId"] == MTURK_LOCALE_REQUIREMENT:

--- a/mephisto/scripts/mturk/launch_makeup_hits.py
+++ b/mephisto/scripts/mturk/launch_makeup_hits.py
@@ -191,7 +191,11 @@ def main():
         # Set up HIT type
         task_config = TaskConfig(task_run)
         hit_type_id = create_hit_type(
-            client, task_config, [qualification], auto_approve_delay=30
+            client,
+            task_config,
+            [qualification],
+            auto_approve_delay=30,
+            skip_locale_qual=True,
         )
 
         # Create the task on MTurk, email the worker


### PR DESCRIPTION
# Overview
As some tasks could be launched specifying a non-default locale qualification, it was possible for the makeup task generation script to later create a makeup task that could not be worked on by a worker outside of the default locale, even if they could work on the main task.

This change makes it possible to skip the locale qualification when making a HIT type, such that the compensation script can restrict just based on the qualification of being a specific worker. 