### PR TITLE
Add new workflows for deploying docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+
+      - name: Move to docs directory
+        run: cd docs/web
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./build
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/web/**"
 
 jobs:
   deploy:
     name: Deploy docs to GitHub Pages
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/web
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -16,8 +21,6 @@ jobs:
           node-version: 16.x
           cache: yarn
 
-      - name: Move to docs directory
-        run: cd docs/web
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website

--- a/.github/workflows/test-deploy-docs.yml
+++ b/.github/workflows/test-deploy-docs.yml
@@ -2,6 +2,8 @@ name: Test docs deployment
 
 on:
   pull_request:
+    paths:
+      - "docs/web/**"
     branches:
       - main
     # Review gh actions docs if you want to further define triggers, paths, etc
@@ -11,6 +13,9 @@ jobs:
   test-deploy:
     name: Test docs deployment
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/web
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -18,8 +23,6 @@ jobs:
           node-version: 16.x
           cache: yarn
 
-      - name: Move to docs directory
-        run: cd docs/web
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Test build website

--- a/.github/workflows/test-deploy-docs.yml
+++ b/.github/workflows/test-deploy-docs.yml
@@ -1,0 +1,26 @@
+name: Test docs deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+    # Review gh actions docs if you want to further define triggers, paths, etc
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+
+jobs:
+  test-deploy:
+    name: Test docs deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: yarn
+
+      - name: Move to docs directory
+        run: cd docs/web
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Test build website
+        run: yarn build

--- a/docs/web/docusaurus.config.js
+++ b/docs/web/docusaurus.config.js
@@ -116,10 +116,10 @@ const config = {
           {
             title: "More",
             items: [
-              {
-                label: "Blog",
-                to: "/blog",
-              },
+              // {
+              //   label: "Blog",
+              //   to: "/blog",
+              // },
               {
                 label: "GitHub",
                 href: "https://github.com/facebookresearch/Mephisto",


### PR DESCRIPTION
Adds a test and deploy workflow for auto-deploying docs to https://mephisto.ai:

https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions

## Details:

- A build test runs only when changes are made in `docs/web/**` in a PR targeting `main`
- Auto-deploy is run whenever there are changes in `docs/web/**` pushed on to `main`
