### PR TITLE
Update doc links in `mephisto-task` README

### DIFF
--- a/packages/mephisto-task/README.md
+++ b/packages/mephisto-task/README.md
@@ -82,13 +82,15 @@ A single task could have multiple `agentId`s, for example in the case of convers
 
 Usually you'll want to use `agentId` to represent workers in your task code as opposed to `mephistoWorkerId` and `providerWorkerId` which are reserved for more advanced usages.
 
-More details about Agents can be found in the [Mephisto architecture overview docs](https://github.com/facebookresearch/Mephisto/blob/main/docs/architecture_overview.md#agent).
+More details about Agents can be found in the [Mephisto architecture overview docs](https://github.com/facebookresearch/Mephisto/blob/main/docs/web/docs/explanations/architecture_overview.md#agent).
+
+
 
 ### `assignmentId`
 
 An `assignmentId` uniquely represents the portion of the task that a worker will be working on.
 
-More details about Assignments can be found in the [Mephisto architecture overview docs](https://github.com/facebookresearch/Mephisto/blob/main/docs/architecture_overview.md#assignment).
+More details about Assignments can be found in the [Mephisto architecture overview docs](https://github.com/facebookresearch/Mephisto/blob/main/docs/web/docs/explanations/architecture_overview.md#assignment).
 
 ### `initialTaskData`
 


### PR DESCRIPTION
Fixes the broken link issue to the architecture overview docs mentioned in #790 