### PR TITLE
Fixing static html onboarding->in_task script refresh

### DIFF
--- a/mephisto/abstractions/blueprints/static_html_task/source/dev/app.jsx
+++ b/mephisto/abstractions/blueprints/static_html_task/source/dev/app.jsx
@@ -214,7 +214,7 @@ function HtmlRenderer({ html, data, mephisto_keys }) {
     if (scripts_to_load.length > 0) {
       handleUpdatingRemainingScripts(0, scripts_to_load);
     }
-  }, [elRef.current]);
+  }, [elRef.current, html]);
 
   return (
     <div


### PR DESCRIPTION
# Overview

Currently a bug in the static_html blueprint only runs imported scripts on the very first HTML load. This means that when transitioning from onboarding to in-task, the newly loaded scripts are not executed. This fix resolves the issue by also running the scripts when the HTML changes.

# Testing

Ran the task in #753 and could reproduce the error of not loading the task scripts properly, and now am no longer able to reproduce.

Fixes #753. cc @edwardguo61