### PR TITLE
Small remaining `MephistoDB` improvements. 

### DIFF
--- a/mephisto/abstractions/databases/README.md
+++ b/mephisto/abstractions/databases/README.md
@@ -4,7 +4,7 @@ This folder contains implementations of the `MephistoDB` abstraction. Databases 
 ## `LocalMephistoDB`
 Activated with `mephisto.database._database_type=local`. An implementation of the Mephisto Data Model outlined in `MephistoDB`. This database stores all of the information locally via SQLite. Some helper functions are included to make the implementation cleaner by abstracting away SQLite error parsing and string formatting, however it's pretty straightforward from the requirements of MephistoDB.
 
-## `SingletonMephistoDB` <defualt>
+## `SingletonMephistoDB` <default>
 This database is best used for high performance runs on a single machine, where direct access to the underlying database isn't necessary during the runtime. It makes no guarantees on the rate of writing state or status to disk, as much of it is stored locally and in caches to keep IO locks down. Using this, you'll likely be able to get up on `max_num_concurrent_units` to 150-300 on live tasks, and upwards from 500 on static tasks.
 
 At the moment this DB acts as a wrapper around the `LocalMephistoDB`, and trades off Mephisto memory consumption for writing time. All of the data model accesses that occur are cached into a library of singletons, so large enough tasks may have memory risks. This allows us to make clearer assertions about the synced nature of the data model members, but obviously requires active memory to do so.

--- a/mephisto/abstractions/databases/README.md
+++ b/mephisto/abstractions/databases/README.md
@@ -1,10 +1,10 @@
 # MephistoDB implementations
-This folder contains implementations of the `MephistoDB` abstraction. Databases can currently be configured using the `mephisto.database._database_type` flag, though all databases other than `local` are considered to be in BETA at this point.
+This folder contains implementations of the `MephistoDB` abstraction. Databases can currently be configured using the `mephisto.database._database_type` flag.
 
 ## `LocalMephistoDB`
-An implementation of the Mephisto Data Model outlined in `MephistoDB`. This database stores all of the information locally via SQLite. Some helper functions are included to make the implementation cleaner by abstracting away SQLite error parsing and string formatting, however it's pretty straightforward from the requirements of MephistoDB.
+Activated with `mephisto.database._database_type=local`. An implementation of the Mephisto Data Model outlined in `MephistoDB`. This database stores all of the information locally via SQLite. Some helper functions are included to make the implementation cleaner by abstracting away SQLite error parsing and string formatting, however it's pretty straightforward from the requirements of MephistoDB.
 
-## `SingletonMephistoDB` <BETA>
-Activated with `mephisto.database._database_type=singleton`. This database is best used for high performance runs on a single machine, where direct access to the underlying database isn't necessary during the runtime. It makes no guarantees on the rate of writing state or status to disk, as much of it is stored locally and in caches to keep IO locks down. Using this, you'll likely be able to get up on `max_num_concurrent_units` to 150-300 on live tasks, and upwards from 500 on static tasks.
+## `SingletonMephistoDB` <defualt>
+This database is best used for high performance runs on a single machine, where direct access to the underlying database isn't necessary during the runtime. It makes no guarantees on the rate of writing state or status to disk, as much of it is stored locally and in caches to keep IO locks down. Using this, you'll likely be able to get up on `max_num_concurrent_units` to 150-300 on live tasks, and upwards from 500 on static tasks.
 
 At the moment this DB acts as a wrapper around the `LocalMephistoDB`, and trades off Mephisto memory consumption for writing time. All of the data model accesses that occur are cached into a library of singletons, so large enough tasks may have memory risks. This allows us to make clearer assertions about the synced nature of the data model members, but obviously requires active memory to do so.

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -207,6 +207,22 @@ CREATE TABLE IF NOT EXISTS granted_qualifications (
 );
 """
 
+# Indices that are used by system-specific calls across Mephisto during live tasks
+# that improve the runtime of the system as a whole
+CREATE_CORE_INDEXES = """
+CREATE INDEX IF NOT EXISTS requesters_by_provider_index ON requesters(provider_type);
+CREATE INDEX IF NOT EXISTS unit_by_status_index ON units(status);
+CREATE INDEX IF NOT EXISTS unit_by_assignment_id_index ON units(assignment_id);
+CREATE INDEX IF NOT EXISTS unit_by_task_run_index ON units(task_run_id);
+CREATE INDEX IF NOT EXISTS unit_by_task_run_by_worker_by_status_index ON units(task_run_id, worker_id, status);
+CREATE INDEX IF NOT EXISTS unit_by_task_by_worker_index ON units(task_id, worker_id);
+CREATE INDEX IF NOT EXISTS agent_by_worker_by_status_index ON agents(worker_id, status);
+CREATE INDEX IF NOT EXISTS agent_by_task_run_index ON agents(task_run_id);
+CREATE INDEX IF NOT EXISTS assignment_by_task_run_index ON assignments(task_run_id);
+CREATE INDEX IF NOT EXISTS task_run_by_requester_index ON task_runs(requester_id);
+CREATE INDEX IF NOT EXISTS task_run_by_task_index ON task_runs(task_id);
+"""
+
 
 class StringIDRow(sqlite3.Row):
     def __getitem__(self, key: str) -> Any:
@@ -275,6 +291,7 @@ class LocalMephistoDB(MephistoDB):
                 c.execute(CREATE_QUALIFICATIONS_TABLE)
                 c.execute(CREATE_GRANTED_QUALIFICATIONS_TABLE)
                 c.execute(CREATE_ONBOARDING_AGENTS_TABLE)
+                c.execute(CREATE_CORE_INDEXES)
 
     def __get_one_by_id(
         self, table_name: str, id_name: str, db_id: str

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -291,7 +291,7 @@ class LocalMephistoDB(MephistoDB):
                 c.execute(CREATE_QUALIFICATIONS_TABLE)
                 c.execute(CREATE_GRANTED_QUALIFICATIONS_TABLE)
                 c.execute(CREATE_ONBOARDING_AGENTS_TABLE)
-                c.execute(CREATE_CORE_INDEXES)
+                c.executescript(CREATE_CORE_INDEXES)
 
     def __get_one_by_id(
         self, table_name: str, id_name: str, db_id: str

--- a/mephisto/operations/hydra_config.py
+++ b/mephisto/operations/hydra_config.py
@@ -21,7 +21,7 @@ config = ConfigStoreWithProvider("mephisto")
 
 @dataclass
 class DatabaseArgs:
-    _database_type: str = "local"  # default DB is local
+    _database_type: str = "singleton"  # default DB is performant singleton
 
 
 @dataclass


### PR DESCRIPTION
# Overview
Incredibly small changes to Mephisto's default behavior of database selection, and adding an index for every common query used by the Mephisto DB. Both of these together should have the outcome of further reducing the access and query time for the DB, increasing throughput.

# Implementation
Upgraded the default DB for the mephisto DB to the `singleton`, meaning that tasks launched live will use this over the `LocalMephistoDB`. At the moment I suggest everyone upgrade to this setup in-person, so this is codifying that change.
Read through all of the `db.find_<>` queries across the entire codebase, and created an index for any queries in a potentially critical path. This should help deal with scaling issues for MephistoDB's in long use. (cc @jxmsML)

# Testing
Automated testing. Ran some `EXPLAIN QUERY PLAN` queries before and after expanding my local database with the new set of indices, and found that before it would search the whole table and now it checks the relevant index first.