### PR TITLE
Make `self.metadata` backward-compatible

### DIFF
--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -60,7 +60,10 @@ class ParlAIChatAgentState(AgentState):
             if 'metadata' in state:
                 self.metadata = _AgentStateMetadata(**state["metadata"])
             elif 'times' in state:
-                self.metadata = _AgentStateMetadata(start_time=state['times']['start_time'], end_time=state['times']['end_time'])
+                self.metadata = _AgentStateMetadata(
+                    start_time=state['times']['start_time'],
+                    end_time=state['times']['end_time'],
+                )
             else:
                 self.meatadata = _AgentStateMetadata()
 

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -57,15 +57,15 @@ class ParlAIChatAgentState(AgentState):
             self.messages = state["outputs"]["messages"]
             self.init_data = state["inputs"]
             self.final_submission = state["outputs"].get("final_submission")
-            if 'metadata' in state:
+            if "metadata" in state:
                 self.metadata = _AgentStateMetadata(**state["metadata"])
-            elif 'times' in state:
+            elif "times" in state:
                 self.metadata = _AgentStateMetadata(
-                    start_time=state['times']['start_time'],
-                    end_time=state['times']['end_time'],
+                    start_time=state["times"]["start_time"],
+                    end_time=state["times"]["end_time"],
                 )
             else:
-                self.meatadata = _AgentStateMetadata()
+                self.metadata = _AgentStateMetadata()
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict with the messages of this agent"""

--- a/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
+++ b/mephisto/abstractions/blueprints/parlai_chat/parlai_chat_agent_state.py
@@ -57,7 +57,12 @@ class ParlAIChatAgentState(AgentState):
             self.messages = state["outputs"]["messages"]
             self.init_data = state["inputs"]
             self.final_submission = state["outputs"].get("final_submission")
-            self.metadata = _AgentStateMetadata(**state["metadata"])
+            if 'metadata' in state:
+                self.metadata = _AgentStateMetadata(**state["metadata"])
+            elif 'times' in state:
+                self.metadata = _AgentStateMetadata(start_time=state['times']['start_time'], end_time=state['times']['end_time'])
+            else:
+                self.meatadata = _AgentStateMetadata()
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict with the messages of this agent"""


### PR DESCRIPTION
This patch makes `self.metadata` in `parlai_chat_agent_state` backward-compatible by adding fallback options when the `metadata` field is not present in the state.