### PR TITLE
Adding reasonable defaults to our examples for max concurrent units

### DIFF
--- a/examples/parlai_chat_task_demo/hydra_configs/conf/base.yaml
+++ b/examples/parlai_chat_task_demo/hydra_configs/conf/base.yaml
@@ -10,4 +10,4 @@ mephisto:
     num_conversations: 1
   task:
     # We expect to be able to handle 25 concurrent conversations without issue
-    max_num_concurrent_units: 50
+    max_num_concurrent_units: 50 # 25 convos * 2 people per

--- a/examples/parlai_chat_task_demo/hydra_configs/conf/base.yaml
+++ b/examples/parlai_chat_task_demo/hydra_configs/conf/base.yaml
@@ -8,3 +8,6 @@ mephisto:
     world_file: ${task_dir}/demo_worlds.py
     task_description_file: ${task_dir}/task_description.html
     num_conversations: 1
+  task:
+    # We expect to be able to handle 25 concurrent conversations without issue
+    max_num_concurrent_units: 50

--- a/examples/remote_procedure/mnist/hydra_configs/conf/launch_with_local.yaml
+++ b/examples/remote_procedure/mnist/hydra_configs/conf/launch_with_local.yaml
@@ -20,3 +20,5 @@ mephisto:
     task_reward: 0.05
     # NOTE will want real tags
     task_tags: "mnist,drawing,models,correction"
+    # We expect to handle 25 people using the MNIST model at once
+    max_num_concurrent_units: 25

--- a/examples/remote_procedure/template/hydra_configs/conf/launch_with_local.yaml
+++ b/examples/remote_procedure/template/hydra_configs/conf/launch_with_local.yaml
@@ -20,3 +20,6 @@ mephisto:
     task_reward: 0.05
     # NOTE will want real tags
     task_tags: "test,task,fix-me"
+    # NOTE Model-in-the-loop tasks need to be careful to configure only as many concurrent
+    # connections as their model can handle at once
+    max_num_concurrent_units: 40

--- a/examples/simple_static_task/hydra_configs/conf/example.yaml
+++ b/examples/simple_static_task/hydra_configs/conf/example.yaml
@@ -16,3 +16,5 @@ mephisto:
     task_description: "This is a simple test of static tasks."
     task_reward: 0.3
     task_tags: "static,task,testing"
+    # We expect to be able to handle 300 concurrent tasks without issue
+    max_num_concurrent_units: 300

--- a/examples/simple_static_task/hydra_configs/conf/onboarding_example.yaml
+++ b/examples/simple_static_task/hydra_configs/conf/onboarding_example.yaml
@@ -18,3 +18,5 @@ mephisto:
     task_description: "This is a simple test of static tasks."
     task_reward: 0.3
     task_tags: "static,task,testing"
+    # We expect to be able to handle 300 concurrent tasks without issue
+    max_num_concurrent_units: 300

--- a/examples/static_react_task/hydra_configs/conf/example.yaml
+++ b/examples/static_react_task/hydra_configs/conf/example.yaml
@@ -15,3 +15,5 @@ mephisto:
     task_description: "In this task, you'll be given a sentence. It is your job to rate it as either good or bad."
     task_reward: 0.05
     task_tags: "test,simple,button"
+    # We expect to be able to handle 300 concurrent tasks without issue
+    max_num_concurrent_units: 300

--- a/examples/static_react_task/hydra_configs/conf/onboarding_example.yaml
+++ b/examples/static_react_task/hydra_configs/conf/onboarding_example.yaml
@@ -15,3 +15,5 @@ mephisto:
     task_description: "In this task, you'll be given a sentence. It is your job to rate it as either good or bad."
     task_reward: 0.05
     task_tags: "test,simple,button"
+    # We expect to be able to handle 300 concurrent tasks without issue
+    max_num_concurrent_units: 300


### PR DESCRIPTION
# Overview
Mostly just the title. As brought up in #746, not having these kinds of defaults means that if people use the default values they're more likely to hit a bad experience (too much server load) rather than be low utilization. To make the basic case better, I've selected some defaults that should be pretty good on this tradeoff (at least until we hit the point that we can use our `metrics` tooling to scale this _dynamically_... in version 2.0 or something).