### PR TITLE
Update Mephisto 1.0 upgrade guide - sendLiveUpdate

### DIFF
--- a/docs/web/docs/guides/upgrade_to_1/guide.md
+++ b/docs/web/docs/guides/upgrade_to_1/guide.md
@@ -12,7 +12,8 @@ sidebar_position: 1
     npm install --save mephisto-task@2
     npm install --save bootstrap-chat@2 # if applicable
     ```
-3. [Migrate your run scripts](../run_scripts) to use the newly introduced syntax, aimed to reduce boilerplate.
+3. For webapps using `mephisto-task`: Migrate any usage of `sendMessage` in your front-end code to `sendLiveUpdate`.   
+4. [Migrate your run scripts](../run_scripts) to use the newly introduced syntax, aimed to reduce boilerplate.
 
 
 :::info


### PR DESCRIPTION
Since starting with 1.0 we renamed `sendMessage` to `sendLiveUpdate`, update the upgrade guide to mention that.