### PR TITLE
EC2 resource cleanup warning

### DIFF
--- a/mephisto/abstractions/architects/ec2/cleanup_ec2_resources.py
+++ b/mephisto/abstractions/architects/ec2/cleanup_ec2_resources.py
@@ -14,6 +14,11 @@ from typing import Dict, Any
 
 # TODO Hydrize
 def main():
+    confirm = input(
+        "This is going to completely delete all resources for your EC2 architect, including the VPC, routes, and fallback server. Are you sure you want to do this?[yes/no]\n>> "
+    )
+    if confirm != "yes":
+        return
     iam_role_name = input("Please enter local profile name for IAM role\n>> ")
     ec2_helpers.cleanup_fallback_server(iam_role_name)
 

--- a/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
+++ b/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
@@ -19,7 +19,6 @@ logger = get_logger(name=__name__)
 
 # TODO Hydrize
 def main():
-    iam_role_name = input("Please enter local profile name for IAM role\n>> ")
     all_server_names = [
         os.path.splitext(s)[0]
         for s in os.listdir(DEFAULT_SERVER_DETAIL_LOCATION)
@@ -37,6 +36,8 @@ def main():
         os.path.join(DEFAULT_SERVER_DETAIL_LOCATION, f"{server_name}.json")
         != DEFAULT_FALLBACK_FILE
     ), "This is going to completely delete the fallback server for your EC2 architect."
+
+    iam_role_name = input("Please enter local profile name for IAM role\n>> ")
 
     session = boto3.Session(profile_name=iam_role_name, region_name="us-east-2")
     ec2_helpers.remove_instance_and_cleanup(session, server_name)

--- a/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
+++ b/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
@@ -36,6 +36,7 @@ def main():
         os.path.join(DEFAULT_SERVER_DETAIL_LOCATION, f"{server_name}.json")
         != DEFAULT_FALLBACK_FILE
     ), "This is going to completely delete the fallback server for your EC2 architect."
+    assert server_name in all_server_names, f"{server_name} does not exist"
 
     iam_role_name = input("Please enter local profile name for IAM role\n>> ")
 

--- a/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
+++ b/mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import mephisto.abstractions.architects.ec2.ec2_helpers as ec2_helpers
+import boto3  # type: ignore
+import os
+
+from mephisto.abstractions.architects.ec2.ec2_helpers import (
+    DEFAULT_FALLBACK_FILE,
+    DEFAULT_SERVER_DETAIL_LOCATION,
+)
+from mephisto.operations.logger_core import get_logger
+
+logger = get_logger(name=__name__)
+
+
+# TODO Hydrize
+def main():
+    iam_role_name = input("Please enter local profile name for IAM role\n>> ")
+    all_server_names = [
+        os.path.splitext(s)[0]
+        for s in os.listdir(DEFAULT_SERVER_DETAIL_LOCATION)
+        if s not in ["README.md", os.path.basename(DEFAULT_FALLBACK_FILE)]
+    ]
+
+    if len(all_server_names) == 0:
+        logger.warning("No server to clean up!")
+        return
+
+    server_name = input(
+        f"Please enter server name you want to clean up (existing servers: {all_server_names})\n>> "
+    )
+    assert (
+        os.path.join(DEFAULT_SERVER_DETAIL_LOCATION, f"{server_name}.json")
+        != DEFAULT_FALLBACK_FILE
+    ), "This is going to completely delete the fallback server for your EC2 architect."
+
+    session = boto3.Session(profile_name=iam_role_name, region_name="us-east-2")
+    ec2_helpers.remove_instance_and_cleanup(session, server_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/mephisto/abstractions/architects/ec2/ec2_helpers.py
+++ b/mephisto/abstractions/architects/ec2/ec2_helpers.py
@@ -638,7 +638,7 @@ def create_target_group(
     Create a target group for the given instance
     """
     client = session.client("elbv2")
-    group_name_hash = hashlib.md5(group_name.encode('utf-8')).hexdigest()
+    group_name_hash = hashlib.md5(group_name.encode("utf-8")).hexdigest()
     anti_collision_group_name = f"{group_name_hash[:8]}-{group_name}"
     final_group_name = f"{anti_collision_group_name[:28]}-tg"
     create_target_response = client.create_target_group(
@@ -708,9 +708,7 @@ def register_instance_to_listener(
     and returns the target group id and rule arn
     """
     subdomain_root = domain.split(".")[0]
-    target_group_arn = create_target_group(
-        session, vpc_id, instance_id, subdomain_root
-    )
+    target_group_arn = create_target_group(session, vpc_id, instance_id, subdomain_root)
     client = session.client("elbv2")
 
     find_rule_response = client.describe_rules(

--- a/mephisto/abstractions/architects/ec2/ec2_helpers.py
+++ b/mephisto/abstractions/architects/ec2/ec2_helpers.py
@@ -1109,6 +1109,16 @@ def cleanup_fallback_server(
     listener_arn = details.get("listener_arn")
     if listener_arn is not None:
         print(f"Deleting listener {listener_arn}...")
+        find_rule_response = elb_client.describe_rules(
+            ListenerArn=listener_arn,
+        )
+        rules = find_rule_response["Rules"]
+        if len(rules) > 1:
+            confirm = input(
+                "There are still existing rules on the router, which would imply that active jobs are running right now. Are you SURE you want to DELETE ALL?[yes/no]"
+            )
+            if confirm != "yes":
+                return
         elb_client.delete_listener(
             ListenerArn=listener_arn,
         )

--- a/mephisto/abstractions/architects/ec2/servers/README.md
+++ b/mephisto/abstractions/architects/ec2/servers/README.md
@@ -1,3 +1,5 @@
 # Server Details
 
 This folder is used to store all of the server details that have been launched by this architect, such that there is a location to find the details and cleanup if something goes wrong. 
+
+If you want to clean up used subdomains (not including fallback though), please use `mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py`.


### PR DESCRIPTION
1. `mephisto/abstractions/architects/ec2/cleanup_ec2_server_by_name.py` which clean local server by name and will ensure fallback server will not be cleanedup.
2. adding the following to `cleanup_all_ec2_resources.py`:
1) a warning saying "This is going to completely delete all resources for your EC2 architect, including the VPC, routes, and fallback server. Are you sure you want to do this?
2) a check to see how many rules are set up on the current server (perhaps using this: https://github.com/facebookresearch/Mephisto/blob/80baca64b53814bd14ce6b0edffef0dda6094868/mephisto/abstractions/architects/ec2/ec2_helpers.py#L677-L680) and ensuring there's only 1 rule, otherwise throwing a second warning "There are still existing rules on the router, which would imply that active jobs are running right now. Are you SURE you want to DELETE ALL?"