### PR TITLE
Fix DISCONNECTED agent status leak

### DIFF
--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -281,6 +281,8 @@ class TaskRunner(ABC):
                     if unit_agent is not None and unit_agent.db_id == agent.db_id:
                         logger.debug(f"Clearing {agent} from {unit} due to {e}")
                         unit.clear_assigned_agent()
+                        if agent.get_status() not in AgentState.complete():
+                            agent.update_status(AgentState.STATUS_DISCONNECT)
                 self.cleanup_unit(unit)
             except Exception as e:
                 logger.exception(f"Unhandled exception in unit {unit}", exc_info=True)
@@ -356,6 +358,8 @@ class TaskRunner(ABC):
                         # Must expire the disconnected unit so that
                         # new workers aren't shown it
                         agent.get_unit().expire()
+                        if agent.get_status() not in AgentState.complete():
+                            agent.update_status(AgentState.STATUS_DISCONNECT)
                 self.cleanup_assignment(assignment)
             except Exception as e:
                 logger.exception(


### PR DESCRIPTION
# Overview
After moving to the `await_submit` semantics of `1.0.0`, we successfully closed a number of `Unit`-`Agent` status mismatches. _This_ one however snuck by: timed out agents weren't properly being marked as disconnected. Downstream this led to a few disconnects slowing down and eventually fully stopping the system from running.

# Nitty-gritty details 
When someone actually times out on their task without submitting, Mephisto would release their agent's `TaskRunner` thread, but the `Agent`'s status would still be `in_task` (as an `AgentTimeoutError` doesn't implicitly disconnect the agent). This would lead to an incomplete cleanup, and future attempts to accept the task would hang, eventually clogging up the system entirely. 

The fix is rather simple: if Mephisto exits on an `AbsentAgentError` of any type (therefore ending the `Unit`), before finishing that cleanup we ensure the disconnecting agent is updated to `STATUS_DISCONNECTED`.

# Testing
Can no longer reproduce locally, would like to test under load before merging though. 