### PR TITLE
Asyncio Agent IO refactor

### DIFF
--- a/mephisto/abstractions/_subcomponents/channel.py
+++ b/mephisto/abstractions/_subcomponents/channel.py
@@ -5,13 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
+from queue import Queue
 import asyncio
 
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 from mephisto.data_model.packet import Packet
 from mephisto.operations.datatypes import LoopWrapper
 
 STATUS_CHECK_TIME = 4
+
+if TYPE_CHECKING:
+    from mephisto.data_model.packet import Packet
 
 
 class Channel(ABC):
@@ -52,6 +56,7 @@ class Channel(ABC):
         self.on_catastrophic_disconnect = on_catastrophic_disconnect
         self.on_message = on_message
         self.loop_wrap: Optional[LoopWrapper] = None
+        self.outgoing_queue: "Queue[Packet]" = Queue()
 
     @abstractmethod
     def is_closed(self):
@@ -82,8 +87,8 @@ class Channel(ABC):
         """
 
     @abstractmethod
-    def send(self, packet: "Packet") -> bool:
+    def enqueue_send(self, packet: "Packet") -> bool:
         """
-        Send the packet given to the intended recipient.
+        Enqueue and send the packet given to the intended recipient.
         Return True on success and False on failure.
         """

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -173,8 +173,6 @@ class TaskRunner(ABC):
                 f"Onboarding agent {onboarding_id} disconnected or errored, "
                 f"final status {onboarding_agent.get_status()}."
             )
-            # TODO is disconnect already being sent?
-            # live_run.worker_pool.push_status_update(agent_info)
             live_run.loop_wrap.execute_coro(cleanup_after())
 
     def execute_unit(

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -444,11 +444,11 @@ class ClientIOHandler:
 
                 async def await_status_task():
                     await self._status_task
+                    self._live_run = None
 
                 self.get_live_run().loop_wrap.execute_coro(await_status_task())
         except asyncio.CancelledError:
             pass
-        self._live_run = None
 
     def _get_channel_for_agent(self, agent_id: str) -> Channel:
         """Return the sending channel for a given agent"""

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -213,7 +213,7 @@ class ClientIOHandler:
                 save_dir = agent.get_data_dir()
                 architect = live_run.architect
                 for f_obj in data_files:
-                    # TODO(#575) this is incredibly blocking!
+                    # TODO(#649) this is incredibly blocking!
                     architect.download_file(f_obj["filename"], save_dir)
 
         agent.pending_actions.put(packet)
@@ -280,7 +280,7 @@ class ClientIOHandler:
         assert isinstance(
             agent, Agent
         ), f"Can only get init unit data for Agents, not OnboardingAgents, got {agent}"
-        # TODO(#575) this is IO bound
+        # TODO(#649) this is IO bound
         unit_data = task_runner.get_init_data_for_agent(agent)
 
         agent_data_packet = Packet(

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -371,6 +371,7 @@ class Operator:
 
     async def shutdown_async(self):
         """Shut down the asyncio parts of the Operator"""
+
         if self._stop_task is not None:
             await self._stop_task
         await self._run_tracker_task

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -275,7 +275,6 @@ class Operator:
             )
 
             live_run.client_io.launch_channels()
-            live_run.worker_pool.launch_sending_thread_deprecated()
         except (KeyboardInterrupt, Exception) as e:
             logger.error(
                 "Encountered error while launching run, shutting down", exc_info=True
@@ -299,7 +298,7 @@ class Operator:
 
     async def _track_and_kill_runs(self):
         """
-        Background thread that shuts down servers when a task
+        Background task that shuts down servers when a task
         is fully done.
         """
         # TODO only trigger these on a status change?

--- a/test/core/test_live_runs.py
+++ b/test/core/test_live_runs.py
@@ -145,6 +145,7 @@ class BaseTestLiveRuns:
             condition_was_met = False
             start_time = time.time()
             while time.time() - start_time < timeout:
+                await asyncio.sleep(0.01)
                 if condition_met():
                     condition_was_met = True
                     break
@@ -178,10 +179,9 @@ class BaseTestLiveRuns:
         self.assertIsNotNone(agent)
 
     def _await_current_tasks(self, live_run, timeout=5) -> None:
-        tasks = asyncio.all_tasks(live_run.loop_wrap.loop)
         self._run_loop_until(
             live_run,
-            lambda: len(asyncio.all_tasks(live_run.loop_wrap.loop)) < 2,
+            lambda: len(asyncio.all_tasks(live_run.loop_wrap.loop)) < 3,
             timeout,
         )
 

--- a/test/core/test_live_runs.py
+++ b/test/core/test_live_runs.py
@@ -179,13 +179,10 @@ class BaseTestLiveRuns:
 
     def _await_current_tasks(self, live_run, timeout=5) -> None:
         tasks = asyncio.all_tasks(live_run.loop_wrap.loop)
-        print(
-            "Await current tasks success",
-            self._run_loop_until(
-                live_run,
-                lambda: len(asyncio.all_tasks(live_run.loop_wrap.loop)) < 2,
-                timeout,
-            ),
+        self._run_loop_until(
+            live_run,
+            lambda: len(asyncio.all_tasks(live_run.loop_wrap.loop)) < 2,
+            timeout,
         )
 
     def await_channel_requests(self, live_run, timeout=2) -> None:
@@ -233,7 +230,6 @@ class BaseTestLiveRuns:
         live_run = self.get_mock_run(blueprint, task_runner)
         self.live_run = live_run
         live_run.client_io.launch_channels()
-        live_run.worker_pool.launch_sending_thread_deprecated()
         self.assertEqual(len(live_run.client_io.channels), 1)
         channel = list(live_run.client_io.channels.values())[0]
         self.assertIsNotNone(channel)
@@ -248,7 +244,6 @@ class BaseTestLiveRuns:
             self.architect.server.last_alive_packet,
             "No alive packet received by server",
         )
-        self.assertIsNotNone(live_run.worker_pool.agent_status_thread)
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
@@ -355,7 +350,6 @@ class BaseTestLiveRuns:
         live_run = self.get_mock_run(blueprint, task_runner)
         self.live_run = live_run
         live_run.client_io.launch_channels()
-        live_run.worker_pool.launch_sending_thread_deprecated()
         self.assertEqual(len(live_run.client_io.channels), 1)
         channel = list(live_run.client_io.channels.values())[0]
         self.assertIsNotNone(channel)
@@ -370,7 +364,6 @@ class BaseTestLiveRuns:
             self.architect.server.last_alive_packet,
             "No alive packet received by server",
         )
-        self.assertIsNotNone(self.worker_pool.agent_status_thread)
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
@@ -488,7 +481,6 @@ class BaseTestLiveRuns:
         live_run = self.get_mock_run(blueprint, task_runner)
         self.live_run = live_run
         live_run.client_io.launch_channels()
-        live_run.worker_pool.launch_sending_thread_deprecated()
         self.assertEqual(len(live_run.client_io.channels), 1)
         channel = list(live_run.client_io.channels.values())[0]
         self.assertIsNotNone(channel)
@@ -503,7 +495,6 @@ class BaseTestLiveRuns:
             self.architect.server.last_alive_packet,
             "No alive packet received by server",
         )
-        self.assertIsNotNone(self.worker_pool.agent_status_thread)
 
         self.assertEqual(len(task_runner.running_units), 0)
 
@@ -750,7 +741,6 @@ class BaseTestLiveRuns:
         live_run = self.get_mock_run(blueprint, task_runner)
         self.live_run = live_run
         live_run.client_io.launch_channels()
-        live_run.worker_pool.launch_sending_thread_deprecated()
         self.assertEqual(len(live_run.client_io.channels), 1)
         channel = list(live_run.client_io.channels.values())[0]
         self.assertIsNotNone(channel)
@@ -765,7 +755,6 @@ class BaseTestLiveRuns:
             self.architect.server.last_alive_packet,
             "No alive packet received by server",
         )
-        self.assertIsNotNone(self.worker_pool.agent_status_thread)
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
@@ -1024,7 +1013,6 @@ class BaseTestLiveRuns:
         live_run = self.get_mock_run(blueprint, task_runner)
         self.live_run = live_run
         live_run.client_io.launch_channels()
-        live_run.worker_pool.launch_sending_thread_deprecated()
         self.assertEqual(len(live_run.client_io.channels), 1)
         channel = list(live_run.client_io.channels.values())[0]
         self.assertIsNotNone(channel)
@@ -1039,7 +1027,6 @@ class BaseTestLiveRuns:
             self.architect.server.last_alive_packet,
             "No alive packet received by server",
         )
-        self.assertIsNotNone(self.worker_pool.agent_status_thread)
 
         # Register workers
         mock_worker_name = "MOCK_WORKER"


### PR DESCRIPTION
#  Overview

As the _final_* step to #575 and the core proposal in #514, this PR updates the `ClientIOHandler` and `WorkerPool` classes to ditch their status polling loops in favor of enqueueing asynchronous tasks directly from the `Agent`s. This means that all of the core code and accesses are on their respective `asyncio` event loops, one for the `Channel` and one for the general operation of `Mephisto`. This should decrease thrash and the cost of long-polling, while also preparing us to do packet batching in the Architect API, multiprocessing in the future (#649), and more.

_* note -_ there's still some cleanup to be done to cut down on `run_in_executor` calls, but that can be deferred to #649 as we're unlikely to see improvements until then anyways.

# Implementation
- Refines `Channel` API a little further to have `send` now `enqueue_send`, for which we can create a message queue to later push over the wire.
- Updates the `Agent` class to directly use the `ClientIOHandler` and `WorkerPool` classes to enqueue message sends and status updates _when they happen_ rather than relying on the two to poll for these events.
- Removes the polling threads from the `ClientIOHandler` and `WorkerPool` classes, as they are no longer needed.

# Testing
- [x] Locally running a Static React task, ensuring that I can complete and that shutdown occurs as expected.
- [x] Automated testing

# Next steps
That's it - I'm about ready to merge all of these down into #575 and get started on the Architect API