### PR TITLE
Improves performance of cypress tests

### DIFF
--- a/examples/remote_procedure/mnist/webapp/cypress/e2e/remote_procedure_mnist.cy.js
+++ b/examples/remote_procedure/mnist/webapp/cypress/e2e/remote_procedure_mnist.cy.js
@@ -7,7 +7,6 @@ describe("Loads remote_procedure_mnist", () => {
     });
   });
   it("Loads correct react elements", () => {
-    cy.visit("/");
     cy.get('[data-cy="canvas-container-0"]');
     cy.get('[data-cy="clear-button-0"]');
     cy.get('[data-cy="correct-checkbox-0"]');
@@ -28,7 +27,6 @@ describe("Loads remote_procedure_mnist", () => {
   });
 
   it("Submitting with three corrected annotations", () => {
-    cy.visit("/");
     cy.on("window:alert", (txt) => {
       expect(txt).to.contain("The task has been submitted!");
     });
@@ -47,7 +45,7 @@ describe("Loads remote_procedure_mnist", () => {
       .trigger("mouseup", 150, 220);
 
     // There is a wait statement here because it takes some time for the model to calculate that it is a 4
-    cy.wait(2000);
+    cy.wait(1000);
     cy.get('[data-cy="current-annotation-0"]').should("contain.text", "4");
     cy.get('[data-cy="correct-checkbox-0"]').check();
     cy.get('[data-cy="correct-text-input-0"]').should("not.exist");
@@ -66,7 +64,7 @@ describe("Loads remote_procedure_mnist", () => {
       .trigger("mousedown", 180, 210)
       .trigger("mouseup", 65, 220);
 
-    cy.wait(2000);
+    cy.wait(1000);
     cy.get('[data-cy="current-annotation-1"]').should("contain.text", "3");
     cy.get('[data-cy="correct-checkbox-1"]').check();
     cy.get('[data-cy="correct-text-input-1]').should("not.exist");

--- a/examples/remote_procedure/template/webapp/cypress/e2e/remote_procedure_template.cy.js
+++ b/examples/remote_procedure/template/webapp/cypress/e2e/remote_procedure_template.cy.js
@@ -8,7 +8,6 @@ describe("Loads remote_procedure_template", () => {
   });
 
   it("Loads correct react elements", () => {
-    cy.visit("/");
     cy.get('[data-cy="directions-header"]');
     cy.get('[data-cy="directions-paragraph"]');
     cy.get('[data-cy="query-backend-button"]');
@@ -16,9 +15,6 @@ describe("Loads remote_procedure_template", () => {
   });
 
   it("Submit button not disabled after querying backend four times", () => {
-    cy.visit("/");
-    let currentRequest = 1;
-
     cy.on("window:alert", (txt) => {
       expect(txt).to.contain("this was request");
     });
@@ -51,7 +47,6 @@ describe("Loads remote_procedure_template", () => {
     cy.wait(1000);
     cy.get("@queryBackendButton").should("be.visible");
     cy.get("@queryBackendButton").click();
-    currentRequest += 1;
 
     cy.wait(1000);
     cy.get("@submitButton").should("not.be.disabled");

--- a/examples/remote_procedure/toxicity_detection/webapp/cypress/e2e/remote_procedure_toxicity_detection.cy.js
+++ b/examples/remote_procedure/toxicity_detection/webapp/cypress/e2e/remote_procedure_toxicity_detection.cy.js
@@ -8,7 +8,6 @@ describe("Loads remote_procedure_toxicity_detection", () => {
   });
 
   it("Loads correct react elements", () => {
-    cy.visit("/");
     cy.get('[data-cy="directions-header"]');
     cy.get('[data-cy="directions-paragraph"]');
     cy.get('[data-cy="detection-text-area"]');
@@ -16,7 +15,6 @@ describe("Loads remote_procedure_toxicity_detection", () => {
   });
 
   it("Typing and submitting a toxic statement", () => {
-    cy.visit("/");
     cy.get('[data-cy="detection-text-area"]').as("textArea");
     cy.get('[data-cy="submit-button"]').as("submitButton");
 
@@ -24,7 +22,7 @@ describe("Loads remote_procedure_toxicity_detection", () => {
     cy.get("@submitButton").click();
     cy.get('[data-cy="loading-spinner"]');
     // This timeout is 25000 because the detoxify model takes a good bit of time to run
-    cy.get('[data-cy="toxicity-alert"]', { timeout: 25000 }).as(
+    cy.get('[data-cy="toxicity-alert"]', { timeout: 40000 }).as(
       "toxicityAlert"
     );
     cy.get("@toxicityAlert").contains(
@@ -39,7 +37,6 @@ describe("Loads remote_procedure_toxicity_detection", () => {
         'The task has been submitted! Data: {"toxicity":'
       );
     });
-    cy.visit("/");
     cy.get('[data-cy="detection-text-area"]').as("textArea");
     cy.get('[data-cy="submit-button"]').as("submitButton");
 

--- a/examples/static_react_task/webapp/cypress/e2e/static_react_task.cy.js
+++ b/examples/static_react_task/webapp/cypress/e2e/static_react_task.cy.js
@@ -7,7 +7,6 @@ describe("Loads static_react_task", () => {
     });
   });
   it("Loads correct react elements", () => {
-    cy.visit("/");
     cy.get('[data-cy="directions-container"]');
     cy.get('[data-cy="task-data-text"]');
     cy.get('[data-cy="good-button"]');
@@ -17,7 +16,6 @@ describe("Loads static_react_task", () => {
 
 describe("Submits static_react_task", () => {
   it("Gets request from pressing good button", () => {
-    cy.visit("/");
     cy.intercept({ pathname: "/submit_task" }).as("goodTaskSubmit");
     cy.get('[data-cy="good-button"]').click();
     cy.wait("@goodTaskSubmit").then((interception) => {
@@ -25,8 +23,6 @@ describe("Submits static_react_task", () => {
     });
   });
   it("Shows alert from pressing good button", () => {
-    cy.visit("/");
-
     cy.on("window:alert", (txt) => {
       expect(txt).to.contains(
         'The task has been submitted! Data: {"rating":"good"}'
@@ -36,7 +32,6 @@ describe("Submits static_react_task", () => {
   });
 
   it("Gets request from pressing bad button", () => {
-    cy.visit("/");
     cy.intercept({ pathname: "/submit_task" }).as("badTaskSubmit");
     cy.get('[data-cy="bad-button"]').click();
     cy.wait("@badTaskSubmit").then((interception) => {
@@ -45,7 +40,6 @@ describe("Submits static_react_task", () => {
   });
 
   it("Shows alert from pressing bad button", () => {
-    cy.visit("/");
     cy.on("window:alert", (txt) => {
       expect(txt).to.contains(
         'The task has been submitted! Data: {"rating":"bad"}'


### PR DESCRIPTION
## Overview
There were additional `cy.visit("/")` statements that were present in the cypress tests because I thought that every "it" block had to have `cy.visit("/")` in it. 

This can be a costly command, so I removed the additional `cy.visit("/")` statements in all the tests.

I also increased the timeout to 40,000 ms for the toxicity detection as 25,000 ms was not always long enough for the github action. It would not pass consistently enough. This issue should be fixed now.