### PR TITLE
Fixing issue with remote procedure agent state preventing reload

### DIFF
--- a/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
+++ b/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
@@ -87,9 +87,11 @@ class RemoteProcedureAgentState(AgentState):
         agent_file = self._get_expected_data_file()
         with open(agent_file, "r") as state_json:
             state = json.load(state_json)
-            self.requests = {x["uuid"]: x for x in state["requests"]}
+            self.requests = {x["uuid"]: RemoteRequest(**x) for x in state["requests"]}
             self.init_data = state["init_data"]
-            self.outputs = state["final_submission"]
+            self.final_submission = state["final_submission"]
+            self.start_time = state["start_time"]
+            self.end_time = state["end_time"]
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict with the messages of this agent"""

--- a/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
+++ b/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
@@ -47,7 +47,7 @@ class RemoteProcedureAgentState(AgentState):
         else:
             self.requests: Dict[str, RemoteRequest] = {}
             self.start_time = time.time()
-            self.end_time = -1
+            self.end_time = -1.0
             self.init_data: Optional[Dict[str, Any]] = None
             self.final_submission: Optional[Dict[str, Any]] = None
             self.save_data()

--- a/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
+++ b/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
@@ -155,4 +155,5 @@ class RemoteProcedureAgentState(AgentState):
     def update_submit(self, submitted_data: Dict[str, Any]) -> None:
         """Append any final submission to this state"""
         self.final_submission = submitted_data
+        self.end_time = time.time()
         self.save_data()


### PR DESCRIPTION
# Overview
A bug with the `load_data` method prevented `RemoteProcedureAgentState`s from properly reloading data for a task review. This PR introduces the fix.

# Testing
First, local testing in terminal. Now using right now in a live deploy