### PR TITLE
Replace cli outputs with tables in docs

### DIFF
--- a/docs/web/docs/guides/how_to_use/task_creation/developing_frontends.md
+++ b/docs/web/docs/guides/how_to_use/task_creation/developing_frontends.md
@@ -16,7 +16,7 @@ npm install mephisto-task
 
 The `mephisto-task` project surfaces three React hooks depending on your use case:
 
-1. `useMephisoTask` - Used for static tasks where one-time initial data is enough to power the task. See the example task in `/examples/static_react_task/` for an example project using this hook.
+1. `useMephistoTask` - Used for static tasks where one-time initial data is enough to power the task. See the example task in `/examples/static_react_task/` for an example project using this hook.
 2. `useMephistoLiveTask` - Used for multi-turn, socket-based tasks, such as a dialogue task. See the example task in `/examples/parlai_chat_task_demo/` for an example project using this hook.
 3. `useMephistoRemoteProcedureTask` - Used for static tasks that require access to some remote function on the back-end, for example invoking a back-end model for model-assisted annotation. See the example task in `/examples/remote_procedure/mnist/` for an example project using this hook.
 

--- a/docs/web/docs/guides/tutorials/custom_react.md
+++ b/docs/web/docs/guides/tutorials/custom_react.md
@@ -53,19 +53,29 @@ We'll begin by modifying the `SharedStaticTaskState`'s `static_task_data` attrib
 ```bash 
 $ mephisto wut blueprint=static_react_task static_task_data
 
+
                 Tasks launched from static blueprints need
                 a prebuilt javascript bundle containing the task. We suggest building
                 with our provided useMephistoTask hook.
             
 
+
 Additional SharedTaskState args from SharedStaticTaskState, which may be configured in your run script
-dest              type                      default    help                                     choices    required
-----------------  ------------------------  ---------  ---------------------------------------  ---------  ----------
-static_task_data  Iterable[Dict[str, Any]]  []         List or generator that returns dicts of  None       False
-                                                       task data. Generators can be used for
-                                                       tasks with lengths that aren't known at
-                                                       the start of a run, or are otherwise
-                                                       determined during the run.
+                                                                                             
+                              Additional Shared TaskState args                               
+╭──────────────────┬────────────────┬─────────┬────────────────────────┬─────────┬──────────╮
+│ dest             │ type           │ default │ help                   │ choices │ required │
+├──────────────────┼────────────────┼─────────┼────────────────────────┼─────────┼──────────┤
+│ static_task_data │ Iterable[Dict] │ []      │ List or generator that │ None    │ False    │
+│                  │                │         │ returns dicts of task  │         │          │
+│                  │                │         │ data. Generators can   │         │          │
+│                  │                │         │ be used for tasks with │         │          │
+│                  │                │         │ lengths that aren't    │         │          │
+│                  │                │         │ known at the start of  │         │          │
+│                  │                │         │ a run, or are          │         │          │
+│                  │                │         │ otherwise determined   │         │          │
+│                  │                │         │ during the run.        │         │          │
+╰──────────────────┴────────────────┴─────────┴────────────────────────┴─────────┴──────────╯
 ```
 This field replaces using the `csv_file` used in the previous tutorial, allowing our run script to specify data directly. React tasks can be run off of `.csv` files as well, if you'd prefer.
 

--- a/docs/web/docs/guides/tutorials/first_task.md
+++ b/docs/web/docs/guides/tutorials/first_task.md
@@ -99,42 +99,90 @@ Mephisto configuration options can be inherited from a number of different locat
 ```bash
 $ mephisto wut architect=local
 
-dest                type    default    help                                    choices    required
-------------------  ------  ---------  --------------------------------------  ---------  ----------
-server_type         str     node       None                                    None       False
-server_source_path  str     ???        Optional path to a prepared server      None       False
-                                       directory containing everything needed
-                                       to run a server of the given type.
-                                       Overrides server type.
-hostname            str     localhost  Addressible location of the server      None       False
-port                str     3000       Port to launch the server on            None       False
+                                     Architect Arguments                                     
+╭────────────────────┬──────┬───────────┬──────────────────────────────┬─────────┬──────────╮
+│ dest               │ type │ default   │ help                         │ choices │ required │
+├────────────────────┼──────┼───────────┼──────────────────────────────┼─────────┼──────────┤
+│ server_type        │ str  │ node      │ None                         │ None    │ False    │
+├────────────────────┼──────┼───────────┼──────────────────────────────┼─────────┼──────────┤
+│ server_source_path │ str  │ ???       │ Optional path to a prepared  │ None    │ False    │
+│                    │      │           │ server directory containing  │         │          │
+│                    │      │           │ everything needed to run a   │         │          │
+│                    │      │           │ server of the given type.    │         │          │
+│                    │      │           │ Overrides server type.       │         │          │
+├────────────────────┼──────┼───────────┼──────────────────────────────┼─────────┼──────────┤
+│ hostname           │ str  │ localhost │ Addressible location of the  │ None    │ False    │
+│                    │      │           │ server                       │         │          │
+├────────────────────┼──────┼───────────┼──────────────────────────────┼─────────┼──────────┤
+│ port               │ str  │ 3000      │ Port to launch the server on │ None    │ False    │
+╰────────────────────┴──────┴───────────┴──────────────────────────────┴─────────┴──────────╯
 ```
 
 **For the blueprint:**
 ```bash
 $ mephisto wut blueprint=static_task
-Tasks launched from static blueprints need a source html file to display to workers, as well as a csv containing values that will be inserted into templates in the html. 
-dest                      type     default    help                                      choices    required
-------------------------  -------  ---------  ----------------------------------------  ---------  ----------
-block_qualification       str      ???        Specify the name of a qualification used  None       False
-                                              to soft block workers.
-onboarding_qualification  str      ???        Specify the name of a qualification used  None       False
-                                              to block workers who fail onboarding,
-                                              Empty will skip onboarding.
-units_per_assignment      int      1          How many workers you want to do each      None       False
-                                              assignment
-extra_source_dir          str      ???        Optional path to sources that the HTML    None       False
-                                              may refer to (such as
-                                              images/video/css/scripts)
-data_json                 str      ???        Path to JSON file containing task data    None       False
-data_jsonl                str      ???        Path to JSON-L file containing task data  None       False
-data_csv                  str      ???        Path to csv file containing task data     None       False
-task_source               str      ???        Path to source HTML file for the task     None       True
-                                              being run
-preview_source            unknown  ???        Optional path to source HTML file to      None       False
-                                              preview the task
-onboarding_source         unknown  ???        Optional path to source HTML file to      None       False
-                                              onboarding the task
+Tasks launched from static blueprints need a source html file to display to workers, 
+as well as a csv containing values that will be inserted into templates in the html. 
+
+                                     Blueprint Arguments                                     
+╭───────────────────┬─────────┬────────────────────┬───────────────────┬─────────┬──────────╮
+│ dest              │ type    │ default            │ help              │ choices │ required │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ block_qualificat… │ str     │ ???                │ Specify the name  │ None    │ False    │
+│                   │         │                    │ of a              │         │          │
+│                   │         │                    │ qualification     │         │          │
+│                   │         │                    │ used to soft      │         │          │
+│                   │         │                    │ block workers.    │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ tips_location     │ str     │ /Users/etesam1/Do… │ Path to csv file  │ None    │ False    │
+│                   │         │                    │ containing tips   │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ onboarding_quali… │ str     │ ???                │ Specify the name  │ None    │ False    │
+│                   │         │                    │ of a              │         │          │
+│                   │         │                    │ qualification     │         │          │
+│                   │         │                    │ used to block     │         │          │
+│                   │         │                    │ workers who fail  │         │          │
+│                   │         │                    │ onboarding, Empty │         │          │
+│                   │         │                    │ will skip         │         │          │
+│                   │         │                    │ onboarding.       │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ units_per_assign… │ int     │ 1                  │ How many workers  │ None    │ False    │
+│                   │         │                    │ you want to do    │         │          │
+│                   │         │                    │ each assignment   │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ extra_source_dir  │ str     │ ???                │ Optional path to  │ None    │ False    │
+│                   │         │                    │ sources that the  │         │          │
+│                   │         │                    │ HTML may refer to │         │          │
+│                   │         │                    │ (such as          │         │          │
+│                   │         │                    │ images/video/css… │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ data_json         │ str     │ ???                │ Path to JSON file │ None    │ False    │
+│                   │         │                    │ containing task   │         │          │
+│                   │         │                    │ data              │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ data_jsonl        │ str     │ ???                │ Path to JSON-L    │ None    │ False    │
+│                   │         │                    │ file containing   │         │          │
+│                   │         │                    │ task data         │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ data_csv          │ str     │ ???                │ Path to csv file  │ None    │ False    │
+│                   │         │                    │ containing task   │         │          │
+│                   │         │                    │ data              │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ task_source       │ str     │ ???                │ Path to source    │ None    │ True     │
+│                   │         │                    │ HTML file for the │         │          │
+│                   │         │                    │ task being run    │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ preview_source    │ unknown │ ???                │ Optional path to  │ None    │ False    │
+│                   │         │                    │ source HTML file  │         │          │
+│                   │         │                    │ to preview the    │         │          │
+│                   │         │                    │ task              │         │          │
+├───────────────────┼─────────┼────────────────────┼───────────────────┼─────────┼──────────┤
+│ onboarding_source │ unknown │ ???                │ Optional path to  │ None    │ False    │
+│                   │         │                    │ source HTML file  │         │          │
+│                   │         │                    │ to onboarding the │         │          │
+│                   │         │                    │ task              │         │          │
+╰───────────────────┴─────────┴────────────────────┴───────────────────┴─────────┴──────────╯
+
 Additional SharedTaskState args from SharedStaticTaskState
 # ... snipped ...
 ```


### PR DESCRIPTION
## Overview

I updated some of the cli outputs in the docs as they will be outdated once `improve-cli-for-other-mephisto-commands` gets merged in.

## Images
### Architect table
![architect-table](https://user-images.githubusercontent.com/55665282/179616878-7062a434-b3b4-46d6-945c-f90488170374.png)

### Blueprint table
![blueprint-table](https://user-images.githubusercontent.com/55665282/179616910-02267432-d0be-4fe2-be53-a8720b31ede4.png)

### Static React Task Blueprint Table
![static_react_task_blueprint](https://user-images.githubusercontent.com/55665282/179616939-3a4ee7db-ff05-4b6d-9486-440d6df8aca0.png)

