### PR TITLE
Update address for pulling python poetry.

### DIFF
--- a/docs/web/docs/guides/quickstart.md
+++ b/docs/web/docs/guides/quickstart.md
@@ -20,7 +20,7 @@ $ pip install -e .
 
 ```bash
 # install poetry
-$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/main/get-poetry.py | python
+$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 # from the root dir, install Mephisto:
 $ poetry install
 ```


### PR DESCRIPTION
The previous address for python poetry poetry returns a 404.  I updated the instructions to fetch from the correct web address.