### PR TITLE
Agent base refactor

### DIFF
--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -372,7 +372,6 @@ class TaskRunner(ABC):
                         agent.await_submit(timeout=self.args.task.submission_timeout)
                     agent.update_status(AgentState.STATUS_COMPLETED)
                     agent.mark_done()
-                agent.hide_state()
 
             for unit in assignment.get_units():
                 self.shared_state.on_unit_submitted(unit)
@@ -382,6 +381,9 @@ class TaskRunner(ABC):
             task_run = self.task_run
             for unit in assignment.get_units():
                 task_run.clear_reservation(unit)
+
+            for agent in agents:
+                agent.hide_state()
 
     @staticmethod
     def get_data_for_assignment(assignment: "Assignment") -> "InitializationData":

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -226,6 +226,7 @@ class TaskRunner(ABC):
             args=(unit, agent),
             name=f"Unit-thread-{unit.db_id}",
         )
+        agent.update_status(AgentState.STATUS_IN_TASK)
         self.running_units[unit.db_id] = RunningUnit(
             unit=unit,
             agent=agent,

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -299,6 +299,7 @@ class TaskRunner(ABC):
 
             self._cleanup_special_units(unit, agent)
             self.task_run.clear_reservation(unit)
+            agent.hide_state()
 
     def execute_assignment(
         self,
@@ -370,6 +371,7 @@ class TaskRunner(ABC):
                         agent.await_submit(timeout=self.args.task.submission_timeout)
                     agent.update_status(AgentState.STATUS_COMPLETED)
                     agent.mark_done()
+                agent.hide_state()
 
             for unit in assignment.get_units():
                 self.shared_state.on_unit_submitted(unit)

--- a/mephisto/abstractions/blueprints/mock/mock_task_runner.py
+++ b/mephisto/abstractions/blueprints/mock/mock_task_runner.py
@@ -72,7 +72,7 @@ class MockTaskRunner(TaskRunner):
         packet = agent.get_live_update(timeout=self.timeout)
         if packet is not None:
             agent.observe(packet)
-        agent.await_submit(self.timeout)
+        agent.await_submit(self.args.task.submission_timeout)
         del self.tracked_tasks[unit.db_id]
 
     def run_assignment(self, assignment: "Assignment", agents: List["Agent"]):
@@ -95,7 +95,7 @@ class MockTaskRunner(TaskRunner):
             if packet is not None:
                 agent.observe(packet)
         for agent in agents:
-            agent.await_submit(self.timeout)
+            agent.await_submit(self.args.task.submission_timeout)
         del self.tracked_tasks[assignment.db_id]
 
     def cleanup_assignment(self, assignment: "Assignment"):

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -254,6 +254,7 @@ class MTurkUnit(Unit):
                 # Treat this as a return event, this hit may be doable by someone else
                 agent = self.get_assigned_agent()
                 if agent is not None and agent.get_status() in [
+                    AgentState.STATUS_ACCEPTED,
                     AgentState.STATUS_IN_TASK,
                     AgentState.STATUS_ONBOARDING,
                     AgentState.STATUS_WAITING,

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -392,7 +392,7 @@ class Agent(
         old_status = self.db_status
         self.db.update_agent(self.db_id, status=new_status)
         self.db_status = new_status
-        if agent_in_active_run(self):
+        if self.agent_in_active_run():
             live_run = self.get_live_run()
             live_run.loop_wrap.execute_coro(
                 live_run.worker_pool.push_status_update(self)

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -57,20 +57,229 @@ ACTIVE_WORKERS = Gauge(
 )
 
 
-def agent_in_active_run(agent: Union["Agent", "OnboardingAgent"]) -> bool:
+class _AgentBase(ABC):
     """
-    Returns whether the given agent is in an active LiveTaskRun
-    and can have status updates
+    This class contains the shared logic between Agents and OnboardingAgents,
+    and should be extended by any class acting like an Agent in the
+    mephisto data model.
     """
-    if agent._associated_live_run is None:
-        return False  # No live run
-    if agent._associated_live_run.client_io.is_shutdown:
-        return False  # Live run, but is shutdown
-    return True
+
+    def __init__(
+        self,
+        db: "MephistoDB",
+        db_id: str,
+        row: Optional[Mapping[str, Any]] = None,
+        _used_new_call: bool = False,
+    ):
+        if not _used_new_call:
+            raise AssertionError(
+                "Direct Agent and data model access via ...Agent(db, id) was "
+                "now deprecated in favor of calling Agent.get(db, id). "
+            )
+        self.db: "MephistoDB" = db
+        assert row is not None, f"AbstractAgent requires a row be provided"
+
+        # Loading of database attributes
+        self.db_id = db_id
+        self.db_status: str = row["status"]
+        self.worker_id: str = row["worker_id"]
+        self.task_type: str = row["task_type"]
+        self.task_run_id: str = row["task_run_id"]
+        self.task_id: str = row["task_id"]
+
+        # Deferred loading of related entities
+        self._worker: Optional["Worker"] = None
+        self._task_run: Optional["TaskRun"] = None
+        self._task: Optional["Task"] = None
+
+        # Related entity set by a live run
+        self._associated_live_run: Optional["LiveTaskRun"] = None
+
+        # Local state for live agents
+        self.pending_actions: "Queue[Dict[str, Any]]" = Queue()
+        self.has_live_update = threading.Event()
+        self.has_live_update.clear()
+        self.did_submit = threading.Event()
+        self.is_shutdown = False
+
+        # Follow-up initialization is deferred
+        self._state = None  # type: ignore
+
+    @property
+    def state(self) -> "AgentState":
+        if self._state is None:
+            self._state = AgentState(self)  # type: ignore
+        return cast("AgentState", self._state)
+
+    def hide_state(self) -> None:
+        """Clean up the state such that the GC may remove it"""
+        self._state = None
+
+    def set_live_run(self, live_run: "LiveTaskRun") -> None:
+        """Set an associated live run for this agent"""
+        self._associated_live_run = live_run
+
+    def get_live_run(self) -> "LiveTaskRun":
+        """Return the associated live run for this agent. Throw if not set"""
+        if self._associated_live_run is None:
+            raise AssertionError(
+                "Should not be getting the live run, not set for given agent"
+            )
+        return self._associated_live_run
+
+    def agent_in_active_run(self) -> bool:
+        """
+        Returns whether the given agent is in an active LiveTaskRun
+        and can have status updates
+        """
+        if self._associated_live_run is None:
+            return False  # No live run
+        if self._associated_live_run.client_io.is_shutdown:
+            return False  # Live run, but is shutdown
+        return True
+
+    def get_worker(self) -> Worker:
+        """
+        Return the worker that is using this agent for a task
+        """
+        if self._worker is None:
+            self._worker = Worker.get(self.db, self.worker_id)
+        return self._worker
+
+    def get_task_run(self) -> "TaskRun":
+        """Return the TaskRun this agent is working within"""
+        if self._task_run is None:
+            from mephisto.data_model.task_run import TaskRun
+
+            self._task_run = TaskRun.get(self.db, self.task_run_id)
+        return self._task_run
+
+    def get_task(self) -> "Task":
+        """Return the Task this agent is working within"""
+        if self._task is None:
+            if self._task_run is not None:
+                self._task = self._task_run.get_task()
+            else:
+                from mephisto.data_model.task import Task
+
+                self._task = Task.get(self.db, self.task_id)
+        return self._task
+
+    def observe(self, live_update: "Dict[str, Any]") -> None:
+        """
+        Pass the observed information to the AgentState, then
+        queue the information to be pushed to the user
+        """
+        if live_update.get("update_id") is None:
+            live_update["update_id"] = str(uuid4())
+        self.state.update_data(live_update)
+
+        if self.agent_in_active_run():
+            live_run = self.get_live_run()
+            live_run.client_io.send_live_update(self.get_agent_id(), live_update)
+
+    def get_live_update(
+        self, timeout: Optional[int] = None
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Request information from the Agent's frontend. If non-blocking,
+        (timeout is None) should return None if no actions are ready
+        to be returned.
+        """
+        if self.pending_actions.empty():
+            if timeout is None or timeout == 0:
+                return None
+            self.has_live_update.wait(timeout)
+
+        if self.pending_actions.empty():
+            if self.is_shutdown:
+                raise AgentShutdownError(self.db_id)
+            # various disconnect cases
+            status = self.get_status()
+            if status == AgentState.STATUS_DISCONNECT:
+                raise AgentDisconnectedError(self.db_id)
+            elif status == AgentState.STATUS_RETURNED:
+                raise AgentReturnedError(self.db_id)
+            self.update_status(AgentState.STATUS_TIMEOUT)
+            raise AgentTimeoutError(timeout, self.db_id)
+        assert (
+            not self.pending_actions.empty()
+        ), "has_live_update released without an action!"
+
+        act = self.pending_actions.get()
+
+        if self.pending_actions.empty():
+            self.has_live_update.clear()
+        self.state.update_data(act)
+        return act
+
+    def act(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """
+        Request information from the Agent's frontend. If non-blocking,
+        (timeout is None) should return None if no actions are ready
+        to be returned.
+        """
+        warn_once(
+            "As of Mephisto 1.0 Agent.act is being deprecated in favor of Agent.get_live_update. "
+            "This functionality will no longer work in 1.1"
+        )
+        return self.get_live_update(timeout)
+
+    def await_submit(self, timeout: Optional[int] = None) -> bool:
+        """Blocking wait for this agent to submit their task"""
+        if timeout is not None:
+            self.did_submit.wait(timeout=timeout)
+        return self.did_submit.is_set()
+
+    def handle_submit(self, submit_data: Dict[str, Any]) -> None:
+        """Handle final submission for an onboarding agent, with the given data"""
+        self.did_submit.set()
+        self.state.update_submit(submit_data)
+
+    def shutdown(self) -> None:
+        """
+        Force the given agent to end any polling threads and throw an AgentShutdownError
+        from any acts called on it, ensuring tasks using this agent can be cleaned up.
+        """
+        logger.debug(f"{self} is shutting down")
+        self.has_live_update.set()
+        self.is_shutdown = True
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.db_id}, {self.db_status})"
+
+    @abstractmethod
+    def get_agent_id(self) -> str:
+        """
+        Return the ID that should be used to refer to this agent
+        in the Mephisto IO API
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_data_dir(self) -> str:
+        """
+        Return the directory to be storing any agent state for
+        this agent into
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_status(self, new_status: str) -> None:
+        """Update the database status of this agent, and
+        possibly send a message to the frontend agent informing
+        them of this update"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_status(self) -> str:
+        """Get the status of this agent in their work on their unit"""
+        raise NotImplementedError
 
 
-# TODO(CLEAN) can probably refactor out some kind of AgentBase
-class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
+class Agent(
+    _AgentBase, MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta
+):
     """
     This class encompasses a worker as they are working on an individual assignment.
     It maintains details for the current task at hand such as start and end time,
@@ -93,39 +302,19 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         if row is None:
             row = db.get_agent(db_id)
         assert row is not None, f"Given db_id {db_id} did not exist in given db"
-        self.db_id: str = row["agent_id"]
-        self.db_status: str = row["status"]
-        self.worker_id: str = row["worker_id"]
+
+        # Cover basic initialization
+        _AgentBase.__init__(self, db, db_id, row=row, _used_new_call=_used_new_call)
+
+        # Agent-specific row fields
         self.unit_id: str = row["unit_id"]
-        self.task_type: str = row["task_type"]
         self.provider_type: str = row["provider_type"]
-        self.pending_actions: "Queue[Dict[str, Any]]" = Queue()
-        self.has_live_update = threading.Event()
-        self.has_live_update.clear()
         self.assignment_id: str = row["assignment_id"]
-        self.task_run_id: str = row["task_run_id"]
-        self.task_id: str = row["task_id"]
-        self.did_submit = threading.Event()
-        self.is_shutdown = False
 
         # Deferred loading of related entities
         self._worker: Optional["Worker"] = None
         self._unit: Optional["Unit"] = None
         self._assignment: Optional["Assignment"] = None
-        self._task_run: Optional["TaskRun"] = None
-        self._task: Optional["Task"] = None
-
-        # Related entity set by a live run
-        self._associated_live_run: Optional["LiveTaskRun"] = None
-
-        # Follow-up initialization is deferred
-        self._state = None  # type: ignore
-
-    @property
-    def state(self) -> "AgentState":
-        if self._state is None:
-            self._state = AgentState(self)  # type: ignore
-        return cast("AgentState", self._state)
 
     def __new__(
         cls,
@@ -157,29 +346,9 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
             # We are constructing another instance directly
             return super().__new__(cls)
 
-    def set_live_run(self, live_run: "LiveTaskRun") -> None:
-        """Set an associated live run for this agent"""
-        self._associated_live_run = live_run
-
-    def get_live_run(self) -> "LiveTaskRun":
-        """Return the associated live run for this agent. Throw if not set"""
-        if self._associated_live_run is None:
-            raise AssertionError(
-                "Should not be getting the live run, not set for given agent"
-            )
-        return self._associated_live_run
-
     def get_agent_id(self) -> str:
         """Return this agent's id"""
         return self.db_id
-
-    def get_worker(self) -> Worker:
-        """
-        Return the worker that is using this agent for a task
-        """
-        if self._worker is None:
-            self._worker = Worker.get(self.db, self.worker_id)
-        return self._worker
 
     def get_unit(self) -> "Unit":
         """
@@ -201,34 +370,6 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
 
                 self._assignment = Assignment.get(self.db, self.assignment_id)
         return self._assignment
-
-    def get_task_run(self) -> "TaskRun":
-        """Return the TaskRun this agent is working within"""
-        if self._task_run is None:
-            if self._unit is not None:
-                self._task_run = self._unit.get_task_run()
-            elif self._assignment is not None:
-                self._task_run = self._assignment.get_task_run()
-            else:
-                from mephisto.data_model.task_run import TaskRun
-
-                self._task_run = TaskRun.get(self.db, self.task_run_id)
-        return self._task_run
-
-    def get_task(self) -> "Task":
-        """Return the Task this agent is working within"""
-        if self._task is None:
-            if self._unit is not None:
-                self._task = self._unit.get_task()
-            elif self._assignment is not None:
-                self._task = self._assignment.get_task()
-            elif self._task_run is not None:
-                self._task = self._task_run.get_task()
-            else:
-                from mephisto.data_model.task import Task
-
-                self._task = Task.get(self.db, self.task_id)
-        return self._task
 
     def get_data_dir(self) -> str:
         """
@@ -325,77 +466,6 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         agent._unit = unit
         return agent
 
-    def observe(self, live_update: "Dict[str, Any]") -> None:
-        """
-        Pass the observed information to the AgentState, then
-        queue the information to be pushed to the user
-        """
-        if live_update.get("update_id") is None:
-            live_update["update_id"] = str(uuid4())
-        self.state.update_data(live_update)
-
-        if agent_in_active_run(self):
-            live_run = self.get_live_run()
-            live_run.client_io.send_live_update(self.get_agent_id(), live_update)
-
-    def get_live_update(
-        self, timeout: Optional[int] = None
-    ) -> Optional[Dict[str, Any]]:
-        """
-        Request information from the Agent's frontend. If non-blocking,
-        (timeout is None) should return None if no actions are ready
-        to be returned.
-        """
-        if self.pending_actions.empty():
-            if timeout is None or timeout == 0:
-                return None
-            self.has_live_update.wait(timeout)
-
-        if self.pending_actions.empty():
-            if self.is_shutdown:
-                raise AgentShutdownError(self.db_id)
-            # various disconnect cases
-            status = self.get_status()
-            if status == AgentState.STATUS_DISCONNECT:
-                raise AgentDisconnectedError(self.db_id)
-            elif status == AgentState.STATUS_RETURNED:
-                raise AgentReturnedError(self.db_id)
-            self.update_status(AgentState.STATUS_TIMEOUT)
-            raise AgentTimeoutError(timeout, self.db_id)
-        assert (
-            not self.pending_actions.empty()
-        ), "has_live_update released without an action!"
-
-        act = self.pending_actions.get()
-
-        if self.pending_actions.empty():
-            self.has_live_update.clear()
-        self.state.update_data(act)
-        return act
-
-    def act(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
-        """
-        Request information from the Agent's frontend. If non-blocking,
-        (timeout is None) should return None if no actions are ready
-        to be returned.
-        """
-        warn_once(
-            "As of Mephisto 1.0 Agent.act is being deprecated in favor of Agent.get_live_update. "
-            "This functionality will no longer work in 1.1"
-        )
-        return self.get_live_update(timeout)
-
-    def await_submit(self, timeout: Optional[int] = None) -> bool:
-        """Blocking wait for this agent to submit their task"""
-        if timeout is not None:
-            self.did_submit.wait(timeout=timeout)
-        return self.did_submit.is_set()
-
-    def handle_submit(self, submit_data: Dict[str, Any]) -> None:
-        """Handle final submission for an onboarding agent, with the given data"""
-        self.did_submit.set()
-        self.state.update_submit(submit_data)
-
     def get_status(self) -> str:
         """Get the status of this agent in their work on their unit"""
         if self.db_status not in AgentState.complete():
@@ -407,25 +477,13 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
                 ]:
                     # Disconnect statuses should free any pending acts
                     self.has_live_update.set()
-                if agent_in_active_run(self):
+                if self.agent_in_active_run():
                     live_run = self.get_live_run()
                     live_run.loop_wrap.execute_coro(
                         live_run.worker_pool.push_status_update(self)
                     )
             self.db_status = row["status"]
         return self.db_status
-
-    def shutdown(self) -> None:
-        """
-        Force the given agent to end any polling threads and throw an AgentShutdownError
-        from any acts called on it, ensuring tasks using this agent can be cleaned up.
-        """
-        logger.debug(f"{self} is shutting down")
-        self.has_live_update.set()
-        self.is_shutdown = True
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.db_id}, {self.db_status})"
 
     # Children classes should implement the following methods
 
@@ -469,7 +527,7 @@ class Agent(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
 
 
 class OnboardingAgent(
-    MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta
+    _AgentBase, MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta
 ):
     """
     Onboarding agents are a special extension of agents used
@@ -498,48 +556,14 @@ class OnboardingAgent(
                 "Direct OnboardingAgent and data model access via OnboardingAgent(db, id) is "
                 "now deprecated in favor of calling OnboardingAgent.get(db, id). "
             )
-        self.db: "MephistoDB" = db
         if row is None:
             row = db.get_onboarding_agent(db_id)
         assert row is not None, f"Given db_id {db_id} did not exist in given db"
-        self.db_id: str = row["onboarding_agent_id"]
-        self.db_status: str = row["status"]
-        self.worker_id: str = row["worker_id"]
-        self.task_type: str = row["task_type"]
-        self.pending_actions: "Queue[Dict[str, Any]]" = Queue()
-        self.has_live_update = threading.Event()
-        self.has_live_update.clear()
-        self.task_run_id: str = row["task_run_id"]
-        self.task_id: str = row["task_id"]
-        self.did_submit = threading.Event()
-        self.is_shutdown = False
-
-        # Deferred loading of related entities
-        self._worker: Optional["Worker"] = None
-        self._task_run: Optional["TaskRun"] = None
-        self._task: Optional["Task"] = None
-
-        # Related entity set by a live run
-        self._associated_live_run: Optional["LiveTaskRun"] = None
-
-        # Follow-up initialization
-        self.state = AgentState(self)  # type: ignore
+        _AgentBase.__init__(self, db, db_id, row=row, _used_new_call=_used_new_call)
 
     def get_agent_id(self) -> str:
         """Return an id to use for onboarding agent requests"""
         return f"{self.DISPLAY_PREFIX}{self.db_id}"
-
-    def set_live_run(self, live_run: "LiveTaskRun") -> None:
-        """Set an associated live run for this agent"""
-        self._associated_live_run = live_run
-
-    def get_live_run(self) -> "LiveTaskRun":
-        """Return the associated live run for this agent. Throw if not set"""
-        if self._associated_live_run is None:
-            raise AssertionError(
-                "Should not be getting the live run, not set for given agent"
-            )
-        return self._associated_live_run
 
     @classmethod
     def is_onboarding_id(cls, agent_id: str) -> bool:
@@ -553,33 +577,6 @@ class OnboardingAgent(
             cls.DISPLAY_PREFIX
         ), f"Provided id {agent_id} is not an onboarding_id"
         return agent_id[len(cls.DISPLAY_PREFIX) :]
-
-    def get_worker(self) -> Worker:
-        """
-        Return the worker that is using this agent for a task
-        """
-        if self._worker is None:
-            self._worker = Worker.get(self.db, self.worker_id)
-        return self._worker
-
-    def get_task_run(self) -> "TaskRun":
-        """Return the TaskRun this agent is working within"""
-        if self._task_run is None:
-            from mephisto.data_model.task_run import TaskRun
-
-            self._task_run = TaskRun.get(self.db, self.task_run_id)
-        return self._task_run
-
-    def get_task(self) -> "Task":
-        """Return the Task this agent is working within"""
-        if self._task is None:
-            if self._task_run is not None:
-                self._task = self._task_run.get_task()
-            else:
-                from mephisto.data_model.task import Task
-
-                self._task = Task.get(self.db, self.task_id)
-        return self._task
 
     def get_data_dir(self) -> str:
         """
@@ -603,7 +600,7 @@ class OnboardingAgent(
         old_status = self.db_status
         self.db.update_onboarding_agent(self.db_id, status=new_status)
         self.db_status = new_status
-        if agent_in_active_run(self):
+        if self.agent_in_active_run():
             if new_status not in [
                 AgentState.STATUS_APPROVED,
                 AgentState.STATUS_REJECTED,
@@ -628,77 +625,6 @@ class OnboardingAgent(
                 worker_id=self.worker_id, agent_type="onboarding"
             ).dec()
 
-    def observe(self, live_update: "Dict[str, Any]") -> None:
-        """
-        Pass the observed information to the AgentState, then
-        queue the information to be pushed to the user
-        """
-        if live_update.get("update_id") is None:
-            live_update["update_id"] = str(uuid4())
-        self.state.update_data(live_update)
-
-        if agent_in_active_run(self):
-            live_run = self.get_live_run()
-            live_run.client_io.send_live_update(self.get_agent_id(), live_update)
-
-    def get_live_update(
-        self, timeout: Optional[int] = None
-    ) -> Optional[Dict[str, Any]]:
-        """
-        Request information from the Agent's frontend. If non-blocking,
-        (timeout is None) should return None if no actions are ready
-        to be returned.
-        """
-        if self.pending_actions.empty():
-            if timeout is None or timeout == 0:
-                return None
-            self.has_live_update.wait(timeout)
-
-        if self.pending_actions.empty():
-            # various disconnect cases
-            if self.is_shutdown:
-                raise AgentShutdownError(self.db_id)
-            status = self.get_status()
-            if status == AgentState.STATUS_DISCONNECT:
-                raise AgentDisconnectedError(self.db_id)
-            elif status == AgentState.STATUS_RETURNED:
-                raise AgentReturnedError(self.db_id)
-            self.update_status(AgentState.STATUS_TIMEOUT)
-            raise AgentTimeoutError(timeout, self.db_id)
-        assert (
-            not self.pending_actions.empty()
-        ), "has_live_update released without an action!"
-
-        act = self.pending_actions.get()
-
-        if self.pending_actions.empty():
-            self.has_live_update.clear()
-        self.state.update_data(act)
-        return act
-
-    def act(self, timeout: Optional[int] = None) -> Optional[Dict[str, Any]]:
-        """
-        Request information from the Agent's frontend. If non-blocking,
-        (timeout is None) should return None if no actions are ready
-        to be returned.
-        """
-        warn_once(
-            "As of Mephisto 1.0 Agent.act is being deprecated in favor of Agent.get_live_update. "
-            "This functionality will no longer work in 1.1"
-        )
-        return self.get_live_update(timeout)
-
-    def await_submit(self, timeout: Optional[int] = None) -> bool:
-        """Blocking wait for this agent to submit their task"""
-        if timeout is not None:
-            self.did_submit.wait(timeout=timeout)
-        return self.did_submit.is_set()
-
-    def handle_submit(self, submit_data: Dict[str, Any]) -> None:
-        """Handle final submission for an onboarding agent, with the given data"""
-        self.did_submit.set()
-        self.state.update_submit(submit_data)
-
     def get_status(self) -> str:
         """Get the status of this agent in their work on their unit"""
         if self.db_status not in AgentState.complete():
@@ -714,22 +640,13 @@ class OnboardingAgent(
                     AgentState.STATUS_APPROVED,
                     AgentState.STATUS_REJECTED,
                 ]:
-                    if agent_in_active_run(self):
+                    if self.agent_in_active_run():
                         live_run = self.get_live_run()
                         live_run.loop_wrap.execute_coro(
                             live_run.worker_pool.push_status_update(self)
                         )
             self.db_status = row["status"]
         return self.db_status
-
-    def shutdown(self) -> None:
-        """
-        Force the given agent to end any polling threads and throw an AgentShutdownError
-        from any acts called on it, ensuring tasks using this agent can be cleaned up.
-        """
-        logger.debug(f"{self} is shutting down")
-        self.has_live_update.set()
-        self.is_shutdown = True
 
     @staticmethod
     def new(db: "MephistoDB", worker: Worker, task_run: "TaskRun") -> "OnboardingAgent":
@@ -746,6 +663,3 @@ class OnboardingAgent(
         ACTIVE_WORKERS.labels(worker_id=worker.db_id, agent_type="onboarding").inc()
         logger.debug(f"Registered new {a} for worker {worker}.")
         return a
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.db_id})"

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -243,6 +243,7 @@ class _AgentBase(ABC):
         """
         logger.debug(f"{self} is shutting down")
         self.has_live_update.set()
+        self.did_submit.set()
         self.is_shutdown = True
 
     def __repr__(self) -> str:

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -226,9 +226,14 @@ class _AgentBase(ABC):
         return self.get_live_update(timeout)
 
     def await_submit(self, timeout: Optional[int] = None) -> bool:
-        """Blocking wait for this agent to submit their task"""
+        """
+        Blocking wait for this agent to submit their task
+        If timeout is provided and exceeded, raises AgentTimeoutError
+        """
         if timeout is not None:
             self.did_submit.wait(timeout=timeout)
+            if not self.did_submit.is_set():
+                raise AgentTimeoutError(timeout, self.db_id)
         return self.did_submit.is_set()
 
     def handle_submit(self, submit_data: Dict[str, Any]) -> None:

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -191,6 +191,8 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
         """
         config = self.get_task_args()
 
+        # TODO handle with temporary local qualifications to prevent
+        # needing to call expensive `find_units`
         if config.allowed_concurrent != 0 or config.maximum_units_per_worker:
             current_units = self.db.find_units(
                 task_run_id=self.db_id,

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -191,8 +191,9 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
         """
         config = self.get_task_args()
 
-        # TODO handle with temporary local qualifications to prevent
-        # needing to call expensive `find_units`
+        # TODO(#773) handle with temporary local qualifications to allow
+        # pushing real exclusionary qualifications after exceeding
+        # maximum_units_per_worker
         if config.allowed_concurrent != 0 or config.maximum_units_per_worker:
             current_units = self.db.find_units(
                 task_run_id=self.db_id,
@@ -238,11 +239,14 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
             is_self_set = map(lambda u: u.worker_id == worker.db_id, unit_set)
             if not any(is_self_set):
                 units += unit_set
+
         # Valid units must be launched and must not be special units (negative indices)
+        # Can use db_status directly rather than polling in the critical path, as in
+        # the worst case we miss the transition from an active to launched unit
         valid_units = [
             u
             for u in units
-            if u.get_status() == AssignmentState.LAUNCHED and u.unit_index >= 0
+            if u.db_status == AssignmentState.LAUNCHED and u.unit_index >= 0
         ]
         logger.debug(f"Found {len(valid_units)} available units")
 

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -244,6 +244,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         """Clear the agent that is assigned to this unit"""
         logger.debug(f"Clearing assigned agent {self.agent_id} from {self}")
         self.db.clear_unit_agent_assignment(self.db_id)
+        self.set_db_status(AssignmentState.LAUNCHED)
         self.get_task_run().clear_reservation(self)
         self.agent_id = None
         self.__agent = None

--- a/mephisto/data_model/unit.py
+++ b/mephisto/data_model/unit.py
@@ -169,7 +169,7 @@ class Unit(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta):
         ), f"{status} not valid Assignment Status, not in {AssignmentState.valid_unit()}"
         if status == self.db_status:
             return
-        logger.debug(f"Updating status for {self} to {status}")
+        logger.debug(f"Updating status for {self} from {self.db_status} to {status}")
         ACTIVE_UNIT_STATUSES.labels(
             status=self.db_status, unit_type=INDEX_TO_TYPE_MAP[self.unit_index]
         ).dec()

--- a/mephisto/operations/client_io_handler.py
+++ b/mephisto/operations/client_io_handler.py
@@ -296,6 +296,12 @@ class ClientIOHandler:
                 f"Onboarding agent {onboarding_id} already submitted or disconnected, "
                 f"but is calling _on_submit_onboarding again"
             )
+            # On resubmit, ensure that the client has the same status
+            agent = live_run.worker_pool.final_onboardings.get(onboarding_id)
+            if agent is not None:
+                live_run.loop_wrap.execute_coro(
+                    live_run.worker_pool.push_status_update(agent)
+                )
             return
         agent = live_run.worker_pool.get_agent_for_id(onboarding_id)
         assert agent is not None, f"Could not find given agent by id {onboarding_id}"

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -103,6 +103,7 @@ class WorkerPool:
         self.agents: Dict[str, "Agent"] = {}
         self.onboarding_agents: Dict[str, "OnboardingAgent"] = {}
         self.onboarding_infos: Dict[str, OnboardingInfo] = {}
+        self.final_onboardings: Dict[str, "OnboardingAgent"] = {}
         # Agent status handling
         self.last_status_check = time.time()
 
@@ -132,6 +133,11 @@ class WorkerPool:
             return self.agents[agent_id]
         elif agent_id in self.onboarding_agents:
             return self.onboarding_agents[agent_id]
+        elif agent_id in self.final_onboardings:
+            logger.debug(
+                f"Found agent id {agent_id} in final_onboardings for get_agent_for_id"
+            )
+            return self.final_onboardings[agent_id]
         return None
 
     async def register_worker(
@@ -516,7 +522,9 @@ class WorkerPool:
                 )
 
                 async def cleanup_onboarding():
+                    onboarding_agent = self.onboarding_agents[onboard_id]
                     del self.onboarding_agents[onboard_id]
+                    self.final_onboardings[onboard_id] = onboarding_agent
                     del self.onboarding_infos[onboard_id]
                     ACTIVE_ONBOARDINGS.dec()
 

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -400,6 +400,14 @@ class WorkerPool:
                         failure_reason=WorkerFailureReasons.NOT_QUALIFIED
                     ).to_dict(),
                 )
+            elif agent.get_status() == AgentState.STATUS_DISCONNECT:
+                # Disconnected agent should get missing response
+                live_run.client_io.enqueue_agent_details(
+                    request_id,
+                    AgentDetails(
+                        failure_reason=WorkerFailureReasons.TASK_MISSING,
+                    ).to_dict(),
+                )
             else:
                 blueprint = live_run.blueprint
                 assert (

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -674,8 +674,7 @@ class WorkerPool:
             if agent.get_status() not in AgentState.complete():
                 agent.update_status(AgentState.STATUS_DISCONNECT)
         for onboarding_agent in self.onboarding_agents.values():
-            if agent.get_status() not in AgentState.complete():
-                onboarding_agent.update_status(AgentState.STATUS_DISCONNECT)
+            onboarding_agent.update_status(AgentState.STATUS_DISCONNECT)
 
     def shutdown(self) -> None:
         """Mark shut down. Handle resource cleanup if necessary"""

--- a/mephisto/utils/metrics.py
+++ b/mephisto/utils/metrics.py
@@ -121,7 +121,7 @@ def start_metrics_server(args: Optional["DictConfig"] = None):
     Future work will extend our metrics logging configuration.
     """
     try:
-        start_http_server(3031)
+        start_http_server(3131)
     except Exception as e:
         logger.exception(
             "Could not launch prometheus metrics client, perhaps a process is already running on 3031? "

--- a/mephisto/utils/metrics.py
+++ b/mephisto/utils/metrics.py
@@ -121,7 +121,7 @@ def start_metrics_server(args: Optional["DictConfig"] = None):
     Future work will extend our metrics logging configuration.
     """
     try:
-        start_http_server(3131)
+        start_http_server(3031)
     except Exception as e:
         logger.exception(
             "Could not launch prometheus metrics client, perhaps a process is already running on 3031? "

--- a/test/core/test_operator.py
+++ b/test/core/test_operator.py
@@ -43,6 +43,7 @@ MOCK_TASK_ARGS = TaskRunArgs(
     task_description="This is a description",
     task_reward=0.3,
     task_tags="1,2,3",
+    submission_timeout=5,
 )
 
 


### PR DESCRIPTION
# Overview
Primarily refactors `Agent` and `OnboardingAgent` to use a new `_AgentBase` shared class, cutting down a ton on the shared code between them. With this, also introduces a functionality in `hide_state` to offload the state of an agent after a `TaskRunner` is complete, after which point the agent should only need its `status`. This reduces the long-term size of what Mephisto keeps in memory over the course of a job.

This PR also includes a number of small minor fixes in `Agent`-related code that were causing other issues, like gradual task throughput declines.

# Details
- `_AgentBase` refactor:
  - Moves most of the shared code from `Agent` and `OnboardingAgent` classes out into the `_AgentBase` class. Generally this counts most of the interaction interface or API for an `Agent` from the perspective of a `TaskRunner`. 
  - Creates a `hide_state` method that offloads agent state to clear after any `TaskRunner` thread is completed. This allows us to retain the agent to track the status on reconnects without leaking too much memory.
- Other fixes
  - `Unit` launches in the `TaskRunner` now properly update the related `Agent` to `STATUS_IN_TASK`
  - Introduces `final_onboardings` dict to the `WorkerPool` to ensure that we can tell an onboarded agent on reconnect what their status was. 
  - Updates the `WorkerPool`'s `reconnect_agent` method to push onboarding agent reconnects to the expected state, not receiving an `agent_id` at all with the correct `AgentDetails` failure reason.
  - Adds `AgentState.STATUS_ACCEPTED` as a valid status to transition from for a return event for `MTurkUnit`s, as if a task is returned after being accepted but before the in-task transition is processed, it should definitely be countable as a return.
  - Changes the `TaskRun`'s `get_valid_units_for_worker` method to not require outbound calls to a crowdprovider via `get_status()`, deferring instead to whatever the local `db_status` is. This value should be updated regularly by the `WorkerPool`, and the performance gains for no longer querying these on the critical path should more than make up for the few times a newly returned task is missed out on being eligible for surfacing here.
  - Adds `assignment_duration_in_seconds` tracking to the `RemoteProcedureTaskRunner` to ensure that the task exits automatically after the maximum duration, if not completed otherwise.
  - Updates the `ClientIOHandler`'s action for a repeated onboarding submission to push the current onboarding agent's status again, as a repeat submission normally would indicate a desync.

# Testing
Local run of an ongoing task, automated testing.