### PR TITLE
New Packet protocol, upgrading `ClientIOHandler` and `WorkerPool`. 

### DIFF
--- a/docs/web/docs/explanations/architect_api.md
+++ b/docs/web/docs/explanations/architect_api.md
@@ -73,7 +73,8 @@ The `Channel` is the primary way of trasmitting packets, with the `WebsocketChan
 ### Packet Types
 There are a number of different packet types used by Mephisto:
 - `PACKET_TYPE_ALIVE`: Used to mark the success of a new socket connection.
-- `PACKET_TYPE_SUBMIT`: Used to handle submission of any subcomponent of a `Unit`, currently either onboarding or full task. 
+- `PACKET_TYPE_SUBMIT_ONBOARDING`: Used to handle submission of onboarding. 
+- `PACKET_TYPE_SUBMIT_UNIT`: Used to handle submission of a `Unit`. 
 - `PACKET_TYPE_CLIENT_BOUND_LIVE_DATA`: Used to send any new live data to an agent.
 - `PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA`: Used for the frontend to send any type of data to the backend, usually to be processed by a user-defined callback. 
 - `PACKET_TYPE_REGISTER_AGENT`: Used to request a new `Agent` and `Unit` data for a specific worker on a task.
@@ -88,7 +89,7 @@ There are a number of different packet types used by Mephisto:
 While this is the "Architect API" most of the responsibilities for the architect are merely pointing the `ClientIOHandler` to the correct `Channel`s for sending packets for a given client. Ultimately it is the `ClientIOHandler` that dictates the responsibilities that the transmitted messages carry:
 - The `ClientIOHandler` must send a `PACKET_TYPE_ALIVE` whenever it opens a new channel (in this case, to a router).
 - For `Unit` Registration, in response to a `PACKET_TYPE_REGISTER_AGENT`, the handler must return a `PACKET_TYPE_AGENT_DETAILS` with the details of an agent and it's initialization data, or the failure status for why an agent couldn't be created.
-- During a `Unit` the handler must process `PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA` and direct the content to the correct handlers, and should send a `PACKET_TYPE_CLIENT_BOUND_LIVE_DATA` for any `Agent.send_data()` call on a live connected `Agent`. The handler must also process `PACKET_TYPE_SUBMIT` packets for the key transitions of a `Unit` in progress, and should respond with `PACKET_TYPE_AGENT_DETAILS` for a submit on an `OnboardingAgent`.
+- During a `Unit` the handler must process `PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA` and direct the content to the correct handlers, and should send a `PACKET_TYPE_CLIENT_BOUND_LIVE_DATA` for any `Agent.send_data()` call on a live connected `Agent`. The handler must also process `PACKET_TYPE_SUBMIT_*` packets for the key transitions of a `Unit` in progress, and should respond with `PACKET_TYPE_AGENT_DETAILS` for a submit on an `OnboardingAgent`.
 - Over any run, the handler should poll with `PACKET_TYPE_REQUEST_STATUS` and update local `Agent` statuses on disconnects from `PACKET_TYPE_RETURN_STATUSES`. This also acts as a heartbeat from the Python core to the router. The handler should also take `PACKET_TYPE_ERROR` and log the contents if this ever occurs.
 
 
@@ -96,7 +97,7 @@ While this is the "Architect API" most of the responsibilities for the architect
 
 The primary responsiblity of the router is to take incoming packets from client connections and direct them to the core Mephisto `ClientIOHandler` and to do the reverse as well. All packets will have a core `agent_id` field denoting either the sender or receiver of the packet, depending on the packet type. The only exception is the `PACKET_TYPE_ALIVE`, which is directed to the router and allows for any registration of an incoming connection.
 
-Secondarily, the router is responsible for converting RESTful `POST` requests from `mephisto-task` into socket messages, and relaying the response as a standard `POST` response. This behavior is _only_ for the `PACKET_TYPE_REGISTER_AGENT`, and `PACKET_TYPE_SUBMIT` packets, and both of them will be serviced by `PACKET_TYPE_AGENT_DETAILS` responses. For these it should be listening to `POST` requests at `/register_worker`, `/submit_onboarding`, and `/submit_task`. `POST` requests to `/log_error` should result in forwarding a `PACKET_TYPE_ERROR`.
+Secondarily, the router is responsible for converting RESTful `POST` requests from `mephisto-task` into socket messages, and relaying the response as a standard `POST` response. This behavior is _only_ for the `PACKET_TYPE_REGISTER_AGENT`, and `PACKET_TYPE_SUBMIT_ONBOARDING` packets, and both of them will be serviced by `PACKET_TYPE_AGENT_DETAILS` responses. For these it should be listening to `POST` requests at `/register_worker`, `/submit_onboarding`, and `/submit_task`. `POST` requests to `/log_error` should result in forwarding a `PACKET_TYPE_ERROR`.
 
 Third, the router is responsible for maintaining track of agent status, and acting as a cache for this information after disconnects. This allows for a worker to return to a task and have updated information about what has transpired, even when the main Mephisto server has cleaned up the related `TaskRunner` and live `Agent`.
 
@@ -104,6 +105,6 @@ Fourth, the router is responsible for serving the static `task_config.json` file
 
 ### `mephisto-task` responsibilities.
 
-The `useMephistoTask` hook is responsible for allowing a worker to connect to a task and submit the relevant data. For this, it only needs to make `POST` requests related to the `PACKET_TYPE_SUBMIT` and `PACKET_TYPE_REGISTER_AGENT` events. The former should be triggered on `handleSubmit`, while the latter should trigger immediately on load.
+The `useMephistoTask` hook is responsible for allowing a worker to connect to a task and submit the relevant data. For this, it only needs to make `POST` requests related to the `PACKET_TYPE_SUBMIT_*` and `PACKET_TYPE_REGISTER_AGENT` events. The former should be triggered on `handleSubmit`, while the latter should trigger immediately on load.
 
 The `useMephistoLiveTask` hook is responsible for the rest of the packets. Data packets should be sent via `sendData` and handled with the `onLiveDataReceived` callback. Providing a callback to `sendData` will call that with any response data that sets the `source_request_id` to the initial send's `message_id`. Local connection state is managed by the `socket_handler.jsx` class, and surfaced through the hook variables for UIs to use. 

--- a/mephisto/abstractions/architects/mock_architect.py
+++ b/mephisto/abstractions/architects/mock_architect.py
@@ -18,7 +18,8 @@ from dataclasses import dataclass, field
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.packet import (
     PACKET_TYPE_ALIVE,
-    PACKET_TYPE_SUBMIT,
+    PACKET_TYPE_SUBMIT_ONBOARDING,
+    PACKET_TYPE_SUBMIT_UNIT,
     PACKET_TYPE_CLIENT_BOUND_LIVE_DATA,
     PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA,
     PACKET_TYPE_REGISTER_AGENT,
@@ -210,10 +211,9 @@ class MockServer(tornado.web.Application):
         Send a packet asking to register a mock agent.
         """
         submit_data["request_id"] = "1234"
-        submit_data["submission_type"] = "unit"
         self._send_message(
             {
-                "packet_type": PACKET_TYPE_SUBMIT,
+                "packet_type": PACKET_TYPE_SUBMIT_UNIT,
                 "subject_id": agent_id,
                 "data": submit_data,
             }
@@ -224,10 +224,9 @@ class MockServer(tornado.web.Application):
         Send a packet asking to register a mock agent.
         """
         onboard_data["request_id"] = "1234"
-        onboard_data["submission_type"] = "onboarding"
         self._send_message(
             {
-                "packet_type": PACKET_TYPE_SUBMIT,
+                "packet_type": PACKET_TYPE_SUBMIT_ONBOARDING,
                 "subject_id": agent_id,
                 "data": onboard_data,
             }

--- a/mephisto/abstractions/architects/mock_architect.py
+++ b/mephisto/abstractions/architects/mock_architect.py
@@ -18,13 +18,15 @@ from dataclasses import dataclass, field
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.packet import (
     PACKET_TYPE_ALIVE,
-    PACKET_TYPE_NEW_WORKER,
-    PACKET_TYPE_NEW_AGENT,
-    PACKET_TYPE_AGENT_ACTION,
-    PACKET_TYPE_SUBMIT_ONBOARDING,
-    PACKET_TYPE_REQUEST_AGENT_STATUS,
-    PACKET_TYPE_RETURN_AGENT_STATUS,
-    PACKET_TYPE_GET_INIT_DATA,
+    PACKET_TYPE_SUBMIT,
+    PACKET_TYPE_CLIENT_BOUND_LIVE_DATA,
+    PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA,
+    PACKET_TYPE_REGISTER_AGENT,
+    PACKET_TYPE_AGENT_DETAILS,
+    PACKET_TYPE_UPDATE_STATUS,
+    PACKET_TYPE_REQUEST_STATUSES,
+    PACKET_TYPE_RETURN_STATUSES,
+    PACKET_TYPE_ERROR,
 )
 from mephisto.operations.registry import register_mephisto_abstraction
 from mephisto.abstractions.architects.channels.websocket_channel import WebsocketChannel
@@ -92,9 +94,11 @@ class SocketHandler(WebSocketHandler):
         message = json.loads(message_text)
         if message["packet_type"] == PACKET_TYPE_ALIVE:
             self.app.last_alive_packet = message
-        elif message["packet_type"] == PACKET_TYPE_AGENT_ACTION:
+        elif message["packet_type"] == PACKET_TYPE_CLIENT_BOUND_LIVE_DATA:
             self.app.actions_observed += 1
-        elif message["packet_type"] != PACKET_TYPE_REQUEST_AGENT_STATUS:
+        elif message["packet_type"] == PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA:
+            self.app.actions_observed += 1
+        elif message["packet_type"] != PACKET_TYPE_REQUEST_STATUSES:
             self.app.last_packet = message
 
     def check_origin(self, origin):
@@ -175,45 +179,24 @@ class MockServer(tornado.web.Application):
         """
         self._send_message(
             {
-                "packet_type": PACKET_TYPE_AGENT_ACTION,
-                "sender_id": agent_id,
-                "receiver_id": "Mephisto",
+                "packet_type": PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA,
+                "subject_id": agent_id,
                 "data": act_content,
             }
         )
 
-    def request_init_data(self, agent_id):
-        """
-        Send a packet from the given agent with
-        the given content
-        """
-        self._send_message(
-            {
-                "packet_type": PACKET_TYPE_GET_INIT_DATA,
-                "sender_id": agent_id,
-                "receiver_id": "Mephisto",
-                "data": {
-                    "request_id": agent_id + str(time.time()),
-                    "provider_data": {
-                        "agent_id": agent_id,
-                    },
-                },
-            }
-        )
-
-    def register_mock_agent(self, worker_id, agent_details):
+    def register_mock_agent(self, worker_name, agent_details):
         """
         Send a packet asking to register a mock agent.
         """
         self._send_message(
             {
-                "packet_type": PACKET_TYPE_NEW_AGENT,
-                "sender_id": "MockServer",
-                "receiver_id": "Mephisto",
+                "packet_type": PACKET_TYPE_REGISTER_AGENT,
+                "subject_id": "MockServer",
                 "data": {
                     "request_id": agent_details,
                     "provider_data": {
-                        "worker_id": worker_id,
+                        "worker_name": worker_name,
                         "agent_registration_id": agent_details,
                     },
                 },
@@ -225,28 +208,12 @@ class MockServer(tornado.web.Application):
         Send a packet asking to register a mock agent.
         """
         onboard_data["request_id"] = "1234"
+        onboard_data["submission_type"] = "onboarding"
         self._send_message(
             {
                 "packet_type": PACKET_TYPE_SUBMIT_ONBOARDING,
-                "sender_id": agent_id,
-                "receiver_id": "Mephisto",
+                "subject_id": agent_id,
                 "data": onboard_data,
-            }
-        )
-
-    def register_mock_worker(self, worker_name):
-        """
-        send a packet asking to register a mock worker.
-        """
-        self._send_message(
-            {
-                "packet_type": PACKET_TYPE_NEW_WORKER,
-                "sender_id": "MockServer",
-                "receiver_id": "Mephisto",
-                "data": {
-                    "request_id": worker_name,
-                    "provider_data": {"worker_name": worker_name},
-                },
             }
         )
 
@@ -256,9 +223,8 @@ class MockServer(tornado.web.Application):
         """
         self._send_message(
             {
-                "packet_type": PACKET_TYPE_RETURN_AGENT_STATUS,
-                "sender_id": "MockServer",
-                "receiver_id": "Mephisto",
+                "packet_type": PACKET_TYPE_RETURN_STATUSES,
+                "subject_id": "Mephisto",
                 "data": {agent_id: AgentState.STATUS_DISCONNECT},
             }
         )

--- a/mephisto/data_model/packet.py
+++ b/mephisto/data_model/packet.py
@@ -7,7 +7,8 @@
 from typing import Optional, Dict, Any
 
 PACKET_TYPE_ALIVE = "alive"
-PACKET_TYPE_SUBMIT = "submit"
+PACKET_TYPE_SUBMIT_ONBOARDING = "submit_onboarding"
+PACKET_TYPE_SUBMIT_UNIT = "submit_unit"
 PACKET_TYPE_CLIENT_BOUND_LIVE_DATA = "client_bound_live_data"
 PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA = "mephisto_bound_live_data"
 PACKET_TYPE_REGISTER_AGENT = "register_agent"

--- a/mephisto/data_model/packet.py
+++ b/mephisto/data_model/packet.py
@@ -6,19 +6,16 @@
 
 from typing import Optional, Dict, Any
 
-PACKET_TYPE_INIT_DATA = "initial_data_send"
-PACKET_TYPE_AGENT_ACTION = "agent_action"
-PACKET_TYPE_REQUEST_ACTION = "request_act"
-PACKET_TYPE_UPDATE_AGENT_STATUS = "update_status"
-PACKET_TYPE_NEW_AGENT = "register_agent"
-PACKET_TYPE_NEW_WORKER = "register_worker"
-PACKET_TYPE_REQUEST_AGENT_STATUS = "request_status"
-PACKET_TYPE_RETURN_AGENT_STATUS = "return_status"
-PACKET_TYPE_GET_INIT_DATA = "init_data_request"
 PACKET_TYPE_ALIVE = "alive"
-PACKET_TYPE_PROVIDER_DETAILS = "provider_details"
-PACKET_TYPE_SUBMIT_ONBOARDING = "submit_onboarding"
-PACKET_TYPE_ERROR_LOG = "log_error"
+PACKET_TYPE_SUBMIT = "submit"
+PACKET_TYPE_CLIENT_BOUND_LIVE_DATA = "client_bound_live_data"
+PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA = "mephisto_bound_live_data"
+PACKET_TYPE_REGISTER_AGENT = "register_agent"
+PACKET_TYPE_AGENT_DETAILS = "agent_details"
+PACKET_TYPE_UPDATE_STATUS = "update_status"
+PACKET_TYPE_REQUEST_STATUSES = "request_statuses"
+PACKET_TYPE_RETURN_STATUSES = "return_statuses"
+PACKET_TYPE_ERROR = "log_error"
 
 
 class Packet:
@@ -33,36 +30,32 @@ class Packet:
     def __init__(
         self,
         packet_type: str,
-        sender_id: str,
-        receiver_id: str,
+        subject_id: str,  # Target agent id the packet is about
         data: Optional[Dict[str, Any]] = None,
     ):
         self.type = packet_type
-        self.sender_id = sender_id
-        self.receiver_id = receiver_id
+        self.subject_id = subject_id
         self.data = {} if data is None else data
         # TODO(#97) Packet validation! Only certain packets can be sent
         # with no data
 
     @staticmethod
     def from_dict(input_dict: Dict[str, Any]) -> "Packet":
-        required_fields = ["packet_type", "sender_id", "receiver_id", "data"]
+        required_fields = ["packet_type", "subject_id", "data"]
         for field in required_fields:
             assert (
                 field in input_dict
             ), f"Packet input dict {input_dict} missing required field {field}"
         return Packet(
             packet_type=input_dict["packet_type"],
-            sender_id=input_dict["sender_id"],
-            receiver_id=input_dict["receiver_id"],
+            subject_id=input_dict["subject_id"],
             data=input_dict["data"],
         )
 
     def to_sendable_dict(self) -> Dict[str, Any]:
         return {
             "packet_type": self.type,
-            "sender_id": self.sender_id,
-            "receiver_id": self.receiver_id,
+            "subject_id": self.subject_id,
             "data": self.data,
         }
 

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -13,7 +13,8 @@ from queue import Queue
 from mephisto.data_model.packet import (
     Packet,
     PACKET_TYPE_ALIVE,
-    PACKET_TYPE_SUBMIT,
+    PACKET_TYPE_SUBMIT_ONBOARDING,
+    PACKET_TYPE_SUBMIT_UNIT,
     PACKET_TYPE_CLIENT_BOUND_LIVE_DATA,
     PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA,
     PACKET_TYPE_REGISTER_AGENT,
@@ -332,15 +333,10 @@ class ClientIOHandler:
         # TODO(#102) this method currently assumes that the packet's subject_id will
         # always be a valid agent in our list of agent_infos. This isn't always the case
         # when relaunching with the same URLs.
-        if packet.type == PACKET_TYPE_SUBMIT:
-            if packet.data["submission_type"] == "onboarding":
-                self._on_submit_onboarding(packet, channel_id)
-            elif packet.data["submission_type"] == "unit":
-                self._on_submit_unit(packet, channel_id)
-            else:
-                raise Exception(
-                    f"Submission packet with unknown target {packet.data['submission_type']}"
-                )
+        if packet.type == PACKET_TYPE_SUBMIT_ONBOARDING:
+            self._on_submit_onboarding(packet, channel_id)
+        elif packet.type == PACKET_TYPE_SUBMIT_UNIT:
+            self._on_submit_unit(packet, channel_id)
         elif packet.type == PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA:
             self._on_live_data(packet, channel_id)
         elif packet.type == PACKET_TYPE_REGISTER_AGENT:

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -389,11 +389,6 @@ class ClientIOHandler:
             subject_id=agent_id,
             data={
                 "status": status,
-                "state": {
-                    # Any non-final status receives None and False for this
-                    "done_text": STATUS_TO_TEXT_MAP.get(status),
-                    "task_done": status == AgentState.STATUS_PARTNER_DISCONNECT,
-                },
             },
         )
         self._get_channel_for_agent(agent_id).enqueue_send(status_packet)

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -13,18 +13,15 @@ from queue import Queue
 from mephisto.data_model.packet import (
     Packet,
     PACKET_TYPE_ALIVE,
-    PACKET_TYPE_AGENT_ACTION,
-    PACKET_TYPE_NEW_AGENT,
-    PACKET_TYPE_NEW_WORKER,
-    PACKET_TYPE_REQUEST_AGENT_STATUS,
-    PACKET_TYPE_RETURN_AGENT_STATUS,
-    PACKET_TYPE_INIT_DATA,
-    PACKET_TYPE_GET_INIT_DATA,
-    PACKET_TYPE_PROVIDER_DETAILS,
-    PACKET_TYPE_SUBMIT_ONBOARDING,
-    PACKET_TYPE_REQUEST_ACTION,
-    PACKET_TYPE_UPDATE_AGENT_STATUS,
-    PACKET_TYPE_ERROR_LOG,
+    PACKET_TYPE_SUBMIT,
+    PACKET_TYPE_CLIENT_BOUND_LIVE_DATA,
+    PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA,
+    PACKET_TYPE_REGISTER_AGENT,
+    PACKET_TYPE_AGENT_DETAILS,
+    PACKET_TYPE_UPDATE_STATUS,
+    PACKET_TYPE_REQUEST_STATUSES,
+    PACKET_TYPE_RETURN_STATUSES,
+    PACKET_TYPE_ERROR,
 )
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.data_model.agent import Agent, OnboardingAgent
@@ -52,7 +49,6 @@ STATUS_TO_TEXT_MAP = {
 }
 
 SYSTEM_CHANNEL_ID = "mephisto"
-SERVER_CHANNEL_ID = "mephisto_server"
 START_DEATH_TIME = 10
 
 
@@ -189,8 +185,7 @@ class ClientIOHandler:
         return self.channels[channel_id].enqueue_send(
             Packet(
                 packet_type=PACKET_TYPE_ALIVE,
-                sender_id=SYSTEM_CHANNEL_ID,
-                receiver_id=channel_id,
+                subject_id=SYSTEM_CHANNEL_ID,
             )
         )
 
@@ -199,10 +194,19 @@ class ClientIOHandler:
         error = packet.data["final_data"]
         logger.warning(f"[FRONT_END_ERROR]: {error}")
 
-    def _on_act(self, packet: Packet, _channel_id: str):
+    def _on_live_data(self, packet: Packet, _channel_id: str):
         """Handle an action as sent from an agent, enqueuing to the agent"""
         live_run = self.get_live_run()
-        agent = live_run.worker_pool.get_agent_for_id(packet.sender_id)
+        agent = live_run.worker_pool.get_agent_for_id(packet.subject_id)
+        assert agent is not None, "Could not find given agent!"
+
+        agent.pending_actions.put(packet)
+        agent.has_action.set()
+
+    def _on_submit_unit(self, packet: Packet, _channel_id: str):
+        """Handle an action as sent from an agent, enqueuing to the agent"""
+        live_run = self.get_live_run()
+        agent = live_run.worker_pool.get_agent_for_id(packet.subject_id)
         assert agent is not None, "Could not find given agent!"
 
         # If the packet is_submit, and has files, we need to
@@ -215,95 +219,17 @@ class ClientIOHandler:
                 for f_obj in data_files:
                     # TODO(#649) this is incredibly blocking!
                     architect.download_file(f_obj["filename"], save_dir)
+        else:
+            raise Exception(f"Got submit call on a non-submit packet: {packet}")
 
+        # TODO(#655) push to an agent _submit_ call rather than being a regular message
         agent.pending_actions.put(packet)
         agent.has_action.set()
-
-    def _register_agent(self, packet: Packet, channel_id: str) -> None:
-        """process the packet, then delegate to the worker pool appropriate registration"""
-        live_run = self.get_live_run()
-        request_id = packet.data["request_id"]
-        self.request_id_to_channel_id[request_id] = channel_id
-        crowd_data = packet.data["provider_data"]
-        agent_registration_id = crowd_data["agent_registration_id"]
-        logger.debug(f"Incoming request to register agent {agent_registration_id}.")
-        if agent_registration_id in self.agents_by_registration_id:
-            agent_id = self.agents_by_registration_id[agent_registration_id]
-            self.agent_id_to_channel_id[agent_id] = channel_id
-            self.enqueue_provider_details(request_id, {"agent_id": agent_id})
-            logger.debug(
-                f"Found existing agent_registration_id {agent_registration_id}, "
-                f"reconnecting to {agent_id}."
-            )
-            return
-
-        live_run.loop_wrap.execute_coro(
-            live_run.worker_pool.register_agent(crowd_data, request_id)
-        )
-
-    def _register_worker(self, packet: Packet, channel_id: str) -> None:
-        """Read and forward a worker registration packet"""
-        live_run = self.get_live_run()
-        request_id = packet.data["request_id"]
-        self.request_id_to_channel_id[request_id] = channel_id
-        crowd_data = packet.data["provider_data"]
-        live_run.loop_wrap.execute_coro(
-            live_run.worker_pool.register_worker(crowd_data, request_id)
-        )
-
-    def enqueue_provider_details(
-        self, request_id: str, additional_data: Dict[str, Any]
-    ):
-        """
-        Synchronous method to enqueue a message sending the given provider details
-        """
-        base_data = {"request_id": request_id}
-        for key, val in additional_data.items():
-            base_data[key] = val
-        self.message_queue.put(
-            Packet(
-                packet_type=PACKET_TYPE_PROVIDER_DETAILS,
-                sender_id=SYSTEM_CHANNEL_ID,
-                receiver_id=self.request_id_to_channel_id[request_id],
-                data=base_data,
-            )
-        )
-        self.process_outgoing_queue(self.message_queue)
-        del self.request_id_to_channel_id[request_id]
-
-    def _get_init_data(self, packet, channel_id: str):
-        """Get the initialization data for the assigned agent's task"""
-        live_run = self.get_live_run()
-        task_runner = live_run.task_runner
-        agent_id = packet.data["provider_data"]["agent_id"]
-        agent = live_run.worker_pool.get_agent_for_id(agent_id)
-        assert isinstance(
-            agent, Agent
-        ), f"Can only get init unit data for Agents, not OnboardingAgents, got {agent}"
-        # TODO(#649) this is IO bound
-        unit_data = task_runner.get_init_data_for_agent(agent)
-
-        agent_data_packet = Packet(
-            packet_type=PACKET_TYPE_INIT_DATA,
-            sender_id=SYSTEM_CHANNEL_ID,
-            receiver_id=channel_id,
-            data={"request_id": packet.data["request_id"], "init_data": unit_data},
-        )
-
-        self.message_queue.put(agent_data_packet)
-        self.process_outgoing_queue(self.message_queue)
-
-        if isinstance(unit_data, dict) and unit_data.get("raw_messages") is not None:
-            # TODO(#651) clarify how raw messages are sent
-            for message in unit_data["raw_messages"]:
-                packet = Packet.from_dict(message)
-                packet.receiver_id = agent_id
-                agent.pending_observations.put(packet)
 
     def _on_submit_onboarding(self, packet: Packet, channel_id: str) -> None:
         """Handle the submission of onboarding data"""
         live_run = self.get_live_run()
-        onboarding_id = packet.sender_id
+        onboarding_id = packet.subject_id
         if onboarding_id not in live_run.worker_pool.onboarding_agents:
             logger.warning(
                 f"Onboarding agent {onboarding_id} already submitted or disconnected, "
@@ -322,48 +248,112 @@ class ClientIOHandler:
         live_run.worker_pool.onboarding_infos[onboarding_id].request_id = request_id
 
         del packet.data["request_id"]
+        # TODO(#655) Update this to _submit_ the given packet, rather than putting it into
+        # pending actions
         agent.pending_actions.put(packet)
         agent.has_action.set()
+
+    def _register_agent(self, packet: Packet, channel_id: str) -> None:
+        """Read and forward a worker registration packet"""
+        live_run = self.get_live_run()
+        request_id = packet.data["request_id"]
+
+        self.request_id_to_channel_id[request_id] = channel_id
+        crowd_data = packet.data["provider_data"]
+
+        # Check for reconnecting agent
+        agent_registration_id = crowd_data["agent_registration_id"]
+        if agent_registration_id in self.agents_by_registration_id:
+            agent_id = self.agents_by_registration_id[agent_registration_id]
+            live_run.loop_wrap.execute_coro(
+                live_run.worker_pool.reconnect_agent(agent_id, request_id)
+            )
+            self.agent_id_to_channel_id[agent_id] = channel_id
+            logger.debug(
+                f"Found existing agent_registration_id {agent_registration_id}, "
+                f"reconnecting to {agent_id}."
+            )
+            return
+
+        # Handle regular agent
+        live_run.loop_wrap.execute_coro(
+            live_run.worker_pool.register_worker(crowd_data, request_id)
+        )
+
+    def enqueue_agent_details(self, request_id: str, additional_data: Dict[str, Any]):
+        """
+        Synchronous method to enqueue a message sending the given agent details
+        """
+        base_data = {"request_id": request_id}
+        for key, val in additional_data.items():
+            base_data[key] = val
+        self.message_queue.put(
+            Packet(
+                packet_type=PACKET_TYPE_AGENT_DETAILS,
+                subject_id=self.request_id_to_channel_id[request_id],
+                data=base_data,
+            )
+        )
+        self.process_outgoing_queue(self.message_queue)
+        del self.request_id_to_channel_id[request_id]
+
+    def _get_init_data(self, packet, channel_id: str):
+        """Get the initialization data for the assigned agent's task"""
+        live_run = self.get_live_run()
+        task_runner = live_run.task_runner
+        agent_id = packet.data["provider_data"]["agent_id"]
+        agent = live_run.worker_pool.get_agent_for_id(agent_id)
+        assert isinstance(
+            agent, Agent
+        ), f"Can only get init unit data for Agents, not OnboardingAgents, got {agent}"
+        # TODO(#649) this is IO bound
+        unit_data = task_runner.get_init_data_for_agent(agent)
+
+        # agent_data_packet = Packet(
+        #     packet_type=PACKET_TYPE_INIT_DATA,
+        #     subject_id=agent_id,
+        #     data={"request_id": packet.data["request_id"], "init_data": unit_data},
+        # )
+
+        # self.message_queue.put(agent_data_packet)
+        self.process_outgoing_queue(self.message_queue)
+
+        # TODO(#655) Move raw message (live message) processing into mephisto-task
+        if isinstance(unit_data, dict) and unit_data.get("raw_messages") is not None:
+            # TODO(#651) clarify how raw messages are sent
+            for message in unit_data["raw_messages"]:
+                packet = Packet.from_dict(message)
+                packet.receiver_id = agent_id
+                agent.pending_observations.put(packet)
 
     def _on_message(self, packet: Packet, channel_id: str):
         """Handle incoming messages from the channel"""
         live_run = self.get_live_run()
-        # TODO(#102) this method currently assumes that the packet's sender_id will
-        # always be a valid agent in our list of agent_infos. At the moment this
-        # is a valid assumption, but will not be on recovery from catastrophic failure.
-        if packet.type == PACKET_TYPE_AGENT_ACTION:
-            self._on_act(packet, channel_id)
-        elif packet.type == PACKET_TYPE_NEW_AGENT:
+        # TODO(#102) this method currently assumes that the packet's subject_id will
+        # always be a valid agent in our list of agent_infos. This isn't always the case
+        # when relaunching with the same URLs.
+        if packet.type == PACKET_TYPE_SUBMIT:
+            if packet.data["submission_type"] == "onboarding":
+                self._on_submit_onboarding(packet, channel_id)
+            elif packet.data["submission_type"] == "unit":
+                self._on_submit_unit(packet, channel_id)
+            else:
+                raise Exception(
+                    f"Submission packet with unknown target {packet.data['submission_type']}"
+                )
+        elif packet.type == PACKET_TYPE_MEPHISTO_BOUND_LIVE_DATA:
+            self._on_live_data(packet, channel_id)
+        elif packet.type == PACKET_TYPE_REGISTER_AGENT:
             self._register_agent(packet, channel_id)
-        elif packet.type == PACKET_TYPE_SUBMIT_ONBOARDING:
-            self._on_submit_onboarding(packet, channel_id)
-        elif packet.type == PACKET_TYPE_NEW_WORKER:
-            self._register_worker(packet, channel_id)
-        elif packet.type == PACKET_TYPE_GET_INIT_DATA:
-            self._get_init_data(packet, channel_id)
-        elif packet.type == PACKET_TYPE_RETURN_AGENT_STATUS:
+        elif packet.type == PACKET_TYPE_RETURN_STATUSES:
             # Record this status response
             live_run.worker_pool.handle_updated_agent_status(packet.data)
-        elif packet.type == PACKET_TYPE_ERROR_LOG:
+        elif packet.type == PACKET_TYPE_ERROR:
             self._log_frontend_error(packet)
         else:
-            # PACKET_TYPE_REQUEST_AGENT_STATUS, PACKET_TYPE_ALIVE,
-            # PACKET_TYPE_INIT_DATA
+            # PACKET_TYPE_REQUEST_STATUSES, PACKET_TYPE_ALIVE,
+            # PACKET_TYPE_CLIENT_BOUND_LIVE_DATA, PACKET_TYPE_AGENT_DETAILS
             raise Exception(f"Unexpected packet type {packet.type}")
-
-    def request_action(self, agent_id: str) -> None:
-        """
-        Request an act from the agent targetted here. If the
-        agent is found by the server, this request will be
-        forwarded.
-        """
-        send_packet = Packet(
-            packet_type=PACKET_TYPE_REQUEST_ACTION,
-            sender_id=SYSTEM_CHANNEL_ID,
-            receiver_id=agent_id,
-            data={},
-        )
-        self._get_channel_for_agent(agent_id).enqueue_send(send_packet)
 
     def _request_status_update(self) -> None:
         """
@@ -372,9 +362,8 @@ class ClientIOHandler:
         """
         for channel_id, channel in self.channels.items():
             send_packet = Packet(
-                packet_type=PACKET_TYPE_REQUEST_AGENT_STATUS,
-                sender_id=SYSTEM_CHANNEL_ID,
-                receiver_id=channel_id,
+                packet_type=PACKET_TYPE_REQUEST_STATUSES,
+                subject_id=SYSTEM_CHANNEL_ID,
                 data={},
             )
             channel.enqueue_send(send_packet)
@@ -384,11 +373,20 @@ class ClientIOHandler:
             self._request_status_update()
             await asyncio.sleep(STATUS_CHECK_TIME)
 
+    def send_live_data(self, agent_id: str, data: Dict[str, Any]):
+        """Send a live data packet to the given agent id"""
+        data_packet = Packet(
+            packet_type=PACKET_TYPE_CLIENT_BOUND_LIVE_DATA,
+            subject_id=agent_id,
+            data=data,
+        )
+        self._get_channel_for_agent(agent_id).enqueue_send(data_packet)
+
     def send_status_update(self, agent_id: str, status: str):
+        """Update the status for the given agent"""
         status_packet = Packet(
-            packet_type=PACKET_TYPE_UPDATE_AGENT_STATUS,
-            sender_id=SYSTEM_CHANNEL_ID,
-            receiver_id=agent_id,
+            packet_type=PACKET_TYPE_UPDATE_STATUS,
+            subject_id=agent_id,
             data={
                 "status": status,
                 "state": {
@@ -403,11 +401,10 @@ class ClientIOHandler:
     def send_done_message(self, agent_id: str):
         """Compose and send a done message to the given agent. This allows submission"""
         done_packet = Packet(
-            packet_type=PACKET_TYPE_UPDATE_AGENT_STATUS,
-            sender_id=SYSTEM_CHANNEL_ID,
-            receiver_id=agent_id,
+            packet_type=PACKET_TYPE_UPDATE_STATUS,
+            subject_id=agent_id,
             data={
-                "status": "completed",
+                "status": "awaiting_submit",
                 "state": {
                     "done_text": "You have completed this task. Please submit.",
                     "task_done": True,
@@ -421,9 +418,9 @@ class ClientIOHandler:
         while not message_queue.empty() > 0:
             curr_obs = message_queue.get()
             try:
-                channel = self._get_channel_for_agent(curr_obs.receiver_id)
+                channel = self._get_channel_for_agent(curr_obs.subject_id)
             except Exception:
-                channel = self.channels[curr_obs.receiver_id]
+                channel = self.channels[curr_obs.subject_id]
             channel.enqueue_send(curr_obs)
 
     def shutdown(self) -> None:

--- a/mephisto/operations/datatypes.py
+++ b/mephisto/operations/datatypes.py
@@ -85,3 +85,4 @@ class WorkerFailureReasons:
     )
     TOO_MANY_CONCURRENT = "You are currently working on too many tasks concurrently to accept another, please finish your current work."
     MAX_FOR_TASK = "You have already completed the maximum amount of tasks the requester has set for this task."
+    TASK_MISSING = "You appear to have already completed this task, or have disconnected long enough for your session to clear..."

--- a/mephisto/operations/datatypes.py
+++ b/mephisto/operations/datatypes.py
@@ -76,3 +76,12 @@ class LiveTaskRun:
         self.task_runner.shutdown()
         self.worker_pool.shutdown()
         self.client_io.shutdown()
+
+
+class WorkerFailureReasons:
+    NOT_QUALIFIED = "You are not currently qualified to work on this task..."
+    NO_AVAILABLE_UNITS = (
+        "There is currently no available work, please try again later..."
+    )
+    TOO_MANY_CONCURRENT = "You are currently working on too many tasks concurrently to accept another, please finish your current work."
+    MAX_FOR_TASK = "You have already completed the maximum amount of tasks the requester has set for this task."

--- a/test/core/test_live_runs.py
+++ b/test/core/test_live_runs.py
@@ -247,30 +247,21 @@ class BaseTestLiveRuns:
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker not successfully registered")
-        worker = workers[0]
-
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker potentially re-registered")
-        worker_id = workers[0].db_id
-
-        self.assertEqual(len(task_runner.running_assignments), 0)
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
+        self.assertEqual(len(workers), 1, "Worker not successfully registered")
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent was not created properly")
 
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
+        self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
         agent = agents[0]
         self.assertIsNotNone(agent)
@@ -284,14 +275,10 @@ class BaseTestLiveRuns:
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
 
         self.assertEqual(len(task_runner.running_units), 2, "Tasks were not launched")
@@ -367,28 +354,17 @@ class BaseTestLiveRuns:
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker not successfully registered")
-        worker = workers[0]
-
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker potentially re-registered")
-        worker_id = workers[0].db_id
-
-        self.assertEqual(len(task_runner.running_assignments), 0)
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
+        self.assertEqual(len(workers), 1, "Worker not successfully registered")
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent was not created properly")
 
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
@@ -404,14 +380,10 @@ class BaseTestLiveRuns:
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
 
         self.assertEqual(
@@ -500,20 +472,13 @@ class BaseTestLiveRuns:
 
         # Fail to register an agent who fails onboarding
         mock_worker_name = "BAD_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
+
+        mock_agent_details = "FAKE_ASSIGNMENT"
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_0 = workers[0]
-
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
-
-        mock_agent_details = "FAKE_ASSIGNMENT"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -558,25 +523,17 @@ class BaseTestLiveRuns:
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
+        # TODO(#655) Create a worker on the DB side for use here
+        assert False
         workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker not successfully registered")
         worker_1 = workers[0]
-
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker potentially re-registered")
-        worker_id = workers[0].db_id
-
-        self.assertEqual(len(task_runner.running_assignments), 0)
 
         # Fail to register a blocked agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         qualification_id = blueprint.onboarding_qualification_id
         self.db.grant_qualification(qualification_id, worker_1.db_id, 0)
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -598,7 +555,7 @@ class BaseTestLiveRuns:
 
         # Register an onboarding agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT_3"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -627,7 +584,7 @@ class BaseTestLiveRuns:
         self.assertEqual(len(agents), 1, "Agent not created after onboarding")
 
         # Re-register as if refreshing
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Agent may have been duplicated")
@@ -644,17 +601,15 @@ class BaseTestLiveRuns:
         )
 
         # Register another worker
+        # TODO(#655) create a worker on the DB to use here
         mock_worker_name = "MOCK_WORKER_2"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_2 = workers[0]
+        assert False
         worker_id = worker_2.db_id
 
         # Register an agent that is already qualified
         mock_agent_details = "FAKE_ASSIGNMENT_4"
         self.db.grant_qualification(qualification_id, worker_2.db_id, 1)
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
 
         last_packet = self.architect.server.last_packet
@@ -758,14 +713,7 @@ class BaseTestLiveRuns:
 
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker not successfully registered")
-        worker_1 = workers[0]
-
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
+        # TODO(#655) create a new worker for this
         workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         self.assertEqual(len(workers), 1, "Worker potentially re-registered")
         worker_id = workers[0].db_id
@@ -776,7 +724,7 @@ class BaseTestLiveRuns:
         mock_agent_details = "FAKE_ASSIGNMENT"
         qualification_id = blueprint.onboarding_qualification_id
         self.db.grant_qualification(qualification_id, worker_1.db_id, 0)
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -798,7 +746,7 @@ class BaseTestLiveRuns:
 
         # Register an agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -827,7 +775,7 @@ class BaseTestLiveRuns:
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
 
         # Re-register as if refreshing
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 0, "Failed agent created after onboarding")
@@ -843,8 +791,7 @@ class BaseTestLiveRuns:
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
+        # TODO($655) create this worker on the backend
         workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_2 = workers[0]
         worker_id = worker_2.db_id
@@ -852,7 +799,7 @@ class BaseTestLiveRuns:
         # Register an agent that is already qualified
         mock_agent_details = "FAKE_ASSIGNMENT_2"
         self.db.grant_qualification(qualification_id, worker_2.db_id, 1)
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
 
         last_packet = self.architect.server.last_packet
@@ -874,14 +821,11 @@ class BaseTestLiveRuns:
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_3"
-        self.architect.server.register_mock_worker(mock_worker_name)
+        mock_agent_details = "FAKE_ASSIGNMENT_3"
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
         worker_3 = workers[0]
-        worker_id = worker_3.db_id
-        mock_agent_details = "FAKE_ASSIGNMENT_3"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
-        self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(
             len(agents), 1, "Agent should not be created yet - need onboarding"
@@ -909,7 +853,7 @@ class BaseTestLiveRuns:
         self.assertEqual(len(agents), 2, "Agent not created after onboarding")
 
         # Re-register as if refreshing
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "Duplicate agent created after onboarding")
@@ -1029,34 +973,20 @@ class BaseTestLiveRuns:
         )
 
         # Register workers
-        mock_worker_name = "MOCK_WORKER"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        self.assertEqual(len(workers), 1, "Worker not successfully registered")
-        worker_1 = workers[0]
-        worker_id = workers[0].db_id
-
-        mock_worker_name = "MOCK_WORKER_2"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_2 = workers[0]
-        worker_id_2 = worker_2.db_id
-
-        mock_worker_name = "MOCK_WORKER_3"
-        self.architect.server.register_mock_worker(mock_worker_name)
-        self.await_channel_requests(live_run)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_3 = workers[0]
-        worker_id_3 = worker_3.db_id
-
-        self.assertEqual(len(task_runner.running_units), 0)
+        mock_worker_name_1 = "MOCK_WORKER"
+        mock_worker_name_2 = "MOCK_WORKER_2"
+        mock_worker_name_3 = "MOCK_WORKER_3"
 
         # Register a screening agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT"
-        self.architect.server.register_mock_agent(worker_id, mock_agent_details)
+        self.architect.server.register_mock_agent(
+            mock_worker_name_1, mock_agent_details
+        )
         self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name_1 + "_sandbox")
+        self.assertEqual(len(workers), 1, "Worker not successfully registered")
+        worker_1 = workers[0]
+        worker_id = workers[0].db_id
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "No agent created for screening")
 
@@ -1068,8 +998,13 @@ class BaseTestLiveRuns:
 
         # Register a second screening agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT2"
-        self.architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        self.architect.server.register_mock_agent(
+            mock_worker_name_2, mock_agent_details
+        )
         self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name_2 + "_sandbox")
+        worker_2 = workers[0]
+        worker_id_2 = worker_2.db_id
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "No agent created for screening")
         last_packet = None
@@ -1082,8 +1017,13 @@ class BaseTestLiveRuns:
 
         # Fail to register a third screening agent
         mock_agent_details = "FAKE_ASSIGNMENT3"
-        self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.architect.server.register_mock_agent(
+            mock_worker_name_3, mock_agent_details
+        )
         self.await_channel_requests(live_run)
+        workers = self.db.find_workers(worker_name=mock_worker_name_3 + "_sandbox")
+        worker_3 = workers[0]
+        worker_id_3 = worker_3.db_id
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 2, "Third agent created, when 2 was max")
 
@@ -1092,7 +1032,9 @@ class BaseTestLiveRuns:
 
         # Register third screening agent
         mock_agent_details = "FAKE_ASSIGNMENT3"
-        self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.architect.server.register_mock_agent(
+            mock_worker_name_3, mock_agent_details
+        )
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 3, "Third agent not created")
@@ -1134,7 +1076,9 @@ class BaseTestLiveRuns:
         # Accept a real task, and complete it, from worker 3
         # Register a task agent successfully
         mock_agent_details = "FAKE_ASSIGNMENT4"
-        self.architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        self.architect.server.register_mock_agent(
+            mock_worker_name_3, mock_agent_details
+        )
         self.await_channel_requests(live_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "No agent created for task")

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -164,28 +164,20 @@ class OperatorBaseTest(object):
         self.assertIsInstance(architect, MockArchitect, "Must use mock in testing")
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
-
-        self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
-        architect.server.register_mock_agent(worker_id, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
         self.assert_agent_created(1)
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        architect.server.register_mock_agent(worker_id, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
         self.assert_agent_created(2)
 
         # Give up to 5 seconds for whole mock task to complete
@@ -227,28 +219,22 @@ class OperatorBaseTest(object):
         self.assertIsInstance(architect, MockArchitect, "Must use mock in testing")
         # Register a worker
         mock_worker_name = "MOCK_WORKER"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
 
         self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
-        architect.server.register_mock_agent(worker_id, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
         self.assert_agent_created(1)
 
         # Register another worker
         mock_worker_name = "MOCK_WORKER_2"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id = workers[0].db_id
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        architect.server.register_mock_agent(worker_id, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
         self.assert_agent_created(2)
 
         # Give up to 5 seconds for both tasks to complete
@@ -301,36 +287,34 @@ class OperatorBaseTest(object):
         architect = tracked_run.architect
         self.assertIsInstance(architect, MockArchitect, "Must use mock in testing")
         # Register a worker
-        mock_worker_name = "MOCK_WORKER"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id_1 = workers[0].db_id
+        mock_worker_name_1 = "MOCK_WORKER"
 
         self.assertEqual(len(tracked_run.task_runner.running_assignments), 0)
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT"
-        architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_1, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name_1)
+        workers = self.db.find_workers(worker_name=mock_worker_name_1 + "_sandbox")
+        worker_id_1 = workers[0].db_id
         self.assert_agent_created(1)
 
         # Try to register a second agent, which should fail due to concurrency
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_1, mock_agent_details)
         self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 1, "Second agent was created")
 
         # Register another worker
-        mock_worker_name = "MOCK_WORKER_2"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id_2 = workers[0].db_id
+        mock_worker_name_2 = "MOCK_WORKER_2"
 
         # Register an agent
         mock_agent_details = "FAKE_ASSIGNMENT_2"
-        architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_2, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name_2)
+        workers = self.db.find_workers(worker_name=mock_worker_name_2 + "_sandbox")
+        worker_id_2 = workers[0].db_id
         self.assert_agent_created(2)
 
         # wait for task to pass
@@ -339,10 +323,10 @@ class OperatorBaseTest(object):
 
         # Pass a second task as well
         mock_agent_details = "FAKE_ASSIGNMENT_3"
-        architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_1, mock_agent_details)
         self.assert_agent_created(3)
         mock_agent_details = "FAKE_ASSIGNMENT_4"
-        architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_2, mock_agent_details)
         self.assert_agent_created(4)
 
         # wait for task to pass
@@ -351,33 +335,31 @@ class OperatorBaseTest(object):
 
         # Both workers should have saturated their tasks, and not be granted agents
         mock_agent_details = "FAKE_ASSIGNMENT_5"
-        architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_1, mock_agent_details)
         self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "Additional agent was created")
-        architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_2, mock_agent_details)
         self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(len(agents), 4, "Additional agent was created")
 
         # new workers should be able to work on these just fine though
-        mock_worker_name = "MOCK_WORKER_3"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id_3 = workers[0].db_id
-        mock_worker_name = "MOCK_WORKER_4"
-        architect.server.register_mock_worker(mock_worker_name)
-        self.assert_sandbox_worker_created(mock_worker_name)
-        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
-        worker_id_4 = workers[0].db_id
+        mock_worker_name_3 = "MOCK_WORKER_3"
+        mock_worker_name_4 = "MOCK_WORKER_4"
 
         # Register agents from new workers
         mock_agent_details = "FAKE_ASSIGNMENT_5"
-        architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_3, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
+        worker_id_3 = workers[0].db_id
         self.assert_agent_created(5)
         mock_agent_details = "FAKE_ASSIGNMENT_6"
-        architect.server.register_mock_agent(worker_id_4, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_4, mock_agent_details)
+        self.assert_sandbox_worker_created(mock_worker_name)
+        workers = self.db.find_workers(worker_name=mock_worker_name + "_sandbox")
+        worker_id_4 = workers[0].db_id
         self.assert_agent_created(6)
 
         # wait for task to pass
@@ -425,7 +407,7 @@ class OperatorBaseTest(object):
 
         # Workers one and two still shouldn't be able to make agents
         mock_agent_details = "FAKE_ASSIGNMENT_7"
-        architect.server.register_mock_agent(worker_id_1, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_1, mock_agent_details)
         self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -434,7 +416,7 @@ class OperatorBaseTest(object):
             "Additional agent was created for worker exceeding max units",
         )
         mock_agent_details = "FAKE_ASSIGNMENT_7"
-        architect.server.register_mock_agent(worker_id_2, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_2, mock_agent_details)
         self.await_channel_requests(tracked_run)
         agents = self.db.find_agents()
         self.assertEqual(
@@ -445,10 +427,10 @@ class OperatorBaseTest(object):
 
         # Three and four should though
         mock_agent_details = "FAKE_ASSIGNMENT_7"
-        architect.server.register_mock_agent(worker_id_3, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_3, mock_agent_details)
         self.assert_agent_created(7)
         mock_agent_details = "FAKE_ASSIGNMENT_8"
-        architect.server.register_mock_agent(worker_id_4, mock_agent_details)
+        architect.server.register_mock_agent(mock_worker_name_4, mock_agent_details)
         self.assert_agent_created(8)
 
         # Ensure the task run completed and that all assignments are done


### PR DESCRIPTION
# Overview
Implements the packet types as described in #655, and updates the `ClientIOHandler` and `WorkerPool` to use these new standards. Also updates the `MockArchitect` and dependent tests to follow the new flow.

# Implementation
- Replaces the packet types in the `Packet` class to be the new ones outlined in #655. Condenses `sender_id` and `receiver_id` into `subject_id`, as all packets are now unidirectional.
- Creates a class `WorkerFailureReasons` to contain the possible failure states of a `_register_agent` call.
- Updates `ClientIOHandler` to reflect the new handshake, replacing `_register_agent `, `_register_worker `, and `enqueue_provider_details ` with `_register_agent ` and `enqueue_agent_details `. The latter always transmits a packet of the form `AgentDetails`. Also updates to reflect the new submission types being discrete, replacing `_on_act ` with `_on_live_data` and `_on_submit_unit`.
- Updates `WorkerPool` to use the new `ClientIOHandler` functions. Also creates a `reconnect_agent` function to wrap some of the functionality that used to be hidden away during reconnects. Mostly minor changes otherwise, as the calls now just run in sequence rather than being triggered by more steps of the handshake.
- Changes the `MockArchitect`'s `MockServer` to use the new handshake. Removes `request_init_data`, `register_mock_agent`, `register_mock_worker `, in favor of one `register_mock_agent` call. Also creates a `submit_mock_unit` call for the new submission type. Fixes the `register_mock_agent_after_onboarding` method to send the correct packet type.
- Updates some test files to use the correct callsites now.

# Testing
Testing currently not possible E2E, but `mypy` passes for these files. Will check again following the agent refactor.