### PR TITLE
Update 1.0 upgrade guide to be more explicit

### DIFF
--- a/docs/web/docs/guides/upgrade_to_1/guide.md
+++ b/docs/web/docs/guides/upgrade_to_1/guide.md
@@ -10,7 +10,7 @@ sidebar_position: 1
 2. Ensure that your front-end code is using the latest packages, by running the following **in your task's webapp folder**.
     ```bash
     npm install --save mephisto-task@2
-    npm install --sav bootstrap-chat@2 # if applicable
+    npm install --save bootstrap-chat@2 # if applicable
     ```
 3. [Migrate your run scripts](../run_scripts) to use the newly introduced syntax, aimed to reduce boilerplate.
 

--- a/docs/web/docs/guides/upgrade_to_1/guide.md
+++ b/docs/web/docs/guides/upgrade_to_1/guide.md
@@ -7,10 +7,10 @@ sidebar_position: 1
 1. Update the Mephisto library to v1.
     - If you set up Mephisto using `pip install -e`, ensure you pull the latest version down from the git repo.
     - Or if you set up Mephisto using the pip wheel: `pip install Mephisto -U`
-2. Ensure that your front-end code is using the latest packages.
+2. Ensure that your front-end code is using the latest packages, by running the following **in your task's webapp folder**.
     ```bash
-    npm install mephisto-task@2
-    npm install bootstrap-chat@2 # if applicable
+    npm install --save mephisto-task@2
+    npm install --sav bootstrap-chat@2 # if applicable
     ```
 3. [Migrate your run scripts](../run_scripts) to use the newly introduced syntax, aimed to reduce boilerplate.
 


### PR DESCRIPTION
Highlight that `npm install --save mephisto-task@2.0.0` should be run the task's webapp folder, as opposed to installing it as a global package, e.g. in the root folder