### PR TITLE
Add path filter

### DIFF
--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -5,7 +5,56 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step
+    outputs:
+      static_react_task: ${{ steps.filter.outputs.static_react_task }}
+      static_react_task_with_tips: ${{ steps.filter.outputs.static_react_task_with_tips }}
+      mnist: ${{ steps.filter.outputs.mnist }}
+      template: ${{ steps.filter.outputs.template }}
+      toxicity_detection: ${{ steps.filter.outputs.toxicity_detection }}
+      abstractions: ${{ steps.filter.outputs.abstractions }}
+      data_model: ${{ steps.filter.outputs.data_model }}
+      operations: ${{ steps.filter.outputs.operations }}
+      tools: ${{ steps.filter.outputs.tools }}
+      mephisto-task: ${{ steps.filter.outputs.mephisto-task }}
+      mephisto-worker-addons: ${{ steps.filter.outputs.mephisto-worker-addons }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            static_react_task:
+              - 'examples/static_react_task/**'
+            static_react_task_with_tips:
+              - 'examples/static_react_task_with_tips/**'
+            mnist:
+              - 'examples/remote_procedure/mnist/**'
+            template:
+              - 'examples/remote_procedure/template/**'
+            toxicity_detection:
+              - 'examples/remote_procedure/toxicity_detection/**'
+            abstractions:
+              - 'mephisto/abstractions/**'
+            data_model:
+              - 'mephisto/data_model/**'
+            operations:
+              - 'mephisto/operations/**'
+            tools:
+              - 'mephisto/tools/**'
+            mephisto-task:
+              - 'packages/mephisto-task/src/**'
+            mephisto-worker-addons:
+              - 'packages/mephisto-worker-addons/src/**'
+
   static-react-task:
+    needs: changes
+    if: ${{ (needs.changes.outputs.static_react_task == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
     runs-on: ubuntu-latest
     steps:
       - name: 🔀 Checking out repo
@@ -48,8 +97,9 @@ jobs:
           headless: true
 
   remote_procedure_template:
+    needs: changes
+    if: ${{ (needs.changes.outputs.template == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
     runs-on: ubuntu-latest
-
     steps:
       - name: 🔀 Checking out repo
         uses: actions/checkout@v2
@@ -91,8 +141,9 @@ jobs:
           headless: true
 
   remote_procedure_mnist:
+    needs: changes
+    if: ${{ (needs.changes.outputs.mnist == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
     runs-on: ubuntu-latest
-
     steps:
       - name: 🔀 Checking out repo
         uses: actions/checkout@v2
@@ -136,8 +187,9 @@ jobs:
           headless: true
 
   remote_procedure_toxicity_detection:
+    needs: changes
+    if: ${{ (needs.changes.outputs.toxicity_detection == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
     runs-on: ubuntu-latest
-
     steps:
       - name: 🔀 Checking out repo
         uses: actions/checkout@v2
@@ -179,8 +231,9 @@ jobs:
           headless: true
 
   static_react_task_with_tips:
+    needs: changes
+    if: ${{ (needs.changes.outputs.static_react_task_with_tips == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.mephisto-worker-addons == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
     runs-on: ubuntu-latest
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: 🔀 Checking out repo
         uses: actions/checkout@v2

--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -142,7 +142,7 @@ jobs:
 
   remote_procedure_mnist:
     needs: changes
-    if: ${{ (needs.changes.outputs.mnist == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
+    if: ${{ (needs.changes.outputs.mnist == 'true') || (needs.changes.outputs.mephisto-task == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: 🔀 Checking out repo
@@ -188,7 +188,7 @@ jobs:
 
   remote_procedure_toxicity_detection:
     needs: changes
-    if: ${{ (needs.changes.outputs.toxicity_detection == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
+    if: ${{ (needs.changes.outputs.toxicity_detection == 'true') || (needs.changes.outputs.mephisto-task == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: 🔀 Checking out repo

--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
 
 jobs:
+  # This job is made to setup path filtering, learn more about it here: https://github.com/facebookresearch/Mephisto/pull/857
   changes:
     runs-on: ubuntu-latest
-    # Set job outputs to values from filter step
+    # Set job outputs to values from filters step below
     outputs:
       static_react_task: ${{ steps.filter.outputs.static_react_task }}
       static_react_task_with_tips: ${{ steps.filter.outputs.static_react_task_with_tips }}
@@ -21,7 +22,6 @@ jobs:
       mephisto-task: ${{ steps.filter.outputs.mephisto-task }}
       mephisto-worker-addons: ${{ steps.filter.outputs.mephisto-worker-addons }}
     steps:
-      # For pull requests it's not necessary to checkout the code
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -52,6 +52,7 @@ jobs:
             mephisto-worker-addons:
               - 'packages/mephisto-worker-addons/src/**'
 
+  # Learn more about this test here: https://github.com/facebookresearch/Mephisto/pull/795
   static-react-task:
     needs: changes
     if: ${{ (needs.changes.outputs.static_react_task == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
@@ -96,6 +97,7 @@ jobs:
           command-prefix: yarn dlx
           headless: true
 
+  # Learn more about the remote_procedure_tests here: https://github.com/facebookresearch/Mephisto/pull/800
   remote_procedure_template:
     needs: changes
     if: ${{ (needs.changes.outputs.template == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}
@@ -230,6 +232,7 @@ jobs:
           command-prefix: yarn dlx
           headless: true
 
+  # Learn more about this test here: https://github.com/facebookresearch/Mephisto/pull/833
   static_react_task_with_tips:
     needs: changes
     if: ${{ (needs.changes.outputs.static_react_task_with_tips == 'true') || (needs.changes.outputs.mephisto-task == 'true') || (needs.changes.outputs.mephisto-worker-addons == 'true') || (needs.changes.outputs.abstractions == 'true') || (needs.changes.outputs.data_model == 'true') || (needs.changes.outputs.operations == 'true') || (needs.changes.outputs.tools == 'true')}}

--- a/examples/static_react_task/webapp/src/css/style.css
+++ b/examples/static_react_task/webapp/src/css/style.css
@@ -2,5 +2,4 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- * touch
  */

--- a/examples/static_react_task/webapp/src/css/style.css
+++ b/examples/static_react_task/webapp/src/css/style.css
@@ -2,4 +2,5 @@
  * Copyright (c) Facebook, Inc. and its affiliates.
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ * touch
  */


### PR DESCRIPTION
## Overview
* Adds path filtering on the job level to allow for jobs to be skipped if certain files are not changed.

![github-actions-architecture](https://user-images.githubusercontent.com/55665282/180323201-7a2c311a-c21d-478e-b9ce-3803556d778b.png)

The base branch is looked at(in this case `add-tests-to-tips-example`) to determine what files are changed.

As commit [62faad8](https://github.com/facebookresearch/Mephisto/pull/857/commits/62faad800a4a68dfbdecc124f369138217877331) updates a file in the static_react_task folder, the static_react_task test gets ran and the others don't.
<img width="834" alt="tests-being-ran" src="https://user-images.githubusercontent.com/55665282/180323750-8f62f85f-a0cf-4b4c-bb9b-8ea1b28cb91c.png">

