### PR TITLE
Fixing cli bugs with mephisto web and mephisto review

### DIFF
--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -15,7 +15,6 @@ from rich_click import RichCommand, RichGroup
 from rich.markdown import Markdown
 
 
-# @click.group(cls=DefaultGroup, default="web", default_if_no_args=True)
 @click.group(cls=RichGroup)
 def cli():
     """[deep_sky_blue4]Bring your research ideas to life

--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -32,7 +32,7 @@ click.rich_click.ERRORS_EPILOGUE = (
 )
 
 
-@cli.command("web")
+@cli.command("web", cls=RichCommand)
 def web():
     """Launch a local webserver with the Mephisto UI"""
     from mephisto.client.full.server import app
@@ -40,7 +40,7 @@ def web():
     app.run(debug=False)
 
 
-@cli.command("config")
+@cli.command("config", cls=RichCommand)
 @click.argument("identifier", type=(str), default=None, required=False)
 @click.argument("value", type=(str), default=None, required=False)
 def config(identifier, value):
@@ -72,7 +72,10 @@ def config(identifier, value):
         print(f"[green]{identifier} succesfully updated to: {value}[/green]")
 
 
-@cli.command("review")
+@cli.command(
+    "review",
+    cls=RichCommand,
+)
 @click.argument(
     "review_app_dir",
     type=click.Path(exists=True),
@@ -132,7 +135,7 @@ def review(
     )
 
 
-@cli.command("check")
+@cli.command("check", cls=RichCommand)
 def check():
     """Checks that mephisto is setup correctly"""
     from mephisto.abstractions.databases.local_database import LocalMephistoDB
@@ -148,7 +151,7 @@ def check():
     print("\n[green]Mephisto seems to be set up correctly.[/green]\n")
 
 
-@cli.command("requesters")
+@cli.command("requesters", cls=RichCommand)
 def list_requesters():
     """Lists all registered requesters"""
     from mephisto.abstractions.databases.local_database import LocalMephistoDB
@@ -168,7 +171,9 @@ def list_requesters():
         print("[red]No requesters found[/red]")
 
 
-@cli.command("register", context_settings={"ignore_unknown_options": True})
+@cli.command(
+    "register", cls=RichCommand, context_settings={"ignore_unknown_options": True}
+)
 @click.argument("args", nargs=-1)
 def register_provider(args):
     """Register a requester with a crowd provider"""
@@ -424,7 +429,9 @@ def get_help_arguments(args):
             console.print(state_args_table)
 
 
-@cli.command("metrics", context_settings={"ignore_unknown_options": True})
+@cli.command(
+    "metrics", cls=RichCommand, context_settings={"ignore_unknown_options": True}
+)
 @click.argument("args", nargs=-1)
 def metrics_cli(args):
     from mephisto.utils.metrics import (

--- a/mephisto/client/cli.py
+++ b/mephisto/client/cli.py
@@ -34,9 +34,9 @@ click.rich_click.ERRORS_EPILOGUE = (
 @cli.command("web", cls=RichCommand)
 def web():
     """Launch a local webserver with the Mephisto UI"""
-    from mephisto.client.full.server import app
+    from mephisto.client.full.server import get_app
 
-    app.run(debug=False)
+    get_app().run(debug=False)
 
 
 @cli.command("config", cls=RichCommand)

--- a/mephisto/client/full/server.py
+++ b/mephisto/client/full/server.py
@@ -15,7 +15,7 @@ import atexit
 import signal
 
 
-def main():
+def get_app():
     app = Flask(
         __name__, static_url_path="/static", static_folder="webapp/build/static"
     )
@@ -57,7 +57,4 @@ def main():
 
     atexit.register(cleanup_resources)
     signal.signal(signal.SIGINT, cleanup_resources)
-
-
-if __name__ == "__main__":
-    main()
+    return app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ hydra-core = "^1.1.0"
 tqdm = "^4.50.2"
 websockets = "^10.1"
 pyyaml = "^5.4.0"
+markupsafe = "2.0.1"
 
 # [tool.poetry.group.worker_addons.dependencies]
 detoxify = "^0.5.0"


### PR DESCRIPTION
## Overview
Currently running `mephisto review` and `mephisto web` will give you the following
```bash
Traceback (most recent call last):
  File "/Users/etesam1/Documents/Mephisto/venv/bin/mephisto", line 8, in <module>
    sys.exit(cli())
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/rich_click/rich_group.py", line 21, in main
    rv = super().main(*args, standalone_mode=False, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/mephisto/client/cli.py", line 104, in review
    from mephisto.client.review.review_server import run
  File "/Users/etesam1/Documents/Mephisto/mephisto/client/review/review_server.py", line 7, in <module>
    from flask import Flask, Blueprint, send_file, jsonify, request  # type: ignore
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/markupsafe/__init__.py)
```

After searching online, this can be fixed by setting markupsafe = "2.0.1", which I did in the `pyproject.toml`

However, running then `mephisto web` gives this error: 

```bash
Traceback (most recent call last):
  File "/Users/etesam1/Documents/Mephisto/venv/bin/mephisto", line 8, in <module>
    sys.exit(cli())
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/rich_click/rich_group.py", line 21, in main
    rv = super().main(*args, standalone_mode=False, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/etesam1/Documents/Mephisto/venv/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/etesam1/Documents/Mephisto/mephisto/client/cli.py", line 37, in web
    from mephisto.client.full.server import app
ImportError: cannot import name 'app' from 'mephisto.client.full.server' (/Users/etesam1/Documents/Mephisto/mephisto/client/full/server.py)
```

I'm not exactly sure about this error
