### PR TITLE
Updating base `Agent` and `TaskRunner` (plus mocks) to Architect API 1.0

### DIFF
--- a/mephisto/abstractions/_subcomponents/agent_state.py
+++ b/mephisto/abstractions/_subcomponents/agent_state.py
@@ -168,19 +168,18 @@ class AgentState(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def update_data(self, packet: "Packet") -> None:
+    def update_data(self, live_data: Dict[str, Any]) -> None:
         """
-        Put new current Unit data into this AgentState
+        Put new live data into this AgentState. Keep only what is necessary
+        to recreate the task for evaluation and later use.
         """
-        # TODO(#100) maybe refine the signature for this function once use cases
-        # are fully scoped
+        raise NotImplementedError()
 
-        # Some use cases might just be appending new data, some
-        # might instead prefer to maintain a final state.
-
-        # Maybe the correct storage is of a series of actions taken
-        # on this Unit? Static tasks only have 2 turns max, dynamic
-        # ones may have multiple turns or steps.
+    @abstractmethod
+    def update_submit(self, submit_data: Dict[str, Any]) -> None:
+        """
+        Update this AgentState with the final submission data.
+        """
         raise NotImplementedError()
 
     def get_task_start(self) -> Optional[float]:

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -243,9 +243,9 @@ class TaskRunner(ABC):
 
         # Unit run now complete
         if agent.get_status() not in AgentState.complete():
-            if not agent.did_submit.is_set():
+            if not agent.await_submit(timeout=None):
                 # Wait for a submit to occur
-                agent.did_submit.wait(timeout=self.args.task.submission_timout)
+                agent.await_submit(timeout=self.args.task.submission_timout)
             agent.update_status(AgentState.STATUS_COMPLETED)
             agent.mark_done()
 
@@ -315,9 +315,9 @@ class TaskRunner(ABC):
         # Wait for agents to be complete
         for agent in agents:
             if agent.get_status() not in AgentState.complete():
-                if not agent.did_submit.is_set():
+                if not agent.await_submit(timeout=None):
                     # Wait for a submit to occur
-                    agent.did_submit.wait(timeout=self.args.task.submission_timout)
+                    agent.await_submit(timeout=self.args.task.submission_timout)
                 agent.update_status(AgentState.STATUS_COMPLETED)
                 agent.mark_done()
 

--- a/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
@@ -88,28 +88,29 @@ class StaticAgentState(AgentState):
             json.dump(self.state, data_file)
         logger.info(f"SAVED_DATA_TO_DISC at {out_filename}")
 
-    def update_data(self, packet: "Packet") -> None:
+    def update_data(self, live_data: Dict[str, Any]) -> None:
         """
         Process the incoming data packet, and handle
         updating the state
         """
-        assert (
-            packet.data.get("MEPHISTO_is_submit") is True
-            or packet.data.get("onboarding_data") is not None
-        ), "Static tasks should only have final act"
+        raise Exception(
+            "Static tasks should only have final act, but updated live data"
+        )
 
+    def update_submit(self, submission_data: Dict[str, Any]) -> None:
+        """Move the submitted output to the local dict"""
         outputs: Dict[str, Any]
 
-        if packet.data.get("onboarding_data") is not None:
-            outputs = packet.data["onboarding_data"]
+        if submission_data.get("onboarding_data") is not None:
+            outputs = submission_data["onboarding_data"]
         else:
-            outputs = packet.data["task_data"]
+            outputs = submission_data["task_data"]
         times_dict = self.state["times"]
         assert isinstance(times_dict, dict)
         times_dict["task_end"] = time.time()
-        if packet.data.get("files") != None:
-            logger.info(f"Got files: {str(packet.data['files'])[:500]}")
-            outputs["files"] = [f["filename"] for f in packet.data["files"]]
+        if submission_data.get("files") != None:
+            logger.info(f"Got files: {str(submission_data['files'])[:500]}")
+            outputs["files"] = [f["filename"] for f in submission_data["files"]]
         self.state["outputs"] = outputs
         self.save_data()
 
@@ -117,10 +118,14 @@ class StaticAgentState(AgentState):
         """
         Extract out and return the start time recorded for this task.
         """
-        return self.state["times"]["task_start"]
+        stored_times = self.state["times"]
+        assert stored_times is not None
+        return stored_times["task_start"]
 
     def get_task_end(self) -> Optional[float]:
         """
         Extract out and return the end time recorded for this task.
         """
-        return self.state["times"]["task_end"]
+        stored_times = self.state["times"]
+        assert stored_times is not None
+        return stored_times["task_end"]

--- a/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
@@ -54,10 +54,10 @@ class StaticTaskRunner(TaskRunner):
 
     def run_onboarding(self, agent: "OnboardingAgent"):
         """
-        Static onboarding flows eaxactly like a regular task, waiting for
+        Static onboarding flows exactly like a regular task, waiting for
         the submit to come through
         """
-        agent_act = agent.act(timeout=self.assignment_duration_in_seconds)
+        agent.did_submit.wait(self.assignment_duration_in_seconds)
 
     def cleanup_onboarding(self, agent: "OnboardingAgent"):
         """Nothing to clean up in a static onboarding"""
@@ -68,10 +68,7 @@ class StaticTaskRunner(TaskRunner):
         Static runners will get the task data, send it to the user, then
         wait for the agent to act (the data to be completed)
         """
-        # Frontend implicitly asks for the initialization data, so we just need
-        # to wait for a response
-        agent_act = agent.act(timeout=self.assignment_duration_in_seconds)
-        agent.did_submit.set()
+        agent.did_submit.wait(self.assignment_duration_in_seconds)
 
     def cleanup_unit(self, unit: "Unit") -> None:
         """There is currently no cleanup associated with killing an incomplete task"""

--- a/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_task_runner.py
@@ -57,7 +57,7 @@ class StaticTaskRunner(TaskRunner):
         Static onboarding flows exactly like a regular task, waiting for
         the submit to come through
         """
-        agent.did_submit.wait(self.assignment_duration_in_seconds)
+        agent.await_submit(self.assignment_duration_in_seconds)
 
     def cleanup_onboarding(self, agent: "OnboardingAgent"):
         """Nothing to clean up in a static onboarding"""
@@ -68,7 +68,7 @@ class StaticTaskRunner(TaskRunner):
         Static runners will get the task data, send it to the user, then
         wait for the agent to act (the data to be completed)
         """
-        agent.did_submit.wait(self.assignment_duration_in_seconds)
+        agent.await_submit(self.assignment_duration_in_seconds)
 
     def cleanup_unit(self, unit: "Unit") -> None:
         """There is currently no cleanup associated with killing an incomplete task"""

--- a/mephisto/abstractions/blueprints/mock/mock_agent_state.py
+++ b/mephisto/abstractions/blueprints/mock/mock_agent_state.py
@@ -55,6 +55,10 @@ class MockAgentState(AgentState):
         """Mock agents don't save data (yet)"""
         pass
 
-    def update_data(self, packet: "Packet") -> None:
+    def update_data(self, live_data: Dict[str, Any]) -> None:
         """Put new data into this mock state"""
-        self.state = packet.data
+        self.state = live_data
+
+    def update_submit(self, submitted_data: Dict[str, Any]) -> None:
+        """Move the submitted data into the live state"""
+        self.state = submitted_data

--- a/mephisto/abstractions/blueprints/mock/mock_task_runner.py
+++ b/mephisto/abstractions/blueprints/mock/mock_task_runner.py
@@ -58,7 +58,6 @@ class MockTaskRunner(TaskRunner):
         """
         packet = onboarding_agent.act(timeout=self.timeout)
         onboarding_agent.did_submit.set()
-        onboarding_agent.mark_done()
 
     def run_unit(self, unit: "Unit", agent: "Agent"):
         """

--- a/mephisto/abstractions/blueprints/mock/mock_task_runner.py
+++ b/mephisto/abstractions/blueprints/mock/mock_task_runner.py
@@ -55,7 +55,7 @@ class MockTaskRunner(TaskRunner):
         Mock runners simply wait for an act to come in with whether
         or not onboarding is complete
         """
-        onboarding_agent.did_submit.wait(self.timeout)
+        onboarding_agent.await_submit(self.timeout)
 
     def run_unit(self, unit: "Unit", agent: "Agent"):
         """
@@ -72,7 +72,7 @@ class MockTaskRunner(TaskRunner):
         packet = agent.get_live_data(timeout=self.timeout)
         if packet is not None:
             agent.observe(packet)
-        agent.did_submit.wait(self.timeout)
+        agent.await_submit(self.timeout)
         del self.tracked_tasks[unit.db_id]
 
     def run_assignment(self, assignment: "Assignment", agents: List["Agent"]):
@@ -95,7 +95,7 @@ class MockTaskRunner(TaskRunner):
             if packet is not None:
                 agent.observe(packet)
         for agent in agents:
-            agent.did_submit.wait(self.timeout)
+            agent.await_submit(self.timeout)
         del self.tracked_tasks[assignment.db_id]
 
     def cleanup_assignment(self, assignment: "Assignment"):

--- a/mephisto/abstractions/blueprints/mock/mock_task_runner.py
+++ b/mephisto/abstractions/blueprints/mock/mock_task_runner.py
@@ -31,7 +31,6 @@ class MockTaskRunner(TaskRunner):
         self.timeout = args.blueprint.timeout_time
         self.tracked_tasks: Dict[str, Union["Assignment", "Unit"]] = {}
         self.is_concurrent = args.blueprint.get("is_concurrent", True)
-        print(f"Blueprint is concurrent: {self.is_concurrent}, {args}")
 
     @staticmethod
     def get_mock_assignment_data() -> InitializationData:
@@ -56,8 +55,7 @@ class MockTaskRunner(TaskRunner):
         Mock runners simply wait for an act to come in with whether
         or not onboarding is complete
         """
-        packet = onboarding_agent.act(timeout=self.timeout)
-        onboarding_agent.did_submit.set()
+        onboarding_agent.did_submit.wait(self.timeout)
 
     def run_unit(self, unit: "Unit", agent: "Agent"):
         """
@@ -71,11 +69,10 @@ class MockTaskRunner(TaskRunner):
         assert (
             assigned_agent.db_id == agent.db_id
         ), "Task was not given to assigned agent"
-        packet = agent.act(timeout=self.timeout)
+        packet = agent.get_live_data(timeout=self.timeout)
         if packet is not None:
             agent.observe(packet)
-        agent.did_submit.set()
-        agent.mark_done()
+        agent.did_submit.wait(self.timeout)
         del self.tracked_tasks[unit.db_id]
 
     def run_assignment(self, assignment: "Assignment", agents: List["Agent"]):
@@ -86,16 +83,19 @@ class MockTaskRunner(TaskRunner):
         self.tracked_tasks[assignment.db_id] = assignment
         agent_dict = {a.db_id: a for a in agents}
         time.sleep(0.3)
+        agents = []
         for unit in assignment.get_units():
             assigned_agent = unit.get_assigned_agent()
             assert assigned_agent is not None, "Task was not fully assigned"
             agent = agent_dict.get(assigned_agent.db_id)
             assert agent is not None, "Task was not launched with assigned agents"
-            packet = agent.act(timeout=self.timeout)
+            agents.append(agent)
+        for agent in agents:
+            packet = agent.get_live_data(timeout=self.timeout)
             if packet is not None:
                 agent.observe(packet)
-            agent.did_submit.set()
-            agent.mark_done()
+        for agent in agents:
+            agent.did_submit.wait(self.timeout)
         del self.tracked_tasks[assignment.db_id]
 
     def cleanup_assignment(self, assignment: "Assignment"):

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -187,10 +187,8 @@ class ParlAIChatTaskRunner(TaskRunner):
         )
 
         # Mark the agent as done, then wait for the incoming submit action
+        # TODO(#655) just wait on this condition!
         while not agent.did_submit.is_set():
-            done_act = agent.act()
-            if done_act is not None:
-                break
             time.sleep(0.3)
 
     def cleanup_onboarding(self, agent: "OnboardingAgent") -> None:

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -16,12 +16,6 @@ except ImportError:
 
     pass  # ParlAI is not installed. TODO remove when we move this blueprint to ParlAI
 
-from mephisto.data_model.packet import (
-    Packet,
-    PACKET_TYPE_AGENT_ACTION,
-    PACKET_TYPE_UPDATE_AGENT_STATUS,
-)
-
 from importlib import import_module
 
 import os
@@ -76,13 +70,9 @@ class MephistoAgentWrapper(ParlAIAgent):
         frontend users, so when these are updated by a
         world we forward that to the frontend
         """
-        packaged_act = Packet(
-            packet_type=PACKET_TYPE_UPDATE_AGENT_STATUS,
-            sender_id="mephisto",
-            receiver_id=self.__mephisto_agent_id,
-            data={"state": {"agent_display_name": new_agent_id}},
+        self.mephisto_agent.observe(
+            {"state": {"agent_display_name": new_agent_id}},
         )
-        self.mephisto_agent.observe(packaged_act)
         self.__agent_id = new_agent_id
 
     def act(self, timeout=None):
@@ -90,9 +80,9 @@ class MephistoAgentWrapper(ParlAIAgent):
         ParlAI Agents send an act dict, we must convert this
         """
         if timeout is None:
-            gotten_act = self.mephisto_agent.act()
+            gotten_act = self.mephisto_agent.get_live_data()
         else:
-            gotten_act = self.mephisto_agent.act(timeout=timeout)
+            gotten_act = self.mephisto_agent.get_live_data(timeout=timeout)
         if gotten_act is None:
             return None
         parsed_act = gotten_act.data
@@ -100,18 +90,10 @@ class MephistoAgentWrapper(ParlAIAgent):
         return Message(parsed_act)
 
     def observe(self, act):
-        """
-        ParlAI Agents observe a dict, we must convert these to  packets?
-        """
+        """We can simply add a message id if not already provided to these"""
         if act.get("message_id") is None:
             act["message_id"] = str(uuid4())
-        packaged_act = Packet(
-            packet_type=PACKET_TYPE_AGENT_ACTION,
-            sender_id="mephisto",
-            receiver_id=self.__mephisto_agent_id,
-            data=act,
-        )
-        self.mephisto_agent.observe(packaged_act)
+        self.mephisto_agent.observe(act)
 
 
 class ParlAIChatTaskRunner(TaskRunner):
@@ -197,21 +179,15 @@ class ParlAIChatTaskRunner(TaskRunner):
             world.parley()
         world.shutdown()
         agent.state.update_data(
-            Packet(
-                packet_type=PACKET_TYPE_AGENT_ACTION,
-                sender_id="mephisto",
-                receiver_id=agent.db_id,
-                data={
-                    "id": "SUBMIT_WORLD_DATA",
-                    "WORLD_DATA": world.prep_save_data([parlai_agent]),
-                    "text": "",
-                },
-            )
+            {
+                "id": "SUBMIT_WORLD_DATA",
+                "WORLD_DATA": world.prep_save_data([parlai_agent]),
+                "text": "",
+            }
         )
 
         # Mark the agent as done, then wait for the incoming submit action
-        agent.mark_done()
-        while not agent.has_action.is_set():
+        while not agent.did_submit.is_set():
             done_act = agent.act()
             if done_act is not None:
                 break
@@ -255,16 +231,11 @@ class ParlAIChatTaskRunner(TaskRunner):
         world.shutdown()
         for idx in range(len(parlai_agents)):
             agents[idx].state.update_data(
-                Packet(
-                    packet_type=PACKET_TYPE_AGENT_ACTION,
-                    sender_id="mephisto",
-                    receiver_id=agents[idx].db_id,
-                    data={
-                        "id": "SUBMIT_WORLD_DATA",
-                        "WORLD_DATA": world.prep_save_data([parlai_agents[idx]]),
-                        "text": "",
-                    },
-                )
+                {
+                    "id": "SUBMIT_WORLD_DATA",
+                    "WORLD_DATA": world.prep_save_data([parlai_agents[idx]]),
+                    "text": "",
+                }
             )
 
     def cleanup_assignment(self, assignment: "Assignment") -> None:
@@ -297,16 +268,11 @@ class ParlAIChatTaskRunner(TaskRunner):
         world.shutdown()
         if hasattr(world, "prep_save_data"):
             agent.observe(
-                Packet(
-                    packet_type=PACKET_TYPE_AGENT_ACTION,
-                    sender_id="mephisto",
-                    receiver_id=agent.db_id,
-                    data={
-                        "id": "SUBMIT_WORLD_DATA",
-                        "WORLD_DATA": world.prep_save_data(parlai_agents),
-                        "text": "",
-                    },
-                )
+                {
+                    "id": "SUBMIT_WORLD_DATA",
+                    "WORLD_DATA": world.prep_save_data(parlai_agents),
+                    "text": "",
+                }
             )
 
     def cleanup_unit(self, unit: "Unit") -> None:

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_task_runner.py
@@ -188,7 +188,7 @@ class ParlAIChatTaskRunner(TaskRunner):
 
         # Mark the agent as done, then wait for the incoming submit action
         # TODO(#655) just wait on this condition!
-        while not agent.did_submit.is_set():
+        while not agent.await_submit(timeout=None):
             time.sleep(0.3)
 
     def cleanup_onboarding(self, agent: "OnboardingAgent") -> None:

--- a/mephisto/abstractions/providers/mock/mock_agent.py
+++ b/mephisto/abstractions/providers/mock/mock_agent.py
@@ -41,12 +41,12 @@ class MockAgent(Agent):
                 "acts": [],
             }
 
-    def observe(self, packet: "Packet") -> None:
+    def observe(self, live_data: Dict[str, Any]) -> None:
         """Put observations into this mock agent's observation list"""
-        self.datastore.agent_data[self.db_id]["observed"].append(packet)
-        super().observe(packet)
+        self.datastore.agent_data[self.db_id]["observed"].append(live_data)
+        super().observe(live_data)
 
-    def act(self, timeout=None) -> Optional["Packet"]:
+    def get_live_data(self, timeout=None) -> Optional[Dict[str, Any]]:
         """
         Either take an act from this mock agent's act queue (for use
         by tests and other mock purposes) or request a regular act

--- a/mephisto/abstractions/providers/mock/mock_agent.py
+++ b/mephisto/abstractions/providers/mock/mock_agent.py
@@ -55,7 +55,7 @@ class MockAgent(Agent):
         if len(self.datastore.agent_data[self.db_id]["pending_acts"]) > 0:
             act = self.datastore.agent_data[self.db_id]["pending_acts"].pop(0)
         else:
-            act = super().act(timeout=timeout)
+            act = super().get_live_data(timeout=timeout)
 
         if act is not None:
             self.datastore.agent_data[self.db_id]["acts"].append(act)
@@ -75,16 +75,9 @@ class MockAgent(Agent):
         """
         self.update_status(AgentState.STATUS_REJECTED)
 
-    def mark_done(self) -> None:
-        """
-        Take any required step with the crowd_provider to ensure that
-        the worker can submit their work and be marked as complete via
-        a call to get_status
-        """
-        if self.get_status() not in AgentState.complete():
-            self.db.update_agent(
-                agent_id=self.db_id, status=AgentState.STATUS_COMPLETED
-            )
+    def mark_done(self):
+        """No need to tell mock crowd provider about doneness"""
+        pass
 
     def mark_disconnected(self) -> None:
         """Mark this mock agent as having disconnected"""

--- a/mephisto/abstractions/providers/mturk/mturk_agent.py
+++ b/mephisto/abstractions/providers/mturk/mturk_agent.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from mephisto.data_model.agent import Agent
-from mephisto.data_model.packet import Packet
 from mephisto.abstractions.blueprint import AgentState
 from mephisto.abstractions.providers.mturk.provider_type import PROVIDER_TYPE
 from mephisto.abstractions.providers.mturk.mturk_utils import (
@@ -14,7 +13,6 @@ from mephisto.abstractions.providers.mturk.mturk_utils import (
     get_assignment,
     get_assignments_for_hit,
 )
-from mephisto.data_model.packet import Packet, PACKET_TYPE_AGENT_ACTION
 
 import xmltodict  # type: ignore
 import json
@@ -107,17 +105,7 @@ class MTurkAgent(Agent):
             entry["QuestionIdentifier"]: entry["FreeText"] for entry in paired_data
         }
         parsed_data["MEPHISTO_MTURK_RECONCILED"] = True
-        packet = Packet(
-            packet_type=PACKET_TYPE_AGENT_ACTION,
-            sender_id=self.db_id,
-            receiver_id="mephisto",
-            data={
-                "task_data": parsed_data,
-                "MEPHISTO_is_submit": True,
-                "files": [],
-            },
-        )
-        self.pending_actions.put(packet)
+        self.handle_submit(parsed_data)
 
     # Required functions for Agent Interface
 

--- a/mephisto/abstractions/test/blueprint_tester.py
+++ b/mephisto/abstractions/test/blueprint_tester.py
@@ -18,6 +18,7 @@ from mephisto.abstractions.blueprint import (
     TaskRunner,
     TaskBuilder,
 )
+from mephisto.abstractions._subcomponents.task_runner import RunningAssignment
 from mephisto.abstractions.databases.local_database import LocalMephistoDB
 from mephisto.data_model.assignment import Assignment
 from mephisto.data_model.task_run import TaskRun
@@ -213,10 +214,10 @@ class BlueprintTests(unittest.TestCase):
             cast("Agent", u.get_assigned_agent()) for u in assignment.get_units()
         ]
 
-        task_runner.running_assignments[
-            assignment.db_id
-        ] = None  # To ensure cleanup works
-        task_runner._launch_and_run_assignment(assignment, agents, lambda: None)
+        task_runner.running_assignments[assignment.db_id] = RunningAssignment(
+            None, None, None
+        )  # type: ignore
+        task_runner._launch_and_run_assignment(assignment, agents)
         self.assertTrue(self.assignment_completed_successfully(assignment))
 
     def test_can_exit_gracefully(self) -> None:
@@ -228,9 +229,7 @@ class BlueprintTests(unittest.TestCase):
         assert isinstance(fail_agent, MockAgent), "Agent must be mock agent for testing"
         fail_agent.mark_disconnected()
         try:
-            task_runner._launch_and_run_assignment(
-                assignment, [fail_agent], lambda: None
-            )
+            task_runner._launch_and_run_assignment(assignment, [fail_agent])
         except Exception as e:
             task_runner.cleanup_assignment(assignment)
 

--- a/mephisto/abstractions/test/blueprint_tester.py
+++ b/mephisto/abstractions/test/blueprint_tester.py
@@ -119,6 +119,10 @@ class BlueprintTests(unittest.TestCase):
         shared_state = self.BlueprintClass.SharedStateClass()
         return self.TaskBuilderClass(self.task_run, config)
 
+    def prep_mock_agents_to_complete(self, agents: List["MockAgent"]) -> None:
+        """Handle initializing mock agents to be able to pass their task"""
+        pass
+
     def test_options(self) -> None:
         """Test the default options, and try to break the initialization"""
         # TODO(#94?) implement with options implementations
@@ -210,10 +214,13 @@ class BlueprintTests(unittest.TestCase):
         """Ensure that a task can be run to completion in the basic case"""
         task_runner = self._get_init_task_runner()
         assignment = self.get_test_assignment()
-        agents: List["Agent"] = [
-            cast("Agent", u.get_assigned_agent()) for u in assignment.get_units()
+        mock_agents: List["MockAgent"] = [
+            cast("MockAgent", u.get_assigned_agent()) for u in assignment.get_units()
         ]
 
+        self.prep_mock_agents_to_complete(mock_agents)
+
+        agents: List["Agent"] = [cast("Agent", a) for a in mock_agents]
         task_runner.running_assignments[assignment.db_id] = RunningAssignment(
             None, None, None
         )  # type: ignore

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -71,10 +71,9 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         self.unit_id = row["unit_id"]
         self.task_type = row["task_type"]
         self.provider_type = row["provider_type"]
-        self.pending_observations: "Queue[Packet]" = Queue()
-        self.pending_actions: "Queue[Packet]" = Queue()
-        self.has_action = threading.Event()
-        self.has_action.clear()
+        self.pending_actions: "Queue[Dict[str, Any]]" = Queue()
+        self.has_live_data = threading.Event()
+        self.has_live_data.clear()
         self.assignment_id = row["assignment_id"]
         self.task_run_id = row["task_run_id"]
         self.task_id = row["task_id"]
@@ -235,7 +234,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             AgentState.STATUS_TIMEOUT,
         ]:
             # Disconnect statuses should free any pending acts
-            self.has_action.set()
+            self.has_live_data.set()
             self.did_submit.set()
             if old_status == AgentState.STATUS_WAITING:
                 # Waiting agents' unit can be reassigned, as no work
@@ -284,34 +283,35 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         agent._unit = unit
         return agent
 
-    def observe(self, packet: "Packet") -> None:
+    def observe(self, live_data: "Dict[str, Any]") -> None:
         """
         Pass the observed information to the AgentState, then
         queue the information to be pushed to the user
         """
-        if packet.data.get("message_id") is None:
-            packet.data["message_id"] = str(uuid4())
-        sending_packet = packet.copy()
-        sending_packet.receiver_id = self.db_id
-        self.state.update_data(sending_packet)
-        self.pending_observations.put(sending_packet)
+        if live_data.get("message_id") is None:
+            live_data["message_id"] = str(uuid4())
+        self.state.update_data(live_data)
+
         if self._associated_live_run is not None:
             live_run = self.get_live_run()
-            live_run.client_io.process_outgoing_queue(self.pending_observations)
+            live_run.client_io.send_live_data(self.get_agent_id(), live_data)
 
-    def act(self, timeout: Optional[int] = None) -> Optional["Packet"]:
+    def get_live_data(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
         """
         Request information from the Agent's frontend. If non-blocking,
         (timeout is None) should return None if no actions are ready
         to be returned.
+
+        Information requests are handled with an outgoing `live_data` packet
+        with `live_data_requested` to true.
         """
         if self.pending_actions.empty():
             if self._associated_live_run is not None:
                 live_run = self.get_live_run()
-                live_run.client_io.request_action(self.get_agent_id())
+                live_run.client_io.request_live_data(self.get_agent_id())
             if timeout is None or timeout == 0:
                 return None
-            self.has_action.wait(timeout)
+            self.has_live_data.wait(timeout)
 
         if self.pending_actions.empty():
             if self.is_shutdown:
@@ -326,17 +326,30 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             raise AgentTimeoutError(timeout, self.db_id)
         assert (
             not self.pending_actions.empty()
-        ), "has_action released without an action!"
+        ), "has_live_data released without an action!"
 
         act = self.pending_actions.get()
 
-        if "MEPHISTO_is_submit" in act.data and act.data["MEPHISTO_is_submit"]:
-            self.did_submit.set()
-
         if self.pending_actions.empty():
-            self.has_action.clear()
+            self.has_live_data.clear()
         self.state.update_data(act)
         return act
+
+    def act(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """
+        Request information from the Agent's frontend. If non-blocking,
+        (timeout is None) should return None if no actions are ready
+        to be returned.
+        """
+        warn_once(
+            "Agent.act is being deprecated in favor of Agent.get_live_data. Please update your callsites!"
+        )
+        return self.get_live_data(timeout)
+
+    def handle_submit(self, submit_data: Dict[str, Any]) -> None:
+        """Handle final submission for an onboarding agent, with the given data"""
+        self.did_submit.set()
+        self.state.update_submit(submit_data)
 
     def get_status(self) -> str:
         """Get the status of this agent in their work on their unit"""
@@ -348,7 +361,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
                     AgentState.STATUS_DISCONNECT,
                 ]:
                     # Disconnect statuses should free any pending acts
-                    self.has_action.set()
+                    self.has_live_data.set()
                 if self._associated_live_run is not None:
                     live_run = self.get_live_run()
                     live_run.loop_wrap.execute_coro(
@@ -363,7 +376,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         from any acts called on it, ensuring tasks using this agent can be cleaned up.
         """
         logger.debug(f"{self} is shutting down")
-        self.has_action.set()
+        self.has_live_data.set()
         self.is_shutdown = True
 
     def __repr__(self) -> str:
@@ -450,10 +463,9 @@ class OnboardingAgent(
         self.db_status = row["status"]
         self.worker_id = row["worker_id"]
         self.task_type = row["task_type"]
-        self.pending_observations: "Queue[Packet]" = Queue()
-        self.pending_actions: "Queue[Packet]" = Queue()
-        self.has_action = threading.Event()
-        self.has_action.clear()
+        self.pending_actions: "Queue[Dict[str, Any]]" = Queue()
+        self.has_live_data = threading.Event()
+        self.has_live_data.clear()
         self.task_run_id = row["task_run_id"]
         self.task_id = row["task_id"]
         self.did_submit = threading.Event()
@@ -558,20 +570,23 @@ class OnboardingAgent(
                 )
         if new_status in [AgentState.STATUS_RETURNED, AgentState.STATUS_DISCONNECT]:
             # Disconnect statuses should free any pending acts
-            self.has_action.set()
+            self.has_live_data.set()
             self.did_submit.set()
 
-    def observe(self, packet: "Packet") -> None:
+    def observe(self, live_data: "Dict[str, Any]") -> None:
         """
         Pass the observed information to the AgentState, then
         queue the information to be pushed to the user
         """
-        sending_packet = packet.copy()
-        sending_packet.receiver_id = self.get_agent_id()
-        self.state.update_data(sending_packet)
-        self.pending_observations.put(sending_packet)
+        if live_data.get("message_id") is None:
+            live_data["message_id"] = str(uuid4())
+        self.state.update_data(live_data)
 
-    def act(self, timeout: Optional[int] = None) -> Optional["Packet"]:
+        if self._associated_live_run is not None:
+            live_run = self.get_live_run()
+            live_run.client_io.send_live_data(self.get_agent_id(), live_data)
+
+    def get_live_data(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
         """
         Request information from the Agent's frontend. If non-blocking,
         (timeout is None) should return None if no actions are ready
@@ -580,10 +595,10 @@ class OnboardingAgent(
         if self.pending_actions.empty():
             if self._associated_live_run is not None:
                 live_run = self.get_live_run()
-                live_run.client_io.request_action(self.get_agent_id())
+                live_run.client_io.request_live_data(self.get_agent_id())
             if timeout is None or timeout == 0:
                 return None
-            self.has_action.wait(timeout)
+            self.has_live_data.wait(timeout)
 
         if self.pending_actions.empty():
             # various disconnect cases
@@ -598,17 +613,30 @@ class OnboardingAgent(
             raise AgentTimeoutError(timeout, self.db_id)
         assert (
             not self.pending_actions.empty()
-        ), "has_action released without an action!"
+        ), "has_live_data released without an action!"
 
         act = self.pending_actions.get()
 
-        if "MEPHISTO_is_submit" in act.data and act.data["MEPHISTO_is_submit"]:
-            self.did_submit.set()
-
         if self.pending_actions.empty():
-            self.has_action.clear()
+            self.has_live_data.clear()
         self.state.update_data(act)
         return act
+
+    def act(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """
+        Request information from the Agent's frontend. If non-blocking,
+        (timeout is None) should return None if no actions are ready
+        to be returned.
+        """
+        warn_once(
+            "Agent.act is being deprecated in favor of Agent.get_live_data. Please update your callsites!"
+        )
+        return self.get_live_data(timeout)
+
+    def handle_submit(self, submit_data: Dict[str, Any]) -> None:
+        """Handle final submission for an onboarding agent, with the given data"""
+        self.did_submit.set()
+        self.state.update_submit(submit_data)
 
     def get_status(self) -> str:
         """Get the status of this agent in their work on their unit"""
@@ -620,7 +648,7 @@ class OnboardingAgent(
                     AgentState.STATUS_DISCONNECT,
                 ]:
                     # Disconnect statuses should free any pending acts
-                    self.has_action.set()
+                    self.has_live_data.set()
                 if row["status"] not in [
                     AgentState.STATUS_APPROVED,
                     AgentState.STATUS_REJECTED,
@@ -633,23 +661,13 @@ class OnboardingAgent(
             self.db_status = row["status"]
         return self.db_status
 
-    def mark_done(self) -> None:
-        """Mark this agent as done by setting the status to a terminal onboarding state"""
-        # TODO(#651) the logic for when onboarding gets marked as waiting or approved/rejected
-        # should likely be cleaned up to remove these conditionals.
-        if self.get_status() not in [
-            AgentState.STATUS_APPROVED,
-            AgentState.STATUS_REJECTED,
-        ]:
-            self.update_status(AgentState.STATUS_WAITING)
-
     def shutdown(self) -> None:
         """
         Force the given agent to end any polling threads and throw an AgentShutdownError
         from any acts called on it, ensuring tasks using this agent can be cleaned up.
         """
         logger.debug(f"{self} is shutting down")
-        self.has_action.set()
+        self.has_live_data.set()
         self.is_shutdown = True
 
     @staticmethod

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -346,6 +346,12 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         )
         return self.get_live_data(timeout)
 
+    def await_submit(self, timeout: Optional[int] = None) -> bool:
+        """Blocking wait for this agent to submit their task"""
+        if timeout is not None:
+            self.did_submit.wait(timeout=timeout)
+        return self.did_submit.is_set()
+
     def handle_submit(self, submit_data: Dict[str, Any]) -> None:
         """Handle final submission for an onboarding agent, with the given data"""
         self.did_submit.set()
@@ -632,6 +638,12 @@ class OnboardingAgent(
             "Agent.act is being deprecated in favor of Agent.get_live_data. Please update your callsites!"
         )
         return self.get_live_data(timeout)
+
+    def await_submit(self, timeout: Optional[int] = None) -> bool:
+        """Blocking wait for this agent to submit their task"""
+        if timeout is not None:
+            self.did_submit.wait(timeout=timeout)
+        return self.did_submit.is_set()
 
     def handle_submit(self, submit_data: Dict[str, Any]) -> None:
         """Handle final submission for an onboarding agent, with the given data"""

--- a/mephisto/operations/README.md
+++ b/mephisto/operations/README.md
@@ -1,6 +1,8 @@
 # Mephisto Operations
 The contents of the operations folder comprise controllers for launching and monitoring tasks, as well as other classes that either operate on the data model or support the mid level of Mephisto's design. Each has a high level responsibility, detailed below. Within these classes there's something of a heirarchy depending on the amount of underlying infrastructure that a class is built upon. 
 
+**NOTE** This README is somewhat out of date, and needs updating for the Mephisto 1.0 release
+
 ### High-level controller components
 This level of components is reserved for modules that operate on the highest level of the Mephisto heirarchy. These should be either directly usable, or easy to bundle into scripts for the client/api.
 

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -211,16 +211,13 @@ class ClientIOHandler:
 
         # If the packet is_submit, and has files, we need to
         # process downloading those files first
-        if packet.data.get("MEPHISTO_is_submit") is True:
-            data_files = packet.data.get("files")
-            if data_files is not None:
-                save_dir = agent.get_data_dir()
-                architect = live_run.architect
-                for f_obj in data_files:
-                    # TODO(#649) this is incredibly blocking!
-                    architect.download_file(f_obj["filename"], save_dir)
-        else:
-            raise Exception(f"Got submit call on a non-submit packet: {packet}")
+        data_files = packet.data.get("files")
+        if data_files is not None:
+            save_dir = agent.get_data_dir()
+            architect = live_run.architect
+            for f_obj in data_files:
+                # TODO(#649) this is incredibly blocking!
+                architect.download_file(f_obj["filename"], save_dir)
 
         agent.handle_submit(packet.data)
 

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -200,8 +200,8 @@ class ClientIOHandler:
         agent = live_run.worker_pool.get_agent_for_id(packet.subject_id)
         assert agent is not None, "Could not find given agent!"
 
-        agent.pending_actions.put(packet)
-        agent.has_action.set()
+        agent.pending_actions.put(packet.data)
+        agent.has_live_data.set()
 
     def _on_submit_unit(self, packet: Packet, _channel_id: str):
         """Handle an action as sent from an agent, enqueuing to the agent"""
@@ -222,9 +222,7 @@ class ClientIOHandler:
         else:
             raise Exception(f"Got submit call on a non-submit packet: {packet}")
 
-        # TODO(#655) push to an agent _submit_ call rather than being a regular message
-        agent.pending_actions.put(packet)
-        agent.has_action.set()
+        agent.handle_submit(packet.data)
 
     def _on_submit_onboarding(self, packet: Packet, channel_id: str) -> None:
         """Handle the submission of onboarding data"""
@@ -240,6 +238,7 @@ class ClientIOHandler:
         assert agent is not None, f"Could not find given agent by id {onboarding_id}"
         request_id = packet.data["request_id"]
         self.request_id_to_channel_id[request_id] = channel_id
+        agent.update_status(AgentState.STATUS_WAITING)
 
         logger.debug(f"{agent} has submitted onboarding: {packet}")
         # Update the request id for the original packet (which has the required
@@ -248,10 +247,7 @@ class ClientIOHandler:
         live_run.worker_pool.onboarding_infos[onboarding_id].request_id = request_id
 
         del packet.data["request_id"]
-        # TODO(#655) Update this to _submit_ the given packet, rather than putting it into
-        # pending actions
-        agent.pending_actions.put(packet)
-        agent.has_action.set()
+        agent.handle_submit(packet.data)
 
     def _register_agent(self, packet: Packet, channel_id: str) -> None:
         """Read and forward a worker registration packet"""
@@ -318,13 +314,13 @@ class ClientIOHandler:
         # self.message_queue.put(agent_data_packet)
         self.process_outgoing_queue(self.message_queue)
 
-        # TODO(#655) Move raw message (live message) processing into mephisto-task
-        if isinstance(unit_data, dict) and unit_data.get("raw_messages") is not None:
-            # TODO(#651) clarify how raw messages are sent
-            for message in unit_data["raw_messages"]:
-                packet = Packet.from_dict(message)
-                packet.receiver_id = agent_id
-                agent.pending_observations.put(packet)
+        # # TODO(#655) Move raw message (live message) processing into mephisto-task
+        # if isinstance(unit_data, dict) and unit_data.get("raw_messages") is not None:
+        #     # TODO(#651) clarify how raw messages are sent
+        #     for message in unit_data["raw_messages"]:
+        #         packet = Packet.from_dict(message)
+        #         packet.receiver_id = agent_id
+        #         agent.pending_observations.put(packet)
 
     def _on_message(self, packet: Packet, channel_id: str):
         """Handle incoming messages from the channel"""
@@ -372,6 +368,10 @@ class ClientIOHandler:
         while not self.is_shutdown and len(self.channels) > 0:
             self._request_status_update()
             await asyncio.sleep(STATUS_CHECK_TIME)
+
+    def request_live_data(self, agent_id: str):
+        """Send a live data packet requesting a live data response"""
+        self.send_live_data(agent_id, {"live_data_requested": True})
 
     def send_live_data(self, agent_id: str, data: Dict[str, Any]):
         """Send a live data packet to the given agent id"""

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -217,7 +217,6 @@ class WorkerPool:
                 live_run.task_runner.execute_unit(
                     unit,
                     agent,
-                    lambda: self._mark_agent_done(agent),
                 )
             else:
                 # See if the concurrent unit is ready to launch
@@ -235,13 +234,7 @@ class WorkerPool:
                     if a is not None
                 ]
 
-                def mark_agents_done():
-                    for agent in registered_agents:
-                        self._mark_agent_done(agent)
-
-                live_run.task_runner.execute_assignment(
-                    assignment, registered_agents, mark_agents_done
-                )
+                live_run.task_runner.execute_assignment(assignment, registered_agents)
 
     async def register_agent_from_onboarding(self, onboarding_agent: "OnboardingAgent"):
         """
@@ -526,22 +519,6 @@ class WorkerPool:
 
         live_run = self.get_live_run()
         live_run.client_io.send_status_update(agent.get_agent_id(), status)
-
-    def _mark_agent_done(self, agent: Union["Agent", "OnboardingAgent"]) -> None:
-        """
-        Handle marking an agent as done, and telling the frontend agent
-        that they have successfully completed their task.
-
-        If the agent is in a final non-successful status, or already
-        told of partner disconnect, skip
-        """
-        if agent.db_status in AgentState.complete() + [
-            AgentState.STATUS_PARTNER_DISCONNECT
-        ]:
-            return  # Don't send done messages to agents that are already completed
-
-        live_run = self.get_live_run()
-        live_run.client_io.send_done_message(agent.db_id)
 
     def handle_updated_agent_status(self, status_map: Dict[str, str]):
         """

--- a/test/abstractions/blueprints/test_mock_blueprint.py
+++ b/test/abstractions/blueprints/test_mock_blueprint.py
@@ -9,7 +9,7 @@ import shutil
 import os
 import tempfile
 
-from typing import Type, ClassVar
+from typing import Type, ClassVar, List
 from mephisto.abstractions.test.blueprint_tester import BlueprintTests
 from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.abstractions.blueprints.mock.mock_blueprint import MockBlueprint
@@ -107,6 +107,12 @@ class MockBlueprintTests(BlueprintTests):
         """
         assert isinstance(task_runner, MockTaskRunner), "Must be a mock runner"
         return assignment.db_id in task_runner.tracked_tasks
+
+    def prep_mock_agents_to_complete(self, agents: List["MockAgent"]) -> None:
+        """Handle initializing mock agents to be able to pass their task"""
+        for agent in agents:
+            agent.enqueue_mock_live_data({"text": "message"})
+            agent.enqueue_mock_submit_event({"submitted": True})
 
     # TODO(#97) are there any other unit tests we'd like to have?
 


### PR DESCRIPTION
# Overview
As part of #655, and updates the `Agent` and `TaskRunner` classes to use the new lifecycle for registration and updating `AgentState`. Removes all direct references of `Packet`s in order to clarify the data format for agents to deal with (arbitrary dicts). Deprecates most of the requirements for moving to completed states with `mark_done` by now just using the `await_submit` function.

 # Implementation
It's a pretty hefty set of changes, but it's mostly just moving towards the outline of #655. Some steps:
- Splits data submission in the `AgentState` into `update_data` for dealing with live data dicts, and `update_submit` for dealing with submission dicts. Pushes these changes to the `StaticAgentState` and `MockAgentState`.
- Removes all references to `Packet`s from agents, instead using data dicts for the `get_live_data` and `handle_submit` methods. 
- Removes `mark_done` and awaiting submission via a condition wait call from the `TaskRunner`, now using the singular `await_submit` method for polling for final task submission. Pushes these changes to the `StaticTaskRunner` and `MockTaskRunner`. Updates the semantics of the `MockTaskRunner` to require one live data and one final submit packet for a `Unit` completion.
- Updates all `Agent`s to use underlying methods rather than direct `Packet` sends. Replaces `has_action` with `has_live_data` and `act` with `get_live_data`.
- Updates `ClientIOHandler` to only pass the data to `Agent`s rather than the `Packet`s.
- Updates the `WorkerPool` to no longer do `task_done` setting, as this is handled in the `TaskRunner` as a part of crowdprovider reconciliation rather than a lifecycle step for the workers.
- Updates `MockAgent` to now be able to enqueue events that will be triggered during a test. (`enqueue_mock_live_data` and `enqueue_mock_submit_event`).
- Updates `BlueprintTester` to use the new standard (meaning we can make automated tests for all of our blueprints moving forward!). Also updates the live run and operator tests.

# Testing
Local automated tests are passing now! This doesn't cover anything outside of the `MockBlueprint`, but that's something. Can't test anything else live just yet, but making progress.