### PR TITLE
Update searchbar colors

### DIFF
--- a/docs/web/docusaurus.config.js
+++ b/docs/web/docusaurus.config.js
@@ -50,7 +50,6 @@ const config = {
         apiKey: "ac51a5b25842fad8a3a7b1f384496bf9",
 
         indexName: "mephisto",
-        contextualSearch: false,
         searchPagePath: false,
       },
       navbar: {

--- a/docs/web/src/css/custom.css
+++ b/docs/web/src/css/custom.css
@@ -118,6 +118,9 @@ h6 {
 }
 
 @media (max-width: 750px) {
+  .DocSearch-Container {
+    position: fixed !important;
+  }
   .DocSearch-Modal {
     margin: 60px 0 !important;
   }

--- a/docs/web/src/css/custom.css
+++ b/docs/web/src/css/custom.css
@@ -23,6 +23,8 @@
   --mephisto-alt-purple: #f0ebf5;
   --mephisto-alt-orange: #fbd6b7;
   --mephisto-alt-yellow: #ffde89;
+  --docsearch-primary-color: var(--ifm-color-primary-darkest) !important;
+  --docsearch-logo-color: var(--ifm-color-primary) !important;
 }
 
 .docusaurus-highlight-code-line {
@@ -119,14 +121,7 @@ h6 {
   .DocSearch-Modal {
     margin: 60px 0 !important;
   }
-}
-
-/*
-  This hides the text that allows you to see all results
-  As of now when you try to see all results it takes you to a separate page
-  This page has a searchbar, but no options show.
-  That is why it is being hidden.
-*/
-.DocSearch-HitsFooter {
-  display: none !important;
+  .DocSearch-Dropdown {
+    padding-bottom: 20px !important;
+  }
 }


### PR DESCRIPTION
## Overview
* Made the algolia search conform to the Mephisto theme
* Fixed issue with contextualSearch making the search bar at the search route not getting any results.
  * I had to delete the search index in the algolia search dashboard.
  * Then I had to crawl the webpage in the algolia crawler(this also recreates the index)
  * I don't know why this decided to work today, given that I tried these two steps multiple times yesterday, but 🤷‍♂️
* Fixed resizing issue with algolia search 
  * On the main page there is this **bug**:

  * https://user-images.githubusercontent.com/55665282/181078313-ab9bc6ea-f7b0-46ed-8888-b8e8a32bce96.mov
  * This has to do with the fact that the mobile version of the search modal has `position: absolute` instead of `position: fixed` for some reason
    * More specifically, the mobile version of the search modal does not account for the user scrolling the page
  * This seems to be a widespread issue as other documentation pages have not included this fix.
    * This is the published docusaurus page as of now:

    *  https://user-images.githubusercontent.com/55665282/181078946-0ae7fecb-8384-4766-a2c0-7083c27e00ad.mov


## Video
https://user-images.githubusercontent.com/55665282/181077258-a46d42d2-7a1d-45e3-b27d-e8a0056966bc.mov

## Resolves #862 
