### PR TITLE
fix breaks in create_validation_function for screening units

### DIFF
--- a/mephisto/abstractions/blueprints/mixins/screen_task_required.py
+++ b/mephisto/abstractions/blueprints/mixins/screen_task_required.py
@@ -217,7 +217,7 @@ class ScreenTaskRequired(BlueprintMixin):
                 args.blueprint.max_screening_units == 0
                 and agent.get_worker().is_qualified(passed_qualification_name)
             ):
-                return
+                return  # Do not run validation if running with no screening_data_factory and worker is qualified
             validation_result = screen_unit(unit)
             if validation_result is True:
                 agent.get_worker().grant_qualification(passed_qualification_name)

--- a/mephisto/abstractions/blueprints/mixins/screen_task_required.py
+++ b/mephisto/abstractions/blueprints/mixins/screen_task_required.py
@@ -205,13 +205,16 @@ class ScreenTaskRequired(BlueprintMixin):
         failed_qualification_name = args.blueprint.block_qualification
 
         def _wrapped_validate(unit):
-            if unit.unit_index >= 0:
+            if args.blueprint.max_screening_units > 0 and unit.unit_index >= 0:
                 return  # We only run validation on the validatable units
-
             agent = unit.get_assigned_agent()
             if agent is None:
                 return  # Cannot validate a unit with no agent
-
+            if (
+                args.blueprint.max_screening_units == 0
+                and agent.get_worker().is_qualified(passed_qualification_name)
+            ):
+                return
             validation_result = screen_unit(unit)
             if validation_result is True:
                 agent.get_worker().grant_qualification(passed_qualification_name)

--- a/mephisto/abstractions/blueprints/mixins/screen_task_required.py
+++ b/mephisto/abstractions/blueprints/mixins/screen_task_required.py
@@ -193,7 +193,7 @@ class ScreenTaskRequired(BlueprintMixin):
                 self.screening_units_launched += 1
                 return data
         except StopIteration:
-            return None  # No screening units left...x
+            return None  # No screening units left...
 
     @classmethod
     def create_validation_function(

--- a/mephisto/abstractions/blueprints/mixins/screen_task_required.py
+++ b/mephisto/abstractions/blueprints/mixins/screen_task_required.py
@@ -168,6 +168,9 @@ class ScreenTaskRequired(BlueprintMixin):
                 "Must provide a generator function to SharedTaskState.screening_data_factory if "
                 "you want to generate screening tasks on the fly, or False if you can screen on any task "
             )
+            assert(max_screening_units > 0), "max_screening_units must be greater than zero if using a screening_data_factory"
+        else:
+            assert(max_screening_units == 0), "max_screening_units must be zero if not using a screening_data_factory"
 
     def worker_needs_screening(self, worker: "Worker") -> bool:
         """Workers that are able to access the task (not blocked) but are not passed need qualification"""
@@ -190,7 +193,7 @@ class ScreenTaskRequired(BlueprintMixin):
                 self.screening_units_launched += 1
                 return data
         except StopIteration:
-            return None  # No screening units left...
+            return None  # No screening units left...x
 
     @classmethod
     def create_validation_function(

--- a/mephisto/abstractions/blueprints/mixins/screen_task_required.py
+++ b/mephisto/abstractions/blueprints/mixins/screen_task_required.py
@@ -168,9 +168,13 @@ class ScreenTaskRequired(BlueprintMixin):
                 "Must provide a generator function to SharedTaskState.screening_data_factory if "
                 "you want to generate screening tasks on the fly, or False if you can screen on any task "
             )
-            assert(max_screening_units > 0), "max_screening_units must be greater than zero if using a screening_data_factory"
+            assert (
+                max_screening_units > 0
+            ), "max_screening_units must be greater than zero if using a screening_data_factory"
         else:
-            assert(max_screening_units == 0), "max_screening_units must be zero if not using a screening_data_factory"
+            assert (
+                max_screening_units == 0
+            ), "max_screening_units must be zero if not using a screening_data_factory"
 
     def worker_needs_screening(self, worker: "Worker") -> bool:
         """Workers that are able to access the task (not blocked) but are not passed need qualification"""
@@ -217,7 +221,7 @@ class ScreenTaskRequired(BlueprintMixin):
                 args.blueprint.max_screening_units == 0
                 and agent.get_worker().is_qualified(passed_qualification_name)
             ):
-                return  # Do not run validation if running with no screening_data_factory and worker is qualified
+                return  # Do not run validation if screening with regular tasks and worker is already qualified
             validation_result = screen_unit(unit)
             if validation_result is True:
                 agent.get_worker().grant_qualification(passed_qualification_name)


### PR DESCRIPTION
Per offline discussions, adding additional checks to use max_screening_units=0 as a way to denote screening on real data