### PR TITLE
Locking node version to 16 current for EC2Architect

### DIFF
--- a/mephisto/abstractions/architects/ec2/run_scripts/node/init_server.sh
+++ b/mephisto/abstractions/architects/ec2/run_scripts/node/init_server.sh
@@ -7,7 +7,7 @@ sudo yum install -y httpd >> /home/ec2-user/routing_server/setup/setup_log.txt 2
 echo "Downloading Node..."
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
 . ~/.nvm/nvm.sh >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
-nvm install node >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
+nvm install v16.14.2 >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
 
 echo "Installing router modules..."
 cd /home/ec2-user/routing_server/router/

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -413,7 +413,7 @@ class Operator:
                 )
 
             def cant_cancel_expirations(self, sig, frame):
-                logging.warn(
+                logger.warn(
                     "Ignoring ^C during unit expirations. ^| if you NEED to exit and you will "
                     "have to clean up units that hadn't been expired afterwards."
                 )


### PR DESCRIPTION
Quick hotfix to lock the version of node that our EC2Architect uses.