### PR TITLE
Removing (almost all) supervisors

### DIFF
--- a/mephisto/abstractions/_subcomponents/agent_state.py
+++ b/mephisto/abstractions/_subcomponents/agent_state.py
@@ -74,7 +74,7 @@ class AgentState(ABC):
 
     @staticmethod
     def complete() -> List[str]:
-        """Return all final Agent statuses which will not be updated by the supervisor"""
+        """Return all final Agent statuses which will not be updated by the WorkerPool"""
         return [
             AgentState.STATUS_COMPLETED,
             AgentState.STATUS_DISCONNECT,

--- a/mephisto/abstractions/_subcomponents/channel.py
+++ b/mephisto/abstractions/_subcomponents/channel.py
@@ -63,7 +63,7 @@ class Channel(ABC):
     def is_closed(self):
         """
         Return whether or not this connection has been explicitly closed
-        by the supervisor or another source.
+        by the ClientIOHandler or another source.
         """
 
     @abstractmethod

--- a/mephisto/abstractions/architects/README.md
+++ b/mephisto/abstractions/architects/README.md
@@ -8,7 +8,7 @@ This folder contains all of the current official `Architect` implementations.
 The `Architect` class is responsible for providing Mephisto with lifecycle functions for preparing, deploying, and shutting down a given server. It's also responsible with providing access to the user via a `Channel`, which defines an interface of callbacks for incoming messages and a function for outgoing messages. It should define the following things in order to operate properly:
 
 - `ArgsClass`: A dataclass that implements `ArchitectArgs`, specifying all of the configuration arguments that the `Architect` uses in order to properly initialize.
-- `get_channels`: A method that will return a list of initialized `Channel`'s that the supervisor will need to communicate with to manage running a task. Returns a list to handle cases where an `Architect` is communicating with multiple servers in a distributed setup.
+- `get_channels`: A method that will return a list of initialized `Channel`'s that the ClientIOHandler will need to communicate with to manage running a task. Returns a list to handle cases where an `Architect` is communicating with multiple servers in a distributed setup.
 - `prepare`: Prepare any files that will be used in the deploy process. Should return the location of the prepared server files.
 - `deploy`: Launch the server (if necessary) and deploy the prepared task files such that the server will be able to serve them. Return the server URL for this task, such that Mephisto can point workers to it.
 - `cleanup`: Clean up any files that were used in the deploy process that aren't necessarily useful for later

--- a/mephisto/abstractions/architects/channels/websocket_channel.py
+++ b/mephisto/abstractions/architects/channels/websocket_channel.py
@@ -59,7 +59,7 @@ class WebsocketChannel(Channel):
     def is_closed(self):
         """
         Return whether or not this connection has been explicitly closed
-        by the supervisor or another source.
+        by the ClientIOHandler or another source.
         """
         return self._is_closed
 

--- a/test/abstractions/blueprints/test_mock_blueprint.py
+++ b/test/abstractions/blueprints/test_mock_blueprint.py
@@ -27,7 +27,7 @@ from mephisto.data_model.assignment import Assignment
 from mephisto.data_model.task_run import TaskRun
 from mephisto.utils.testing import get_test_task_run
 
-# TODO(#97) Update supervisor to be able to provide mock setups to test against a blueprint
+# TODO(#97) Update operator to be able to provide mock setups to test against a blueprint
 from mephisto.abstractions.providers.mock.mock_agent import MockAgent
 from mephisto.abstractions.providers.mock.mock_unit import MockUnit
 from mephisto.abstractions.providers.mock.mock_worker import MockWorker

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -102,7 +102,7 @@ class OperatorBaseTest(object):
             time.sleep(0.1)
         self.assertLess(time.time() - start_time, 5, "Mock server not up in time")  # type: ignore
 
-    def test_initialize_supervisor(self):
+    def test_initialize_operator(self):
         """Quick test to ensure that the operator can be initialized"""
         self.operator = Operator(self.db)
 
@@ -140,7 +140,7 @@ class OperatorBaseTest(object):
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_job_concurrent(self):
-        """Ensure that the supervisor object can even be created"""
+        """Ensure that a job can be run that requires connected concurrent workers"""
         self.operator = Operator(self.db)
         config = MephistoConfig(
             blueprint=MockBlueprintArgs(num_assignments=1, is_concurrent=True),
@@ -200,7 +200,7 @@ class OperatorBaseTest(object):
 
     @patch("mephisto.operations.operator.RUN_STATUS_POLL_TIME", 1.5)
     def test_run_job_not_concurrent(self):
-        """Ensure that the supervisor object can even be created"""
+        """Ensure that a job can be run that doesn't require connected workers"""
         self.operator = Operator(self.db)
         config = MephistoConfig(
             blueprint=MockBlueprintArgs(num_assignments=1, is_concurrent=False),


### PR DESCRIPTION
I missed a few (lowercase) mentions of supervisor when I last attempted to remove all mentions. This leaves the only one in the Architecture Overview, which would require recreating the flow charts (out of scope for right now).

Thanks for finding in #700 