### PR TITLE
Updates contributing.md with info on pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ We actively welcome your pull requests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
 5. Make sure your code lints.
+    * This can be done by running `pre-commit install`. This will check the if your code is formatted correctly on each commit.
+    * Make sure that pre-commit is installed by following the steps in [this website](https://pre-commit.com/).
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 
 ### Task Contributions


### PR DESCRIPTION
## Summary
There were some issues where my prettier configuration was not matching with what the pre-commit github hook was expecting, so I would often fail the pre-commit / code-style test. 

I first thought the solution to this was to add a prettierrc.json file so that whatever you formatted would match the code-style hook. There are two problems to this approach.

1. I couldn't find the exact configuration that the pre-commit hook would use, so I didn't really know what to put in the prettierrc file.
2. If the pre-commit hook was updated, then the prettierrc would also have to be tediously updated to match.

After some researching, the solution to this was already implemented in this repo, I just didn't realize/notice it. 

If you run `pre-commit-install` it will run the pre-commit / code-style tests on your local code every time you commit. If the code fails, then it prevents the commit from going through, until you `git add` the files that the test updated.

This is clearly the most optimal solution as every commit will have to be pass the pre-commit / code-style before pushing. 

**I added this info to the contributing.md so that it is clear that you should install pre-commit from brew or pip and run pre-commit install.**

## Test Plan
  
https://user-images.githubusercontent.com/55665282/176711185-23acf507-a52f-43f2-87e1-e3b572b0f0b5.mov

The video above shows how files get updated when your commit fails.


## Area for improvement
It might make sense to find a way to automatically install pre-commit when you setup the repo by running `pip install -e .`. If that runs `pip install pre-commit`, then the only command that has to be explicitly ran is `pre-commit install`

This would simplify the setup process a little bit