### PR TITLE
Fixes bug with remoteFunction() not existing in remote_procedure template

### DIFF
--- a/examples/remote_procedure/template/webapp/src/app.jsx
+++ b/examples/remote_procedure/template/webapp/src/app.jsx
@@ -39,12 +39,12 @@ function RemoteProcedureApp() {
     initialTaskData,
     isLoading,
     handleSubmit,
-    remoteFunction,
+    remoteProcedure,
     isOnboarding,
     handleFatalError,
   } = mephistoProps;
 
-  const handleRemoteCall = remoteFunction("handle_with_model");
+  const handleRemoteCall = remoteProcedure("handle_with_model");
 
   if (isOnboarding) {
     // TODO You can use this as an opportunity to display anything you want for


### PR DESCRIPTION
## Summary

In the app.jsx a function named remoteFunction was being extracted from mephistoProps (mephistoProps comes from the mephisto-task package). This function does not seem to exist anymore as seen by the below screenshot:
<img width="1161" alt="template-bug" src="https://user-images.githubusercontent.com/55665282/174390455-42cd380d-73de-4204-a632-d3e2b1a14a3c.png">

I'm pretty sure this function got renamed to remoteProcedure()


## Testing
You can clearly see from the video below, that the template example works now


https://user-images.githubusercontent.com/55665282/174390966-ef8371be-f252-4375-a299-db60924437ad.mov


