### PR TITLE
Add GH action for checking npm version consistency on merge to main

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Install Mephisto
         run: pip install -e .
       - name: Run version sync script
-        run: python scripts/check_npm_package_version.py
+        run: python scripts/check_npm_package_versions.py

--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -1,8 +1,7 @@
 name: npm-check
 
 on:
-  push:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 jobs:

--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -1,0 +1,17 @@
+name: npm-check
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  mephisto-task-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install Mephisto
+        run: pip install -e .
+      - name: Run version sync script
+        run: python scripts/check_npm_package_version.py

--- a/scripts/check_npm_package_versions.py
+++ b/scripts/check_npm_package_versions.py
@@ -18,38 +18,45 @@ from mephisto.operations.logger_core import format_loud
 
 
 ROOT_DIR = get_root_dir()
-MEPHISTO_TASK_PACKAGE = os.path.join(ROOT_DIR, "packages/mephisto-task/package.json")
+CHECK_PACKAGES = ["mephisto-task", "bootstrap-chat"]
 
 
 def run_check():
-    assert os.path.exists(
-        MEPHISTO_TASK_PACKAGE
-    ), f"Can't find task package at {MEPHISTO_TASK_PACKAGE}"
-    with open(MEPHISTO_TASK_PACKAGE) as mephisto_task_package:
-        version = json.load(mephisto_task_package)["version"]
+    all_success = True
+    for pkg in CHECK_PACKAGES:
+        package_location = os.path.join(ROOT_DIR, "packages", pkg, "package.json")
+        assert os.path.exists(
+            package_location
+        ), f"Can't find package {pkg} at {package_location}"
+        with open(package_location) as package_json:
+            version = json.load(package_json)["version"]
 
-    print(f"Detected mephisto-task version '{version}' at '{MEPHISTO_TASK_PACKAGE}'")
+        print()
+        print(f"Detected '{pkg}' version '{version}' at '{package_location}'")
 
-    link = "https://registry.npmjs.org/-/package/mephisto-task/dist-tags"
+        link = f"https://registry.npmjs.org/-/package/{pkg}/dist-tags"
 
-    try:
-        f = urlopen(link)
-        contents = f.read().decode("utf-8")
-        latest_version = json.loads(contents)["latest"]
-        print(f"Detected mephisto-task@latest as version '{version}' on npm")
-    except:
-        print(
-            f"{format_loud('[ERROR]')} Could not access latest version of package on npm."
-        )
-        sys.exit(1)
+        try:
+            f = urlopen(link)
+            contents = f.read().decode("utf-8")
+            latest_version = json.loads(contents)["latest"]
+            print(f"Detected '{pkg}@latest' as version '{latest_version}' on npm")
+        except:
+            print(
+                f"{format_loud('[ERROR]')} Could not access latest version of package '{pkg}' on npm."
+            )
+            all_success &= False
 
-    if latest_version != version:
-        print(
-            f"{format_loud('[VERSION MISMATCH]')} The latest version of the "
-            f"'mephisto-task' package on npm ({latest_version}) doesn't match "
-            f"the version in the codebase ({version}). If this is part of a"
-            f"merge onto the main branch, you may want to deploy the packages first."
-        )
+        if latest_version != version:
+            print(
+                f"{format_loud('[VERSION MISMATCH]')} The latest version of the "
+                f"'{pkg}' package on npm ({latest_version}) doesn't match "
+                f"the version in the codebase ({version}). If this is part of a"
+                f"merge onto the main branch, you may want to deploy the packages first."
+            )
+            all_success &= False
+
+    if not all_success:
         sys.exit(1)
 
 

--- a/scripts/check_npm_package_versions.py
+++ b/scripts/check_npm_package_versions.py
@@ -41,18 +41,18 @@ def run_check():
             contents = f.read().decode("utf-8")
             latest_version = json.loads(contents)["latest"]
             print(f"Detected '{pkg}@latest' as version '{latest_version}' on npm")
+
+            if latest_version != version:
+                print(
+                    f"{format_loud('[VERSION MISMATCH]')} The latest version of the "
+                    f"'{pkg}' package on npm ({latest_version}) doesn't match "
+                    f"the version in the codebase ({version}). If this is part of a"
+                    f"merge onto the main branch, you may want to deploy the packages first."
+                )
+                all_success &= False
         except:
             print(
                 f"{format_loud('[ERROR]')} Could not access latest version of package '{pkg}' on npm."
-            )
-            all_success &= False
-
-        if latest_version != version:
-            print(
-                f"{format_loud('[VERSION MISMATCH]')} The latest version of the "
-                f"'{pkg}' package on npm ({latest_version}) doesn't match "
-                f"the version in the codebase ({version}). If this is part of a"
-                f"merge onto the main branch, you may want to deploy the packages first."
             )
             all_success &= False
 

--- a/scripts/check_npm_package_versions.py
+++ b/scripts/check_npm_package_versions.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Script that checks if the deployed packages on npm match
+the version that's in our source repository.
+"""
+
+import os
+import sys
+import json
+from mephisto.operations.utils import get_root_dir
+from urllib.request import urlopen
+from mephisto.operations.logger_core import format_loud
+
+
+ROOT_DIR = get_root_dir()
+MEPHISTO_TASK_PACKAGE = os.path.join(ROOT_DIR, "packages/mephisto-task/package.json")
+
+
+def run_check():
+    assert os.path.exists(
+        MEPHISTO_TASK_PACKAGE
+    ), f"Can't find task package at {MEPHISTO_TASK_PACKAGE}"
+    with open(MEPHISTO_TASK_PACKAGE) as mephisto_task_package:
+        version = json.load(mephisto_task_package)["version"]
+
+    print(f"Detected mephisto-task version '{version}' at '{MEPHISTO_TASK_PACKAGE}'")
+
+    link = "https://registry.npmjs.org/-/package/mephisto-task/dist-tags"
+
+    try:
+        f = urlopen(link)
+        contents = f.read().decode("utf-8")
+        latest_version = json.loads(contents)["latest"]
+        print(f"Detected mephisto-task@latest as version '{version}' on npm")
+    except:
+        print(
+            f"{format_loud('[ERROR]')} Could not access latest version of package on npm."
+        )
+        sys.exit(1)
+
+    if latest_version != version:
+        print(
+            f"{format_loud('[VERSION MISMATCH]')} The latest version of the "
+            f"'mephisto-task' package on npm ({latest_version}) doesn't match "
+            f"the version in the codebase ({version}). If this is part of a"
+            f"merge onto the main branch, you may want to deploy the packages first."
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_check()


### PR DESCRIPTION
## Overview

On PR merges into the `main` branch, we run a GH action to check that packages on npm `mephisto-task@latest` and `bootstrap-chat@latest` match the version in the repo. 

## Details

This is done to reduce a class of errors where the main repo is out of sync with npm, e.g. when we fix a bug in the repo and tell users to update their packages to incorporate the fix.

This is also a stopgap measure until we roll out an automated npm deploy process. IMO it is a sufficiently effective one and should catch and alert for most errors with minimal overhead created.


#### Side note:

It also doesn't consider the case where we make edits to `mephisto-task` and `bootstrap-chat` but we forget to update the version number.

Perhaps in the future we want to update the workflow to also run the following test:

```
[[ $(git diff ${{ github.head_ref }}..${{ github.base_ref }} --name-only -- packages/ | wc -l) -ne 0 ]]
```

...and if true, check that a package version change has occurred.

There may also be easier GH workflow-esque ways of doing this. Would need to do some research.

## Testing

Note that commit [86cfd51](https://github.com/facebookresearch/Mephisto/pull/678/commits/86cfd51a098727a122b8018d1ceca84e2601d8e4) below has the `npm-check` test run, while after commit [**ddf6271**](https://github.com/facebookresearch/Mephisto/pull/678/commits/ddf62714879cf832d071e5ec96f345d880e7d25c) is introduced, the test doesn't run, since that commit introduces the run-when-merging-against-`main` branch functionality.

Ran the `/scripts/check_npm_package_versions.py` file locally, including while internet was disconnected to verify error when npm can't be accessed.