### PR TITLE
Asyncio Worker Pool + Operator

### DIFF
--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -154,7 +154,9 @@ class TaskRunner(ABC):
         # Onboarding now complete
         if onboarding_agent.get_status() == AgentState.STATUS_WAITING:
             # The agent completed the onboarding task
-            live_run.worker_pool.register_agent_from_onboarding(onboarding_agent)
+            live_run.loop_wrap.execute_coro(
+                live_run.worker_pool.register_agent_from_onboarding(onboarding_agent)
+            )
         else:
             logger.info(
                 f"Onboarding agent {onboarding_id} disconnected or errored, "

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -5,12 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
+import asyncio
 from mephisto.operations.utils import find_or_create_qualification
 from typing import (
     List,
     Dict,
     Callable,
     Tuple,
+    Awaitable,
     TYPE_CHECKING,
 )
 
@@ -127,7 +129,7 @@ class TaskRunner(ABC):
     def _launch_and_run_onboarding(
         self,
         onboarding_agent: "OnboardingAgent",
-        cleanup_after: Callable[[], None],
+        cleanup_after: Callable[[], Awaitable[None]],
     ) -> None:
         """Supervise the completion of an onboarding"""
         live_run = onboarding_agent.get_live_run()
@@ -154,18 +156,21 @@ class TaskRunner(ABC):
         # Onboarding now complete
         if onboarding_agent.get_status() == AgentState.STATUS_WAITING:
             # The agent completed the onboarding task
-            live_run.loop_wrap.execute_coro(
-                live_run.worker_pool.register_agent_from_onboarding(onboarding_agent)
-            )
+            async def register_then_cleanup():
+                await live_run.worker_pool.register_agent_from_onboarding(
+                    onboarding_agent
+                )
+                await cleanup_after
+
+            live_run.loop_wrap.execute_coro(register_then_cleanup())
         else:
             logger.info(
                 f"Onboarding agent {onboarding_id} disconnected or errored, "
                 f"final status {onboarding_agent.get_status()}."
             )
             # TODO is disconnect already being sent?
-            # live_run.worker_pool.send_status_update_deprecated(agent_info)
-
-        cleanup_after()
+            # live_run.worker_pool.push_status_update(agent_info)
+            live_run.loop_wrap.execute_coro(cleanup_after())
 
     def execute_unit(
         self,

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -41,6 +41,11 @@ from mephisto.operations.logger_core import get_logger
 
 logger = get_logger(name=__name__)
 
+# TODO rather than always running in threads, there may be cases
+# where we're better off running in different _processes_. The
+# IO for underlying agents could then take place in the relevant
+# process's update_data call rather than delaying the ClientIOHandler.
+
 
 @dataclass
 class RunningUnit:

--- a/mephisto/abstractions/architects/ec2/ec2_architect.py
+++ b/mephisto/abstractions/architects/ec2/ec2_architect.py
@@ -49,7 +49,7 @@ def url_safe_string(in_string: str) -> str:
     in ec2 resources
     """
     hyphenated = in_string.replace("_", "-")
-    return re.sub("[^0-9a-zA-Z\-]+", "", hyphenated)
+    return re.sub("[^0-9a-zA-Z-]+", "", hyphenated)
 
 
 @dataclass

--- a/mephisto/abstractions/crowd_provider.py
+++ b/mephisto/abstractions/crowd_provider.py
@@ -76,6 +76,11 @@ class CrowdProvider(ABC):
             db.set_datastore_for_provider(self.PROVIDER_TYPE, self.datastore)
 
     @classmethod
+    def is_sandbox(cls) -> bool:
+        """Determine if the given crowd provider is a sandbox provider"""
+        return cls.RequesterClass.is_sandbox()
+
+    @classmethod
     def assert_task_args(cls, args: DictConfig, shared_state: "SharedTaskState"):
         """
         Assert that the provided arguments are valid. Should

--- a/mephisto/abstractions/providers/mock/mock_requester.py
+++ b/mephisto/abstractions/providers/mock/mock_requester.py
@@ -69,6 +69,7 @@ class MockRequester(Requester):
         """MockRequesters have $100000 to spend"""
         return MOCK_BUDGET
 
+    @classmethod
     def is_sandbox(self) -> bool:
         """MockRequesters are for testing only, and are thus treated as sandbox"""
         return True

--- a/mephisto/abstractions/providers/mock/mock_worker.py
+++ b/mephisto/abstractions/providers/mock/mock_worker.py
@@ -63,4 +63,4 @@ class MockWorker(Worker):
 
     @staticmethod
     def new(db: "MephistoDB", worker_id: str) -> "Worker":
-        return MockWorker._register_worker(db, worker_id, PROVIDER_TYPE)
+        return MockWorker._register_worker(db, worker_id + "_sandbox", PROVIDER_TYPE)

--- a/mephisto/abstractions/providers/mturk_sandbox/sandbox_mturk_requester.py
+++ b/mephisto/abstractions/providers/mturk_sandbox/sandbox_mturk_requester.py
@@ -45,7 +45,8 @@ class SandboxMTurkRequester(MTurkRequester):
         """
         return self.datastore.get_sandbox_client_for_requester(requester_name)
 
-    def is_sandbox(self) -> bool:
+    @classmethod
+    def is_sandbox(cls) -> bool:
         """
         Determine if this is a requester on sandbox
         """

--- a/mephisto/data_model/db_backed_meta.py
+++ b/mephisto/data_model/db_backed_meta.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
+from functools import partial
 from typing import List, Optional, Tuple, Mapping, Dict, Any, TYPE_CHECKING
 
 from abc import ABCMeta
@@ -72,3 +74,25 @@ class MephistoDataModelComponentMixin:
             loaded_val = cls.__call__(db, db_id, row=row, _used_new_call=True)
             db.cache_result(cls, loaded_val)
         return loaded_val
+
+    @classmethod
+    async def async_get(
+        cls,
+        db: "MephistoDB",
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+    ):
+        """
+        Async wrapper for retrieving from the db. In the future, if a db implements
+        a different get method, will call that instead.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            partial(
+                cls.get,
+                db,
+                db_id,
+                row=row,
+            ),
+        )

--- a/mephisto/data_model/requester.py
+++ b/mephisto/data_model/requester.py
@@ -116,6 +116,7 @@ class Requester(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMe
             total_spend += run.get_total_spend()
         return total_spend
 
+    @classmethod
     def is_sandbox(self) -> bool:
         """
         Determine if this is a requester on a sandbox/test account

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -218,7 +218,9 @@ class ClientIOHandler:
             )
             return
 
-        live_run.worker_pool.register_agent(crowd_data, request_id, live_run)
+        live_run.loop_wrap.execute_coro(
+            live_run.worker_pool.register_agent(crowd_data, request_id)
+        )
 
     def _register_worker(self, packet: Packet, channel_id: str) -> None:
         """Read and forward a worker registration packet"""
@@ -226,7 +228,9 @@ class ClientIOHandler:
         request_id = packet.data["request_id"]
         self.request_id_to_channel_id[request_id] = channel_id
         crowd_data = packet.data["provider_data"]
-        live_run.worker_pool.register_worker(crowd_data, request_id)
+        live_run.loop_wrap.execute_coro(
+            live_run.worker_pool.register_worker(crowd_data, request_id)
+        )
 
     def send_provider_details(self, request_id: str, additional_data: Dict[str, Any]):
         base_data = {"request_id": request_id}

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -84,7 +84,6 @@ class Operator:
         self._loop_wrapper = LoopWrapper(self._event_loop)
         self._run_tracker_task = self._event_loop.create_task(
             self._track_and_kill_runs(),
-            name="Operator-tracking-task",
         )
         self._stop_task: Optional[asyncio.Task] = None
 
@@ -505,7 +504,6 @@ class Operator:
         asyncio.set_event_loop(self._event_loop)
         self._stop_task = self._event_loop.create_task(
             self._stop_loop_when_no_running_tasks(log_rate=timeout_time),
-            name="Operator-loop-stop-task",
         )
 
         def trigger_shutdown():
@@ -526,7 +524,6 @@ class Operator:
         asyncio.set_event_loop(self._event_loop)
         self._stop_task = self._event_loop.create_task(
             self._stop_loop_when_no_running_tasks(log_rate=log_rate),
-            name="Operator-loop-stop-task",
         )
         try:
             self._event_loop.run_forever()

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -128,38 +128,60 @@ class WorkerPool:
                 ),
             )
 
-    def _assign_unit_to_agent(
+    async def _assign_unit_to_agent(
         self, crowd_data: Dict[str, Any], request_id: str, units: List["Unit"]
     ):
         live_run = self.get_live_run()
         task_run = live_run.task_run
+        loop = live_run.loop_wrap.loop
         crowd_provider = live_run.provider
         worker_id = crowd_data["worker_id"]
-        worker = Worker.get(self.db, worker_id)
+        worker = await Worker.async_get(self.db, worker_id)
 
-        logger.debug(
-            f"Worker {worker_id} is being assigned one of " f"{len(units)} units."
-        )
+        logger.debug(f"Worker {worker_id} is being assigned one of {len(units)} units.")
 
         reserved_unit = None
         while len(units) > 0 and reserved_unit is None:
             unit = units.pop(0)
             reserved_unit = task_run.reserve_unit(unit)
         if reserved_unit is None:
-            live_run.client_io.send_provider_details(request_id, {"agent_id": None})
+            await loop.run_in_executor(
+                None,
+                partial(
+                    live_run.client_io.send_provider_details,
+                    request_id,
+                    {"agent_id": None},
+                ),
+            )
         else:
-            agent = crowd_provider.AgentClass.new_from_provider_data(
-                self.db, worker, unit, crowd_data
+            agent = await loop.run_in_executor(
+                None,
+                partial(
+                    crowd_provider.AgentClass.new_from_provider_data,
+                    self.db,
+                    worker,
+                    unit,
+                    crowd_data,
+                ),
             )
             agent.set_live_run(live_run)
-            live_run.client_io.register_agent_from_request_id(
-                agent.get_agent_id(),
-                request_id,
-                crowd_data["agent_registration_id"],
+            await loop.run_in_executor(
+                None,
+                partial(
+                    live_run.client_io.register_agent_from_request_id,
+                    agent.get_agent_id(),
+                    request_id,
+                    crowd_data["agent_registration_id"],
+                ),
             )
             logger.debug(f"Created agent {agent}, {agent.db_id}.")
-            live_run.client_io.send_provider_details(
-                request_id, {"agent_id": agent.get_agent_id()}
+            await loop.run_in_executor(
+                None,
+                partial(
+                    live_run.client_io.send_provider_details,
+                    request_id,
+                    {"agent_id": agent.get_agent_id()},
+                ),
             )
             self.agents[agent.get_agent_id()] = agent
 
@@ -173,8 +195,8 @@ class WorkerPool:
                 )
             else:
                 # See if the concurrent unit is ready to launch
-                assignment = unit.get_assignment()
-                agents = assignment.get_agents()
+                assignment = await loop.run_in_executor(None, unit.get_assignment)
+                agents = await loop.run_in_executor(None, assignment.get_agents)
                 if None in agents:
                     agent.update_status(AgentState.STATUS_WAITING)
                     return  # need to wait for all agents to be here to launch
@@ -199,7 +221,7 @@ class WorkerPool:
         """
         Convert the onboarding agent to a full agent
         """
-        logger.info(f"Registering onboarding agent {onboarding_agent}")
+        logger.debug(f"Registering onboarding agent {onboarding_agent}")
         onboarding_id = onboarding_agent.get_agent_id()
         onboarding_agent_info = self.onboarding_agents.get(onboarding_id)
 
@@ -260,11 +282,8 @@ class WorkerPool:
         crowd_data = onboarding_info.crowd_data
         request_id = onboarding_info.request_id
 
-        # TODO async
-        self._try_send_agent_messages(onboarding_agent_info)
-        # TODO is this status update necessary?
-        # TODO async?
-        self.send_status_update_deprecated(onboarding_agent_info)
+        await self._try_send_agent_messages(onboarding_agent_info)
+        await self.push_status_update(onboarding_agent_info)
         if len(usable_units) == 0:
             await loop.run_in_executor(
                 None,
@@ -275,12 +294,12 @@ class WorkerPool:
                 ),
             )
         else:
-            # TODO async
-            self._assign_unit_to_agent(crowd_data, request_id, usable_units)
+            await self._assign_unit_to_agent(crowd_data, request_id, usable_units)
 
     async def register_agent(self, crowd_data: Dict[str, Any], request_id: str):
         """Process an agent registration packet to register an agent, returning the agent_id"""
         # Process a new agent
+        logger.debug(f"Registering agent {crowd_data}, {request_id}")
         live_run = self.get_live_run()
         loop = live_run.loop_wrap.loop
         task_run = live_run.task_run
@@ -356,12 +375,12 @@ class WorkerPool:
                         },
                     ),
                 )
-                logger.debug(
+                logger.info(
                     f"{worker} is starting onboarding thread with "
                     f"onboarding {onboard_agent}."
                 )
 
-                def cleanup_onboarding():
+                async def cleanup_onboarding():
                     del self.onboarding_agents[onboard_id]
                     del self.onboarding_infos[onboard_id]
 
@@ -432,22 +451,26 @@ class WorkerPool:
                     return
 
         # Not onboarding, so just register directly
-        # TODO async
-        self._assign_unit_to_agent(crowd_data, request_id, units)
+        await self._assign_unit_to_agent(crowd_data, request_id, units)
 
-    def _try_send_agent_messages(self, agent: Union["Agent", "OnboardingAgent"]):
+    async def _try_send_agent_messages(self, agent: Union["Agent", "OnboardingAgent"]):
         """Handle sending any possible messages for a specific agent"""
         live_run = self.get_live_run()
-        live_run.client_io.send_message_queue(agent.pending_observations)
+        await live_run.loop_wrap.loop.run_in_executor(
+            None,
+            partial(
+                live_run.client_io.send_message_queue,
+                agent.pending_observations,
+            ),
+        )
 
-    def send_status_update_deprecated(
+    async def push_status_update(
         self, agent: Union["Agent", "OnboardingAgent"]
     ) -> None:
         """
-        Handle telling the frontend agent about a change in their
-        active status. (Pushing a change in AgentState)
+        Force a status update for a specific agent, pushing the db status to
+        the frontend client
         """
-        # TODO deprecate, have status updates trigger sends automatically
         status = agent.db_status
         if isinstance(agent, OnboardingAgent):
             if status in [AgentState.STATUS_APPROVED, AgentState.STATUS_REJECTED]:
@@ -457,7 +480,14 @@ class WorkerPool:
                 status = AgentState.STATUS_WAITING
 
         live_run = self.get_live_run()
-        live_run.client_io.send_status_update(agent.get_agent_id(), status)
+        await live_run.loop_wrap.loop.run_in_executor(
+            None,
+            partial(
+                live_run.client_io.send_status_update,
+                agent.get_agent_id(),
+                status,
+            ),
+        )
 
     def _mark_agent_done(self, agent: Union["Agent", "OnboardingAgent"]) -> None:
         """
@@ -482,6 +512,7 @@ class WorkerPool:
 
         Takes as input a mapping from agent_id to server-side status
         """
+        live_run = self.get_live_run()
         for agent_id, status in status_map.items():
             if status not in AgentState.valid():
                 logger.warning(f"Invalid status for agent {agent_id}: {status}")
@@ -505,7 +536,9 @@ class WorkerPool:
                     continue
                 if status != AgentState.STATUS_DISCONNECT:
                     # Stale or reconnect, send a status update
-                    self.send_status_update_deprecated(self.agents[agent_id])
+                    live_run.loop_wrap.execute_coro(
+                        self.push_status_update(self.agents[agent_id])
+                    )
                     continue  # Only DISCONNECT can be marked remotely, rest are mismatch (except STATUS_COMPLETED)
                 agent.update_status(status)
         pass
@@ -527,10 +560,10 @@ class WorkerPool:
                     agent.wants_action.clear()
                 # Pass updated statuses
                 if agent.has_updated_status.is_set():
-                    self.send_status_update_deprecated(agent)
+                    live_run.loop_wrap.execute_coro(self.push_status_update(agent))
                     agent.has_updated_status.clear()
                 # clear the message queue for this agent
-                self._try_send_agent_messages(agent)
+                live_run.loop_wrap.execute_coro(self._try_send_agent_messages(agent))
             time.sleep(0.1)
 
     def launch_sending_thread_deprecated(self) -> None:

--- a/test/core/test_live_runs.py
+++ b/test/core/test_live_runs.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 import asyncio
 
-from typing import List
+from typing import List, Callable
 
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.abstractions.blueprints.mock.mock_task_runner import MockTaskRunner
@@ -127,6 +127,62 @@ class BaseTestLiveRuns:
         mock_data = MockTaskRunner.get_mock_assignment_data()
         return [mock_data, mock_data]
 
+    def _run_loop_until(
+        self, live_run: LiveTaskRun, condition_met: Callable[[], bool], timeout
+    ) -> bool:
+        """
+        Function to run the event loop until a specific condition is met, or
+        a timeout elapses
+        """
+        loop = live_run.loop_wrap.loop
+        asyncio.set_event_loop(loop)
+
+        async def wait_for_condition_or_timeout():
+            condition_was_met = False
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                if condition_met():
+                    condition_was_met = True
+                    break
+                await asyncio.sleep(0.2)
+            return condition_was_met
+
+        return loop.run_until_complete(wait_for_condition_or_timeout())
+
+    def assert_sandbox_worker_created(self, live_run, worker_name, timeout=2) -> None:
+        self.assertTrue(
+            self._run_loop_until(
+                live_run,
+                lambda: len(self.db.find_workers(worker_name=worker_name + "_sandbox"))
+                > 0,
+                timeout,
+            ),
+            f"Worker {worker_name} not created in time!",
+        )
+
+    def assert_agent_created(self, live_run, agent_num, timeout=2) -> None:
+        self.assertTrue(
+            self._run_loop_until(
+                live_run,
+                lambda: len(self.db.find_agents()) == agent_num,
+                timeout,
+            ),
+            f"Agent {agent_num} not created in time!",
+        )
+        agents = self.db.find_agents()
+        agent = agents[agent_num - 1]
+        self.assertIsNotNone(agent)
+
+    def await_channel_requests(self, live_run, timeout=2) -> None:
+        self.assertTrue(
+            self._run_loop_until(
+                live_run,
+                lambda: len(live_run.client_io.request_id_to_channel_id) == 0,
+                timeout,
+            ),
+            f"Channeled requests not processed in time!",
+        )
+
     def test_channel_operations(self):
         """
         Initialize a channel, and ensure the basic
@@ -182,12 +238,14 @@ class BaseTestLiveRuns:
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker = workers[0]
 
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
 
@@ -196,10 +254,12 @@ class BaseTestLiveRuns:
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent was not created properly")
 
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
         agent = agents[0]
@@ -215,12 +275,14 @@ class BaseTestLiveRuns:
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
 
         self.assertEqual(len(task_runner.running_units), 2, "Tasks were not launched")
         agents = [a for a in live_run.worker_pool.agents.values()]
@@ -231,6 +293,7 @@ class BaseTestLiveRuns:
         agent_2_data = agents[1].datastore.agent_data[agent_id_2]
         self.architect.server.send_agent_act(agent_id_1, {"text": "message1"})
         self.architect.server.send_agent_act(agent_id_2, {"text": "message2"})
+        self.await_channel_requests(live_run)
 
         # Give up to 1 seconds for the actual operations to occur
         start_time = time.time()
@@ -301,12 +364,14 @@ class BaseTestLiveRuns:
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker = workers[0]
 
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
 
@@ -315,10 +380,12 @@ class BaseTestLiveRuns:
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent was not created properly")
 
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
         agent = agents[0]
@@ -334,12 +401,14 @@ class BaseTestLiveRuns:
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
 
         self.assertEqual(
             len(task_runner.running_assignments), 1, "Task was not launched"
@@ -352,6 +421,7 @@ class BaseTestLiveRuns:
         agent_2_data = agents[1].datastore.agent_data[agent_id_2]
         self.architect.server.send_agent_act(agent_id_1, {"text": "message1"})
         self.architect.server.send_agent_act(agent_id_2, {"text": "message2"})
+        self.await_channel_requests(live_run)
 
         # Give up to 1 seconds for the actual operation to occur
         start_time = time.time()
@@ -433,17 +503,20 @@ class BaseTestLiveRuns:
         # Fail to register an agent who fails onboarding
         mock_worker_name = "BAD_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_0 = workers[0]
 
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
 
         mock_agent_details = "FAKE_ASSIGNMENT"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 0, "Agent should not be created yet - need onboarding"
@@ -466,11 +539,13 @@ class BaseTestLiveRuns:
         self.architect.server.register_mock_agent_after_onboarding(
             worker_id, onboard_agents[0].get_agent_id(), onboard_data
         )
+        self.await_channel_requests(live_run, 4)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
 
         # Re-register as if refreshing
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
         self.assertEqual(
@@ -486,12 +561,14 @@ class BaseTestLiveRuns:
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_1 = workers[0]
 
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
 
@@ -502,6 +579,7 @@ class BaseTestLiveRuns:
         qualification_id = blueprint.onboarding_qualification_id
         self.db.grant_qualification(qualification_id, worker_1.db_id, 0)
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 0, "Agent should not be created yet, failed onboarding"
@@ -523,6 +601,7 @@ class BaseTestLiveRuns:
         # Register an onboarding agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT_3"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 0, "Agent should not be created yet - need onboarding"
@@ -545,11 +624,13 @@ class BaseTestLiveRuns:
         self.architect.server.register_mock_agent_after_onboarding(
             worker_id, onboard_agents[1].get_agent_id(), onboard_data
         )
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent not created after onboarding")
 
         # Re-register as if refreshing
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
         agent = agents[0]
@@ -567,7 +648,8 @@ class BaseTestLiveRuns:
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_2 = workers[0]
         worker_id = worker_2.db_id
 
@@ -575,6 +657,7 @@ class BaseTestLiveRuns:
         mock_agent_details = "FAKE_ASSIGNMENT_4"
         self.db.grant_qualification(qualification_id, worker_2.db_id, 1)
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         time.sleep(0.1)
         last_packet = self.architect.server.last_packet
         self.assertIsNotNone(last_packet)
@@ -604,6 +687,7 @@ class BaseTestLiveRuns:
         agent_2_data = agents[1].datastore.agent_data[agent_id_2]
         self.architect.server.send_agent_act(agent_id_1, {"text": "message1"})
         self.architect.server.send_agent_act(agent_id_2, {"text": "message2"})
+        self.await_channel_requests(live_run)
 
         # Give up to 1 seconds for the actual operation to occur
         start_time = time.time()
@@ -683,12 +767,14 @@ class BaseTestLiveRuns:
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_1 = workers[0]
 
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
 
@@ -699,6 +785,7 @@ class BaseTestLiveRuns:
         qualification_id = blueprint.onboarding_qualification_id
         self.db.grant_qualification(qualification_id, worker_1.db_id, 0)
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 0, "Agent should not be created yet, failed onboarding"
@@ -720,6 +807,7 @@ class BaseTestLiveRuns:
         # Register an agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 0, "Agent should not be created yet - need onboarding"
@@ -742,11 +830,13 @@ class BaseTestLiveRuns:
         self.architect.server.register_mock_agent_after_onboarding(
             worker_id, onboard_agents[0].get_agent_id(), onboard_data
         )
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
 
         # Re-register as if refreshing
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
         self.assertEqual(
@@ -762,7 +852,8 @@ class BaseTestLiveRuns:
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_2 = workers[0]
         worker_id = worker_2.db_id
 
@@ -770,6 +861,7 @@ class BaseTestLiveRuns:
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         self.db.grant_qualification(qualification_id, worker_2.db_id, 1)
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         time.sleep(0.1)
         last_packet = self.architect.server.last_packet
         self.assertIsNotNone(last_packet)
@@ -791,11 +883,13 @@ class BaseTestLiveRuns:
         # Register another worker
         mock_worker_name = "MOCK_WORKER_3"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_3 = workers[0]
         worker_id = worker_3.db_id
         mock_agent_details = "FAKE_ASSIGNMENT_3"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 1, "Agent should not be created yet - need onboarding"
@@ -818,11 +912,13 @@ class BaseTestLiveRuns:
         self.architect.server.register_mock_agent_after_onboarding(
             worker_id, onboard_agents[1].get_agent_id(), onboard_data
         )
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "Agent not created after onboarding")
 
         # Re-register as if refreshing
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "Duplicate agent created after onboarding")
         agent = agents[1]
@@ -845,6 +941,7 @@ class BaseTestLiveRuns:
         agent_2_data = agents[1].datastore.agent_data[agent_id_2]
         self.architect.server.send_agent_act(agent_id_1, {"text": "message1"})
         self.architect.server.send_agent_act(agent_id_2, {"text": "message2"})
+        self.await_channel_requests(live_run)
 
         # Give up to 1 seconds for the actual operation to occur
         start_time = time.time()
@@ -948,20 +1045,23 @@ class BaseTestLiveRuns:
         # Register workers
         mock_worker_name = "MOCK_WORKER"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_1 = workers[0]
         worker_id = workers[0].db_id
 
         mock_worker_name = "MOCK_WORKER_2"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_2 = workers[0]
         worker_id_2 = worker_2.db_id
 
         mock_worker_name = "MOCK_WORKER_3"
         self.architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_3 = workers[0]
         worker_id_3 = worker_3.db_id
 
@@ -970,6 +1070,7 @@ class BaseTestLiveRuns:
         # Register a screening agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT"
         self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "No agent created for screening")
         time.sleep(0.1)
@@ -982,6 +1083,7 @@ class BaseTestLiveRuns:
         # Register a second screening agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT2"
         self.architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "No agent created for screening")
         last_packet = None
@@ -995,6 +1097,7 @@ class BaseTestLiveRuns:
         # Fail to register a third screening agent
         mock_agent_details = "FAKE_ASSIGNMENT3"
         self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "Third agent created, when 2 was max")
         time.sleep(0.1)
@@ -1006,6 +1109,7 @@ class BaseTestLiveRuns:
         # Register third screening agent
         mock_agent_details = "FAKE_ASSIGNMENT3"
         self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 3, "Third agent not created")
         time.sleep(0.1)
@@ -1018,6 +1122,7 @@ class BaseTestLiveRuns:
         # Submit screening from the agent
         screening_data = {"success": False}
         self.architect.server.send_agent_act(agents[1].get_agent_id(), screening_data)
+        self.await_channel_requests(live_run)
         # Assert failed screening screening
         start_time = time.time()
         TIMEOUT_TIME = 5
@@ -1032,6 +1137,7 @@ class BaseTestLiveRuns:
         # Submit screening from the agent
         screening_data = {"success": True}
         self.architect.server.send_agent_act(agents[2].get_agent_id(), screening_data)
+        self.await_channel_requests(live_run)
         # Assert successful screening screening
         start_time = time.time()
         TIMEOUT_TIME = 5
@@ -1047,6 +1153,7 @@ class BaseTestLiveRuns:
         # Register a task agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT4"
         self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "No agent created for task")
         last_packet = None

--- a/test/core/test_live_runs.py
+++ b/test/core/test_live_runs.py
@@ -10,6 +10,7 @@ import shutil
 import os
 import tempfile
 import time
+import asyncio
 
 from typing import List
 
@@ -24,7 +25,7 @@ from mephisto.abstractions.blueprints.mixins.screen_task_required import (
 from mephisto.abstractions.test.utils import get_test_task_run
 from mephisto.data_model.assignment import InitializationData
 from mephisto.data_model.task_run import TaskRun
-from mephisto.operations.datatypes import LiveTaskRun
+from mephisto.operations.datatypes import LiveTaskRun, LoopWrapper
 from mephisto.operations.client_io_handler import ClientIOHandler
 from mephisto.operations.worker_pool import WorkerPool
 
@@ -116,6 +117,7 @@ class BaseTestLiveRuns:
             self.launcher,
             self.client_io,
             self.worker_pool,
+            LoopWrapper(asyncio.new_event_loop()),
         )
         self.client_io.register_run(live_run)
         self.worker_pool.register_run(live_run)

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -63,7 +63,7 @@ class OperatorBaseTest(object):
 
     def tearDown(self):
         if self.operator is not None:
-            self.operator.shutdown()
+            self.operator.force_shutdown(timeout=10)
         self.db.shutdown()
         shutil.rmtree(self.data_dir, ignore_errors=True)
         threads = threading.enumerate()
@@ -98,6 +98,37 @@ class OperatorBaseTest(object):
         """Quick test to ensure that the operator can be initialized"""
         self.operator = Operator(self.db)
 
+    def assert_sandbox_worker_created(self, worker_name, timeout=2) -> None:
+        self.assertTrue(
+            self.operator._run_loop_until(
+                lambda: len(self.db.find_workers(worker_name=worker_name + "_sandbox"))
+                > 0,
+                timeout,
+            ),
+            f"Worker {worker_name} not created in time!",
+        )
+
+    def assert_agent_created(self, agent_num, timeout=2) -> None:
+        self.assertTrue(
+            self.operator._run_loop_until(
+                lambda: len(self.db.find_agents()) == agent_num,
+                timeout,
+            ),
+            f"Agent {agent_num} not created in time!",
+        )
+        agents = self.db.find_agents()
+        agent = agents[agent_num - 1]
+        self.assertIsNotNone(agent)
+
+    def await_channel_requests(self, tracked_run, timeout=2) -> None:
+        self.assertTrue(
+            self.operator._run_loop_until(
+                lambda: len(tracked_run.client_io.request_id_to_channel_id) == 0,
+                timeout,
+            ),
+            f"Channeled requests not processed in time!",
+        )
+
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_job_concurrent(self):
         """Ensure that the supervisor object can even be created"""
@@ -126,7 +157,8 @@ class OperatorBaseTest(object):
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
@@ -134,20 +166,19 @@ class OperatorBaseTest(object):
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
         architect.server.register_mock_agent(worker_id, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 1, "Agent was not created properly")
-        agent = agents[0]
-        self.assertIsNotNone(agent)
+        self.assert_agent_created(1)
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.assert_agent_created(2)
 
         # Give up to 5 seconds for whole mock task to complete
         start_time = time.time()
@@ -162,6 +193,7 @@ class OperatorBaseTest(object):
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
+    # @unittest.skip("demonstrating skipping")
     def test_run_job_not_concurrent(self):
         """Ensure that the supervisor object can even be created"""
         self.operator = Operator(self.db)
@@ -189,7 +221,8 @@ class OperatorBaseTest(object):
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
@@ -197,20 +230,19 @@ class OperatorBaseTest(object):
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
         architect.server.register_mock_agent(worker_id, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 1, "Agent was not created properly")
-        agent = agents[0]
-        self.assertIsNotNone(agent)
+        self.assert_agent_created(1)
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.assert_agent_created(2)
 
         # Give up to 5 seconds for both tasks to complete
         start_time = time.time()
@@ -225,6 +257,7 @@ class OperatorBaseTest(object):
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
+    # @unittest.skip("demonstrating skipping")
     def test_run_jobs_with_restrictions(self):
         """Ensure allowed_concurrent and maximum_units_per_worker work"""
         self.operator = Operator(self.db)
@@ -264,7 +297,8 @@ class OperatorBaseTest(object):
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id_1 = workers[0].db_id
 
         self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
@@ -272,75 +306,76 @@ class OperatorBaseTest(object):
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
         architect.server.register_mock_agent(worker_id_1, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 1, "Agent was not created properly")
-        agent = agents[0]
-        self.assertIsNotNone(agent)
+        self.assert_agent_created(1)
 
         # Try to register a second agent, which should fail due to concurrency
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Second agent was created")
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id_2 = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         architect.server.register_mock_agent(worker_id_2, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 2, "Second agent was not created")
+        self.assert_agent_created(2)
 
         # wait for task to pass
+        agents = self.db.find_agents()
         self.wait_for_complete_assignment(agents[1].get_unit().get_assignment(), 3)
 
         # Pass a second task as well
         mock_agent_details = "FAKE_ASSIGNMENT_3"
         architect.server.register_mock_agent(worker_id_1, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 3, "Agent was not created properly")
+        self.assert_agent_created(3)
         mock_agent_details = "FAKE_ASSIGNMENT_4"
         architect.server.register_mock_agent(worker_id_2, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 4, "Fourth agent was not created")
+        self.assert_agent_created(4)
 
         # wait for task to pass
+        agents = self.db.find_agents()
         self.wait_for_complete_assignment(agents[3].get_unit().get_assignment(), 3)
 
         # Both workers should have saturated their tasks, and not be granted agents
         mock_agent_details = "FAKE_ASSIGNMENT_5"
         architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "Additional agent was created")
         architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "Additional agent was created")
 
         # new workers should be able to work on these just fine though
         mock_worker_name = "MOCK_WORKER_3"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id_3 = workers[0].db_id
         mock_worker_name = "MOCK_WORKER_4"
         architect.server.register_mock_worker(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_id_4 = workers[0].db_id
 
         # Register agents from new workers
         mock_agent_details = "FAKE_ASSIGNMENT_5"
         architect.server.register_mock_agent(worker_id_3, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 5, "Additional agent was not created")
+        self.assert_agent_created(5)
         mock_agent_details = "FAKE_ASSIGNMENT_6"
         architect.server.register_mock_agent(worker_id_4, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 6, "Additional agent was not created")
+        self.assert_agent_created(6)
 
         # wait for task to pass
+        agents = self.db.find_agents()
         self.wait_for_complete_assignment(agents[5].get_unit().get_assignment(), 3)
 
         # Give up to 5 seconds for whole mock task to complete
@@ -351,6 +386,7 @@ class OperatorBaseTest(object):
         )
 
         self.operator.shutdown()
+        # Create a new operator, shutdown is a one-time thing
         self.operator = Operator(self.db)
 
         # Ensure all assignments are completed
@@ -384,6 +420,7 @@ class OperatorBaseTest(object):
         # Workers one and two still shouldn't be able to make agents
         mock_agent_details = "FAKE_ASSIGNMENT_7"
         architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents),
@@ -392,6 +429,7 @@ class OperatorBaseTest(object):
         )
         mock_agent_details = "FAKE_ASSIGNMENT_7"
         architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents),
@@ -402,12 +440,10 @@ class OperatorBaseTest(object):
         # Three and four should though
         mock_agent_details = "FAKE_ASSIGNMENT_7"
         architect.server.register_mock_agent(worker_id_3, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 7, "Additional agent was not created")
+        self.assert_agent_created(7)
         mock_agent_details = "FAKE_ASSIGNMENT_8"
         architect.server.register_mock_agent(worker_id_4, mock_agent_details)
-        agents = self.db.find_agents()
-        self.assertEqual(len(agents), 8, "Additional agent was not created")
+        self.assert_agent_created(8)
 
         # Ensure the task run completed and that all assignments are done
         start_time = time.time()

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -193,7 +193,6 @@ class OperatorBaseTest(object):
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
-    # @unittest.skip("demonstrating skipping")
     def test_run_job_not_concurrent(self):
         """Ensure that the supervisor object can even be created"""
         self.operator = Operator(self.db)
@@ -257,7 +256,6 @@ class OperatorBaseTest(object):
         self.assertEqual(assignment.get_status(), AssignmentState.COMPLETED)
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
-    # @unittest.skip("demonstrating skipping")
     def test_run_jobs_with_restrictions(self):
         """Ensure allowed_concurrent and maximum_units_per_worker work"""
         self.operator = Operator(self.db)


### PR DESCRIPTION
# Overview
As another part of #575 and a direct follow-up to #633, this PR updates the operator and worker pool to use `async` functions for registering new workers and agents with the data model, and for monitoring the active jobs in the `Operator`. It also makes a number of incremental cleanup changes that are required for next steps on the master integration plan.

# Implementation
1. Primarily updates all of the major registration functions in the `WorkerPool` to be `async`. This lets us suspend execution only on _specific_ locations, which tend to be io-bound retrievals from the db, file changes, or user-supplied processing.
2. Moves the `ClientIOHandler` and `Agent` classes to use actual `Queue` objects rather than lists acting as queues, which sets us up to interchange in the multiprocessing-compatible `Queue`s in the future.
3. Creates the `WrappedLoop` class, which allows a simple interface for properly executing coroutines from arbitrary locations into the correct thread.
4. Updates and standardizes a method for determining if a `CrowdProvider` is for sandbox use, allowing us to better determine worker names
5. Provides testing utilities for async to allow easier interactions with the `EventLoop`

# Testing
Automated tests pass locally, updated some of the testing to be `asyncio` compatible.

# Next Steps
The next PR will include a pretty substantial overhaul to the `Channel` API to be async, and will update our existing channels to use the new API. It will also then update more of the `ClientIOHandler` to manage the new API as well. `Channel`s under the new paradigm will be responsible for _their own_ threads and have _their own_ `asyncio` loops. (Perhaps at some point may lead to being able to launch channels as processes).

Then one last big PR to wrap up the `asyncio` changes will include alterations to the `Agent` class (and API) to have statuses be push-based. This will lead to changes in the `WorkerPool` and `TaskRunner`, as the semantics for when messages and events are queued (on arrival now rather than polled) and where the queue is located (now a queue, but could extend to be a multiprocessing queue if the TaskRunner uses the shared `loop`). 

A final PR may include smaller changes to make the `TaskLauncher` and other `run_in_executor`-frequenting classes more `asyncio`-friendly.

Once this is all complete, we can finally attempt to run the `TaskRunner` in a multiprocessing setup, but that can come _after_ 1.0, as the API will be final prior to that. (The remaining changes involve altering the type of `executor` that we use, right now it defaults to threading but we could use process pools). 