### PR TITLE
Adding assert to static tasks for data type

### DIFF
--- a/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
+++ b/mephisto/abstractions/blueprints/abstract/static_task/static_agent_state.py
@@ -97,6 +97,10 @@ class StaticAgentState(AgentState):
     def update_submit(self, submission_data: Dict[str, Any]) -> None:
         """Move the submitted output to the local dict"""
         outputs: Dict[str, Any]
+        assert isinstance(submission_data, dict), (
+            "Static tasks must get dict results. Ensure you are passing an object to "
+            f"your frontend task's `handleSubmit` method. Got {submission_data}"
+        )
         output_files = submission_data.get("files")
         if output_files is not None:
             submission_data["files"] = [f["filename"] for f in submission_data["files"]]


### PR DESCRIPTION
# Overview
In upgrading to 1.0, we revealed some tasks that weren't following the expected format for Static Tasks. This adds an assertion to the underlying `AgentState` which is now responsible for noting when the expected data format isn't met. It also updates a comment in-code to point to the leaky abstraction where the `ClientIOHandler` contains some code that services a specific blueprint, however I don't have a short-term solution to resolve this one.

# Testing

Automated testing