### PR TITLE
Making operator forced shutdown safer and clearer

### DIFF
--- a/mephisto/abstractions/_subcomponents/__init__.py
+++ b/mephisto/abstractions/_subcomponents/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/mephisto/abstractions/_subcomponents/task_builder.py
+++ b/mephisto/abstractions/_subcomponents/task_builder.py
@@ -12,6 +12,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from mephisto.data_model.task_run import TaskRun
+    from omegaconf import DictConfig
 
 from mephisto.operations.logger_core import get_logger
 

--- a/mephisto/operations/logger_core.py
+++ b/mephisto/operations/logger_core.py
@@ -93,3 +93,11 @@ def get_logger(
         # logger.addHandler(handler)
         loggers[name] = logger
         return logger
+
+
+BOLD_RED = "\u001b[31;1m"
+RESET = "\u001b[0m"
+
+
+def format_loud(target_text: str):
+    return f"{BOLD_RED}{target_text}{RESET}"


### PR DESCRIPTION
# Overview
While working on #655 and running into a ton of things that didn't work, I found that the shutdown process for operators was unclear, slow, and didn't always clean up properly. Cleanup has been a common complaint in the past, so I took the opportunity to resolve.

# Implementation
- Bolding and coloring some of the clearer warnings to not just mash `Ctrl-C` to oblivion
- More opportunities to catch `Ctrl-C`s and continue proper shutdown
- Forced push of disconnect state to agents in-flight after a bold warning that you're interrupting active work.

# Testing
After this change, I was able to get #661 out, so that was cool.
![Screen Shot 2022-02-11 at 6 26 54 PM](https://user-images.githubusercontent.com/1276867/153688994-45ba50d4-29d4-42cc-a810-95eb956c1747.png)
(ignore debug spam, I was still working!)
