### PR TITLE
Creates a readme for simple_static_task

### DIFF
--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -1,6 +1,8 @@
 name: cypress-end-to-end-tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   push:
     branches: [main]
-
+    paths-ignore:
+      - "**.md"
 jobs:
   # This job is made to setup path filtering, learn more about it here: https://github.com/facebookresearch/Mephisto/pull/857
   changes:

--- a/examples/simple_static_task/README.md
+++ b/examples/simple_static_task/README.md
@@ -1,0 +1,47 @@
+# Simple Static Task
+This example script is to demonstrate how to launch a simple task using a html file. The "static" nature of this task means that all of the content required for a worker to complete the task must be set before the task is launched, and must be able to be sent to the app upon initialization.
+
+This specific example can be run with:
+```console
+python static_test_script.py
+```
+
+and can additionally be launched with an onboarding step by specifying an onboarding qualification:
+
+```console
+python static_run_with_onboarding.py
+```
+
+## Submit button customization
+### Hide the submit button 
+Writing the markup below in `demo_task.html` will allow you to hide the submit button.
+
+```html
+<script>
+  window._MEPHISTO_CONFIG_.set("HIDE_SUBMIT_BUTTON", true)
+</script>
+```
+
+You can get window properties as such:
+```html
+<script>
+  window._MEPHISTO_CONFIG_.get("HIDE_SUBMIT_BUTTON")
+</script>
+```
+
+
+## Testing
+To run tests locally you should first launch the task as follows:
+
+```bash
+python static_test_script.py
+```
+This will run the task.
+
+Then go into the `mephisto/abstractions/blueprints/static_html_task/source` and run 
+```console
+npm run test
+``` 
+to open cypress.
+
+Select the Chrome browser and click on the one spec that shows up to run the tests.

--- a/examples/static_react_task/README.md
+++ b/examples/static_react_task/README.md
@@ -130,6 +130,6 @@ python run_task.py mephisto.task.post_install_script=link_mephisto_task.sh mephi
 ```
 This will run the task and make sure to link the `mephisto-task` package with the local one. 
 
-Also make sure that the baseUrl property in the cypress.config.js matches one of the urls that are outputted from the run_task.py script.
+Then you can run cypress by going into the webapp directory and running `npm run test`. This should open the cypress app. 
 
-Then you can run cypress by going into the webapp directory and running `npm run test`. This should open the cypress app. It should be self-explanatory from this point on.
+Click the Chrome browser and select a spec to run some tests.

--- a/mephisto/abstractions/blueprints/static_html_task/README.md
+++ b/mephisto/abstractions/blueprints/static_html_task/README.md
@@ -1,4 +1,5 @@
 # `StaticHTMLBlueprint`
+
 ## Overview
 The `StaticHTMLBlueprint` exists to create a simple transition stand-in to allow users of other platforms (which generally push for customization with HTML) to begin using Mephisto with minimal changes. This generally exists in the form of specifying a templated HTML file and providing assignment data that fills the templates.
 
@@ -9,6 +10,7 @@ An example usage case is available [here](https://github.com/facebookresearch/Me
 
 ## Implementation Details
 At a high level, this is a deeper implementation of the abstract `StaticArchitect`, which contains all of the logic for deploying arbitrary tasks where the worker is given some content, and we ask for one response, as a complete `Unit`. This module adds the logic to ensure that the frontend where the worker is given content is able to render arbitrary HTML.
+
 ### `app.jsx`
 The `app.jsx` file contains most of the logic to ensure we can render HTML, including being able to attach and execute the arbitrary scripts that are included or linked in the given HTML file. It creates a react application using the `mephisto-task` package, and creates an empty form with a submit button. It then populates the inner form using two primary methods:
 - `handleUpdatingRemainingScripts`: This method walks through the list of scripts that are given in the attached HTML, either loading the external script and putting it into the head, or directly evaluating the content of local scripts. As the page has already loaded by the time we are loading in the remaining scripts, this all must be injected in an asynchronous manner. _Ultimately_ this isn't incredibly safe if you don't trust the attached scripts.

--- a/mephisto/abstractions/blueprints/static_html_task/README.md
+++ b/mephisto/abstractions/blueprints/static_html_task/README.md
@@ -12,7 +12,9 @@ An example usage case is available [here](https://github.com/facebookresearch/Me
 At a high level, this is a deeper implementation of the abstract `StaticArchitect`, which contains all of the logic for deploying arbitrary tasks where the worker is given some content, and we ask for one response, as a complete `Unit`. This module adds the logic to ensure that the frontend where the worker is given content is able to render arbitrary HTML.
 
 ### `app.jsx`
-The `app.jsx` file contains most of the logic to ensure we can render HTML, including being able to attach and execute the arbitrary scripts that are included or linked in the given HTML file. It creates a react application using the `mephisto-task` package, and creates an empty form with a submit button. It then populates the inner form using two primary methods:
+The `app.jsx` file contains most of the logic to ensure we can render HTML, including being able to attach and execute the arbitrary scripts that are included or linked in the given HTML file. It creates a react application using the `mephisto-task` package, and creates an empty form with a submit button. 
+
+It then populates the inner form using two primary methods:
 - `handleUpdatingRemainingScripts`: This method walks through the list of scripts that are given in the attached HTML, either loading the external script and putting it into the head, or directly evaluating the content of local scripts. As the page has already loaded by the time we are loading in the remaining scripts, this all must be injected in an asynchronous manner. _Ultimately_ this isn't incredibly safe if you don't trust the attached scripts.
 - `interpolateHtml`: This method injects the values for the specific task into their template variable slots. These template variables are specified in the `InitializationData` for an assignment, and populate fields as noted in the **Template Variables** section below.
 

--- a/mephisto/abstractions/blueprints/static_html_task/README.md
+++ b/mephisto/abstractions/blueprints/static_html_task/README.md
@@ -25,7 +25,8 @@ As of now, we also make available the following variables to the HTML via templa
 - `${provider_worker_id}`: The worker id that the provider uses locally to identify the worker.
 
 #### `useMephistoGlobalConfig` 
-This hook allows for a state to be updated when an event is consumed. An event is emitted for consumption whenever a window variable is set in `demo_task.html` using
+This hook allows for a state to be updated when an event is consumed. An event is emitted for consumption whenever a window variable is set in `demo_task.html` using:
+
 ```html
 <script>
 window._MEPHISTO_CONFIG.set(eventName, valueThatStateWillBeUpdatedTo)

--- a/mephisto/abstractions/blueprints/static_html_task/README.md
+++ b/mephisto/abstractions/blueprints/static_html_task/README.md
@@ -18,10 +18,36 @@ Upon submit, the data in the form (as marked by the `name` fields of any inputs)
 
 #### Template Variables
 You can provide template variables when running your task, generally in the form of template variables that are given names. When you specify these (either via `.csv` or directly providing a parsed array of dicts for this data), any named variable `my_special_variable` will be filled into the frontend in all locations containing `${my_special_variable}`.
+
 #### Mephisto-specific Template Variables
 As of now, we also make available the following variables to the HTML via templating:
 - `${mephisto_agent_id}`: The agent ID that Mephisto has associated with the current worker and task.
 - `${provider_worker_id}`: The worker id that the provider uses locally to identify the worker.
+
+#### `useMephistoGlobalConfig` 
+This hook allows for a state to be updated when an event is consumed. An event is emitted for consumption whenever a window variable is set in `demo_task.html` using
+```html
+<script>
+window._MEPHISTO_CONFIG.set(eventName, valueThatStateWillBeUpdatedTo)
+</script>
+```
+
+**Example of the hook in use**
+```jsx
+const [isSubmitButtonHidden, setIsSubmitButtonHidden] =
+    useMephistoGlobalConfig(
+      "HIDE_SUBMIT_BUTTON",
+      false,
+      (valueThatStateWillBeUpdatedTo) => typeof valueThatStateWillBeUpdatedTo === "boolean"
+    );
+```
+This sets the isSubmitButtonHidden state to be equal to whatever it was set to in the html.
+
+In this case:
+* The first argument is the name of the event you are consuming.
+* The second argument(optional) is the default value for `isSubmitButtonHidden`
+* The third argument(optional) is a validation function.
+  * When defined, the validation function has to return true for the state to update to `valueThatStateWillBeUpdatedTo`
 
 ### `StaticHTMLBlueprint`
 The `Blueprint` here extends on the abstract `StaticBlueprint`, adding HTML-specific requirements to outline the task that ends up visualized. The added arguments are as follows:

--- a/mephisto/abstractions/blueprints/static_html_task/README.md
+++ b/mephisto/abstractions/blueprints/static_html_task/README.md
@@ -33,7 +33,7 @@ This hook allows for a state to be updated when an event is consumed. An event i
 
 ```html
 <script>
-window._MEPHISTO_CONFIG.set(eventName, valueThatStateWillBeUpdatedTo)
+window._MEPHISTO_CONFIG.set(configName, valueThatStateWillBeUpdatedTo)
 </script>
 ```
 
@@ -46,7 +46,7 @@ const [isSubmitButtonHidden, setIsSubmitButtonHidden] =
       (valueThatStateWillBeUpdatedTo) => typeof valueThatStateWillBeUpdatedTo === "boolean"
     );
 ```
-This sets the isSubmitButtonHidden state to be equal to whatever it was set to in the html.
+This sets the isSubmitButtonHidden state to be equal to whatever it was set to in the html when the HIDE_SUBMIT_BUTTON config name is consumed.
 
 In this case:
 * The first argument is the name of the event you are consuming.


### PR DESCRIPTION
## Overview
* Creates a readme for simple_static_task
* Updates `StaticHTMLBlueprint` readme to include information on the `useMephistoGlobalConfig` hook.

TODO:
* I am trying to make it so that commits to only markdown files do not trigger the cypress e2e github action. Doesn't seem to be working currently.