### PR TITLE
Adds http:// before launch message url

### DIFF
--- a/mephisto/abstractions/providers/mock/mock_unit.py
+++ b/mephisto/abstractions/providers/mock/mock_unit.py
@@ -49,12 +49,12 @@ class MockUnit(Unit):
         port = task_url.split(":")[1].split("/")[0]
         print(task_url)
         print(
-            f"Mock task launched: localhost:{port} for preview, "
-            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id}"
+            f"Mock task launched: http://localhost:{port} for preview, "
+            f"http://localhost:{port}/?worker_id=x&assignment_id={self.db_id}"
         )
         logger.info(
-            f"Mock task launched: localhost:{port} for preview, "
-            f"localhost:{port}/?worker_id=x&assignment_id={self.db_id} for assignment {self.assignment_id}"
+            f"Mock task launched: http://localhost:{port} for preview, "
+            f"http://localhost:{port}/?worker_id=x&assignment_id={self.db_id} for assignment {self.assignment_id}"
         )
 
         return None


### PR DESCRIPTION
## Overview
### Resolves #828
* Adds http:// before the url that appears when a mock unit is launched. 
* This allows for links to be visited in an easier fashion.

## Video
https://user-images.githubusercontent.com/55665282/179418063-26efe9ca-07b5-4574-a363-0f1416a3ff36.mov


