### PR TITLE
Updating Flask Blueprint for architect API 1.0

### DIFF
--- a/mephisto/abstractions/architects/channels/websocket_channel.py
+++ b/mephisto/abstractions/architects/channels/websocket_channel.py
@@ -129,7 +129,6 @@ class WebsocketChannel(Channel):
             # Outer loop allows reconnects
             while not self._is_closed:
                 try:
-                    print("TRYING TO CONNECT", self.socket_url)
                     async with websockets.connect(
                         self.socket_url, open_timeout=30
                     ) as websocket:

--- a/mephisto/abstractions/architects/channels/websocket_channel.py
+++ b/mephisto/abstractions/architects/channels/websocket_channel.py
@@ -129,6 +129,7 @@ class WebsocketChannel(Channel):
             # Outer loop allows reconnects
             while not self._is_closed:
                 try:
+                    print("TRYING TO CONNECT", self.socket_url)
                     async with websockets.connect(
                         self.socket_url, open_timeout=30
                     ) as websocket:
@@ -156,6 +157,11 @@ class WebsocketChannel(Channel):
                     # Issue with opening this channel, should shut down to prevent inaccessible tasks
                     self.on_catastrophic_disconnect(self.channel_id)
                     return
+                except OSError as e:
+                    logger.info(
+                        f"Unhandled OSError exception in socket {e}, attempting restart"
+                    )
+                    await asyncio.sleep(0.2)
                 except Exception as e:
                     logger.exception(f"Unhandled exception in socket {e}, {repr(e)}")
                     if self._is_closed:

--- a/mephisto/abstractions/architects/router/flask/mephisto_flask_blueprint.py
+++ b/mephisto/abstractions/architects/router/flask/mephisto_flask_blueprint.py
@@ -399,6 +399,9 @@ def submit_onboarding():
     del provider_data["USED_AGENT_ID"]
     provider_data["request_id"] = str(uuid4())
 
+    if "onboarding_data" not in provider_data:
+        provider_data["onboarding_data"] = {}
+
     # Construct and send onboarding submission packet
     packet = {
         "packet_type": PACKET_TYPE_SUBMIT_ONBOARDING,

--- a/mephisto/abstractions/architects/router/node/server.js
+++ b/mephisto/abstractions/architects/router/node/server.js
@@ -442,6 +442,8 @@ app.post("/submit_onboarding", function (req, res) {
   debug_log("Am submitting onboarding for " + agent_id);
   delete provider_data.USED_AGENT_ID;
 
+  provider_data.onboarding_data = provider_data.onboarding_data || {};
+
   provider_data.request_id = request_id;
 
   let submit_packet = {

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -212,6 +212,9 @@ class ClientIOHandler:
 
     def _on_submit_onboarding(self, packet: Packet, channel_id: str) -> None:
         """Handle the submission of onboarding data"""
+        assert (
+            "onboarding_data" in packet.data
+        ), f"Onboarding packet {packet} submitted without data"
         live_run = self.get_live_run()
         onboarding_id = packet.subject_id
         if onboarding_id not in live_run.worker_pool.onboarding_agents:
@@ -232,7 +235,7 @@ class ClientIOHandler:
         # back properly under the new request)
         live_run.worker_pool.onboarding_infos[onboarding_id].request_id = request_id
 
-        agent.handle_submit(packet.data)
+        agent.handle_submit(packet.data["onboarding_data"])
 
     def _register_agent(self, packet: Packet, channel_id: str) -> None:
         """Read and forward a worker registration packet"""

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -212,9 +212,6 @@ class ClientIOHandler:
 
     def _on_submit_onboarding(self, packet: Packet, channel_id: str) -> None:
         """Handle the submission of onboarding data"""
-        assert (
-            "onboarding_data" in packet.data
-        ), f"Onboarding packet {packet} submitted without data"
         live_run = self.get_live_run()
         onboarding_id = packet.subject_id
         if onboarding_id not in live_run.worker_pool.onboarding_agents:
@@ -235,7 +232,7 @@ class ClientIOHandler:
         # back properly under the new request)
         live_run.worker_pool.onboarding_infos[onboarding_id].request_id = request_id
 
-        agent.handle_submit(packet.data["onboarding_data"])
+        agent.handle_submit(packet.data)
 
     def _register_agent(self, packet: Packet, channel_id: str) -> None:
         """Read and forward a worker registration packet"""


### PR DESCRIPTION
# Overview
Inline with #658, this pushes the same changes to our `Flask` implementation. I won't go in-depth over details, as the changes are analogous.

One small change that this version includes the same `unsent_messages` setup that the node version does, which allows for a clean transition from onboarding to in-task. This resolves #476 