### PR TITLE
Improves clarity of setting data folder in docs

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,0 @@
-## Data
-The data folder is populated with any data that the Mephisto system is using to keep state and store results.
-
-This is the default location for such storage, however the location is configured in `~/.mephisto/config.yml`

--- a/docs/web/docs/guides/quickstart.md
+++ b/docs/web/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ Now that you have Mephisto installed, you should have access to the `mephisto` C
 
 Let's use this CLI tool to set up a data directory via the `mephisto config` command. The data directory is where the results of your crowdsourcing tasks will be stored.
 
-The below command expects that you have created a folder named "mephisto-data" at your home directory and a folder named "data" inside of it.
+The command below expects that you have created a folder named "mephisto-data" at your home directory and a folder named "data" inside of it.
 
 ```bash
 $ mephisto config core.main_data_directory ~/mephisto-data/data

--- a/docs/web/docs/guides/quickstart.md
+++ b/docs/web/docs/guides/quickstart.md
@@ -33,8 +33,10 @@ Now that you have Mephisto installed, you should have access to the `mephisto` C
 
 Let's use this CLI tool to set up a data directory via the `mephisto config` command. The data directory is where the results of your crowdsourcing tasks will be stored.
 
+The below command expects that you have created a folder named "mephisto-data" at your home directory and a folder named "data" inside of it.
+
 ```bash
-$ mephisto config core.main_data_directory ~/Mephisto/data
+$ mephisto config core.main_data_directory ~/mephisto-data/data
 ```
 
 Check that everything is set up correctly!


### PR DESCRIPTION
## Summary
### Resolves #835 
* Deletes the data folder in the repo as the data directory should be external.
* Adds an extra sentence to give more clarity on what should be done before running the command.

## Screenshot

![data-dir-update](https://user-images.githubusercontent.com/55665282/179620993-2ab20df5-31aa-48e0-bd72-063f5306bb7e.png)

