### PR TITLE
Fix trigger for `npm-check` workflow

### DIFF
--- a/.github/workflows/npm-check.yml
+++ b/.github/workflows/npm-check.yml
@@ -1,7 +1,7 @@
 name: npm-check
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
`pull_request_target` for security reasons restricts the ref to the target branch. Changing to the `pull_request` event.

Fixes https://github.com/facebookresearch/Mephisto/pull/728#issuecomment-1085221637