### PR TITLE
Don't update agent_id_to_socket when the key is already deleted

### DIFF
--- a/mephisto/abstractions/architects/router/deploy/server.js
+++ b/mephisto/abstractions/architects/router/deploy/server.js
@@ -382,7 +382,10 @@ wss.on("connection", function (socket) {
           agent.last_ping = Date.now();
           packet.data.status = agent.status;
           packet.data.state = agent.state;
-          if (agent_id_to_socket[agent.agent_id] != socket && agent_id_to_socket[agent.agent_id] != undefined) {
+          if (
+            agent_id_to_socket[agent.agent_id] != socket &&
+            agent_id_to_socket[agent.agent_id] != undefined
+          ) {
             // Not communicating to the correct socket, update
             debug_log("Updating socket for ", agent);
             agent_id_to_socket[agent.agent_id] = socket;

--- a/mephisto/abstractions/architects/router/deploy/server.js
+++ b/mephisto/abstractions/architects/router/deploy/server.js
@@ -382,7 +382,7 @@ wss.on("connection", function (socket) {
           agent.last_ping = Date.now();
           packet.data.status = agent.status;
           packet.data.state = agent.state;
-          if (agent_id_to_socket[agent.agent_id] != socket) {
+          if (agent_id_to_socket[agent.agent_id] != socket && agent_id_to_socket[agent.agent_id] != undefined) {
             // Not communicating to the correct socket, update
             debug_log("Updating socket for ", agent);
             agent_id_to_socket[agent.agent_id] = socket;


### PR DESCRIPTION
Another small fix to https://github.com/facebookresearch/Mephisto/issues/563

In https://github.com/facebookresearch/Mephisto/pull/573, when clearing the onboarding agent, the onboarding_agent, socket pair is removed from `agent_id_to_socket` and `socket_id_to_agent`, but is added back again in L385 in `mephisto/abstractions/architects/router/deploy/server.js` when receiving a heartbeat.

This pr will check if the onboarding_agent, socket pair has been deleted before adding back to the mapping.

socket log before the fix:
```
Am submitting onboarding for onboarding_116910
Clearing agent onboarding_116910
[2022-01-05 19:58:04,654][mephisto.operations.supervisor][DEBUG] - OnboardingAgent(116910) has submitted onboarding: {'packet_type': 'submit_onboarding', 'sender_id': 'onboarding_116910', 'receiver_id': 'mephisto', 'data': {'request_id': '5466faf7-7f64-4e2f-9dc4-d2e0156e624a'}}
________before clearing agent socket_id_to_agent { 'ca9df1cd-89ac-48d4-a1c8-311e2c36a01c':
   LocalAgentState {
     status: 'waiting',
     agent_id: 'onboarding_116910',
     unsent_messages: [],
     state: { wants_act: true, done_text: null, task_done: false },
     is_alive: true,
     last_ping: 1641441480202 } }
Deleting socket id to agent ca9df1cd-89ac-48d4-a1c8-311e2c36a01c
________after clearing agent socket_id_to_agent {}
[2022-01-05 19:58:04,776][mephisto.operations.supervisor][INFO] - Registering onboarding agent OnboardingAgent(116910)
Update agent status { packet_type: 'update_status',
  sender_id: 'mephisto',
  receiver_id: 'onboarding_116910',
  data:
   { status: 'waiting',
     state: { done_text: null, task_done: false } } }
Am creating agent for onboarding_116910
Adding message to agent queue { packet_type: 'update_status',
  sender_id: 'mephisto',
  receiver_id: 'onboarding_116910',
  data:
   { status: 'waiting',
     state: { wants_act: false, done_text: null, task_done: false } } }
[2022-01-05 19:58:04,784][mephisto.data_model.worker][DEBUG] - Granting worker MockWorker(35935) qualification onb-cl1109: 1
[2022-01-05 19:58:04,801][mephisto.data_model.agent][DEBUG] - Updating OnboardingAgent(116910) to approved
[2022-01-05 19:58:04,814][mephisto.operations.supervisor][INFO] - Onboarding agent onboarding_116910 registered out from onboarding
Update agent status { packet_type: 'update_status',
  sender_id: 'mephisto',
  receiver_id: 'onboarding_116910',
  data:
   { status: 'waiting',
     state: { done_text: null, task_done: false } } }
Adding message to agent queue { packet_type: 'update_status',
  sender_id: 'mephisto',
  receiver_id: 'onboarding_116910',
  data:
   { status: 'waiting',
     state: { wants_act: false, done_text: null, task_done: false } } }
________before updating socket socket_id_to_agent {}
Updating socket for  LocalAgentState {
  status: 'waiting',
  agent_id: 'onboarding_116910',
  unsent_messages:
   [ { packet_type: 'update_status',
       sender_id: 'mephisto',
       receiver_id: 'onboarding_116910',
       data: [Object] },
     { packet_type: 'update_status',
       sender_id: 'mephisto',
       receiver_id: 'onboarding_116910',
       data: [Object] } ],
  state: { wants_act: false, done_text: null, task_done: false },
  is_alive: true,
  last_ping: 1641441485707 }
________after updating socket socket_id_to_agent { 'ca9df1cd-89ac-48d4-a1c8-311e2c36a01c':
   LocalAgentState {
     status: 'waiting',
     agent_id: 'onboarding_116910',
     unsent_messages: [ [Object], [Object] ],
     state: { wants_act: false, done_text: null, task_done: false },
     is_alive: true,
     last_ping: 1641441485707 } }
Adding message to agent queue { packet_type: 'heartbeat',
  msg_id: '5c19abac-0fff-4a5f-ab5a-05d372df6996',
  receiver_id: 'onboarding_116910',
  sender_id: 'mephisto_server',
  data:
   { last_mephisto_ping: 1641441481973,
     status: 'waiting',
     state: { wants_act: false, done_text: null, task_done: false } } }
Mephisto requesting status
Adding message to agent queue { packet_type: 'request_status',
  sender_id: 'mephisto',
  receiver_id: '79730',
  data: null }
Adding message to agent queue { packet_type: 'request_status',
  sender_id: 'mephisto',
  receiver_id: 'onboarding_116910',
  data: null }
```