### PR TITLE
Change min Python requirement to 3.7

### DIFF
--- a/.github/workflows/docker-testing-matrix.yml
+++ b/.github/workflows/docker-testing-matrix.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false # Run all combos, don't skip on failures
       matrix:
         # from: https://hub.docker.com/r/nikolaik/python-nodejs
-        python-version: ["3.9", "3.8", "3.7", "3.6"]
+        python-version: ["3.9", "3.8", "3.7"]
         nodejs-version: ["15", "14", "12", "10"]
         image-suffix: ["", "-slim"]
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,7 @@
 
 First, clone this repo to your local system.
 
-Mephisto requires >= Python 3.6 and >= npm v6.
+Mephisto requires >= Python 3.7 and >= npm v6.
 
 ### Installation
 


### PR DESCRIPTION
Fixes #610

See the issue for more details.

Updates the quickstart and removes Python 3.6 testing from Github Actions.