### PR TITLE
Update black version in pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=10000"]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
## Overview

Implements https://github.com/psf/black/issues/2964#issuecomment-1080974737 to upgrade `black` version number to fix the constantly failing `pre-commit / code-style` job (related to black/click dependency).

```
- repo: https://github.com/psf/black
  rev: 22.3.0
  hooks:
    - id: black
```

## Testing

All tests on this PR should pass, namely `pre-commit / code-style`.