### PR TITLE
Remove prometheus/grafana executables from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,11 @@
 **/build/*
 data/*
 **/*.mp4
+
+mephisto/scripts/metrics/*
+!mephisto/scripts/metrics/resources
+!mephisto/scripts/metrics/install_*.sh
+!mephisto/scripts/metrics/README.md
+!mephisto/scripts/metrics/view_metrics.py
+!mephisto/scripts/metrics/shutdown_metrics.py
+


### PR DESCRIPTION
## Overview

Partially addresses a bug surfaced via #752 and #744 in that metrics executables saved down on the host computer would be copied into the Docker context and cause issues when running the docker image due to architecture mismatches.

This was fixed by updating the .dockerignore file

## Testing

```bash
docker build -t mephisto .
docker run -p 3000:3000 mephisto bash -c \
    'cd mephisto/examples/simple_static_task && python static_test_script.py'

...

[2022-04-07 21:04:03,109][mephisto.abstractions.providers.mock.mock_unit][INFO] - Mock task launched: localhost:3000 for preview, localhost:3000/?worker_id=x&assignment_id=4 for assignment 2
```