### PR TITLE
Onboarding + Shutdown cleanup fixes

### DIFF
--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -111,13 +111,10 @@ class ClientIOHandler:
         server_timestamp = packet.server_timestamp
         response_timestamp = time.time()
         if router_outgoing_timestamp is None:
-            print(packet, "no outgoing timestamp")
             router_outgoing_timestamp = server_timestamp
         if router_incoming_timestamp is None:
-            print(packet, "no incoming timestamp")
             router_incoming_timestamp = router_outgoing_timestamp
         if client_timestamp is None:
-            print(packet, "no client timestamp")
             client_timestamp = router_incoming_timestamp
         client_to_router = max(0, router_incoming_timestamp - client_timestamp)
         router_processing = max(

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -261,7 +261,7 @@ class ClientIOHandler:
         """Handle an action as sent from an agent, enqueuing to the agent"""
         live_run = self.get_live_run()
         agent = live_run.worker_pool.get_agent_for_id(packet.subject_id)
-        assert agent is not None, "Could not find given agent!"
+        assert agent is not None, f"Could not find given agent: {packet.subject_id}"
 
         agent.pending_actions.put(packet.data)
         agent.has_live_update.set()

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -652,9 +652,11 @@ class WorkerPool:
         to disconnected to clear their running tasks
         """
         for agent in self.agents.values():
-            agent.update_status(AgentState.STATUS_DISCONNECT)
+            if agent.get_status() not in AgentState.complete():
+                agent.update_status(AgentState.STATUS_DISCONNECT)
         for onboarding_agent in self.onboarding_agents.values():
-            onboarding_agent.update_status(AgentState.STATUS_DISCONNECT)
+            if agent.get_status() not in AgentState.complete():
+                onboarding_agent.update_status(AgentState.STATUS_DISCONNECT)
 
     def shutdown(self) -> None:
         """Mark shut down. Handle resource cleanup if necessary"""

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -639,9 +639,7 @@ class WorkerPool:
                     continue
                 if status != AgentState.STATUS_DISCONNECT:
                     # Stale or reconnect, send a status update
-                    live_run.loop_wrap.execute_coro(
-                        self.push_status_update(self.agents[agent_id])
-                    )
+                    live_run.loop_wrap.execute_coro(self.push_status_update(agent))
                     continue  # Only DISCONNECT can be marked remotely, rest are mismatch (except STATUS_COMPLETED)
                 agent.update_status(status)
         pass


### PR DESCRIPTION
# Overview
While running a long-lived live task using `RemoteProcedureBlueprint`, I noticed that in onboarding some conversions to task weren't working as expected. These were being hidden during shutdown, which made it difficult to debug.

This PR includes the fix to the onboarding edge transition (wherein the state change wasn't being pushed), as well as the fix to shutdown that stops agent status from being wiped.

# Implementation
- No longer changes agent status to disconnected during forced shutdown unless the status isn't final
- No longer attempts to send messages via `client_io` if it's already shut down (handled with the `agent_in_active_run` method.

# Testing
Automated testing, now running in my deploy.