### PR TITLE
[js] Use HTMLFormElement prototype func to submit forms

### DIFF
--- a/mephisto/abstractions/providers/mturk/wrap_crowd_source.js
+++ b/mephisto/abstractions/providers/mturk/wrap_crowd_source.js
@@ -69,7 +69,7 @@ function handleSubmitToProvider(task_data) {
   }
   form.method = "POST";
   form.action = urlParams.get("turkSubmitTo") + "/mturk/externalSubmit";
-  form.submit();
+  HTMLFormElement.prototype.submit.call(form);
 }
 
 /* === UI error handling code ======= */

--- a/mephisto/abstractions/providers/mturk_sandbox/wrap_crowd_source.js
+++ b/mephisto/abstractions/providers/mturk_sandbox/wrap_crowd_source.js
@@ -69,7 +69,7 @@ function handleSubmitToProvider(task_data) {
   }
   form.method = "POST";
   form.action = urlParams.get("turkSubmitTo") + "/mturk/externalSubmit";
-  form.submit();
+  HTMLFormElement.prototype.submit.call(form);
 }
 
 /* === UI error handling code ======= */


### PR DESCRIPTION
Don't use the property-based `submit` callable on the HTMLFormElement --
because tasktask data is attached as form `input` elements, an `input`
element with the property name `submit` will [clobber](https://github.com/facebookresearch/Mephisto/blob/bbc14aab6bef682f24912fb992c104d3f8b8c035/mephisto/abstractions/providers/mturk_sandbox/wrap_crowd_source.js#L66) the form's property.
- `caniuse` - https://caniuse.com/mdn-api_htmlformelement
- before/after behavior - https://jsfiddle.net/Lhtodmv7/31/
- also tested on a standalone repro with the static React app example