### PR TITLE
Add info on `link_task_source` to docs

### DIFF
--- a/docs/web/docs/guides/tutorials/custom_react.md
+++ b/docs/web/docs/guides/tutorials/custom_react.md
@@ -57,7 +57,7 @@ This will launch a simple task where an annotator is supposed to note a sentence
 
 To establish a link where your changes will be propagated to the localhost server(when you reload) create a separate terminal window and run
 ```bash
-cd webapp && npm run dev
+cd webapp && npm run dev:watch
 ```
 
 Moving forward, we'll update this task so that workers are able to edit the text as well as rate the original sentence.

--- a/docs/web/docs/guides/tutorials/custom_react.md
+++ b/docs/web/docs/guides/tutorials/custom_react.md
@@ -36,14 +36,29 @@ mephisto:
     task_tags: "test,simple,button"
 ```
 
-The only change we'll make is to the `task_name` (as you should on any new tasks!), but we will update the other fields as we go. It's important to note the `task_source` and `extra_source_dir` arguments though, as this is where the `StaticReactBlueprint` class will be looking for the compiled React app's Javascript bundle as well as a folder for extra static resources for the page, respectively.
+It is important to give a new `task_name` as we are creating a custom task. For local development **only** it also makes sense to set `link_task_source` to true. This allows changes to propagate to your localhost server when you reload the page (otherwise you would have to shutdown and restart the server to see changes). 
+
+The `task_source` and `extra_source_dir` arguments are also of importance, as this is where the `StaticReactBlueprint` class will be looking for the compiled React app's Javascript bundle as well as a folder for extra static resources for the page, respectively.
 
 ### 1.2 Launching the task
 From the current directory, you should be able to execute the run script and get a job working. We're using a different `task_name` to prevent polluting our later task with data that won't share the same format. It is a good practice to do this with initial iterations, and to change the `task_name` any time you change input or output arguments.
+
+You can update the `task_name` and `link_task_source` values in your config and run the task like below
 ```bash
-python run_task.py mephisto.task.task_name=custom-react-tutorial-iterating
+python run_task.py
+```
+
+or you can set them when you run the task:
+
+```bash
+python run_task.py mephisto.task.task_name=custom-react-tutorial-iterating mephisto.blueprint.link_task_source=true
 ```
 This will launch a simple task where an annotator is supposed to note a sentence as being good or bad. Clicking a button auto-submits the task. In the next sections we'll add other content. 
+
+To establish a link where your changes will be propagated to the localhost server(when you reload) create a separate terminal window and run
+```bash
+cd webapp && npm run dev
+```
 
 Moving forward, we'll update this task so that workers are able to edit the text as well as rate the original sentence.
 

--- a/docs/web/docs/guides/tutorials/custom_react.md
+++ b/docs/web/docs/guides/tutorials/custom_react.md
@@ -55,7 +55,7 @@ python run_task.py mephisto.task.task_name=custom-react-tutorial-iterating mephi
 ```
 This will launch a simple task where an annotator is supposed to note a sentence as being good or bad. Clicking a button auto-submits the task. In the next sections we'll add other content. 
 
-To establish a link where your changes will be propagated to the localhost server(when you reload) create a separate terminal window and run
+To establish a link where your changes will be propagated to the localhost server(when you reload), create a separate terminal window and run
 ```bash
 cd webapp && npm run dev:watch
 ```

--- a/mephisto/abstractions/blueprints/static_react_task/static_react_blueprint.py
+++ b/mephisto/abstractions/blueprints/static_react_task/static_react_blueprint.py
@@ -22,6 +22,9 @@ from typing import ClassVar, Type, TYPE_CHECKING
 from mephisto.abstractions.blueprint import (
     SharedTaskState,
 )
+from mephisto.utils.logger_core import (
+    get_logger,
+)
 
 if TYPE_CHECKING:
     from mephisto.data_model.task_run import TaskRun
@@ -31,6 +34,7 @@ if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 BLUEPRINT_TYPE_STATIC_REACT = "static_react_task"
+logger = get_logger(name=__name__)
 
 
 @dataclass
@@ -120,3 +124,9 @@ class StaticReactBlueprint(StaticBlueprint):
         assert link_task_source == False or (
             link_task_source == True and current_architect in allowed_architects
         ), f"`link_task_source={link_task_source}` is not compatible with architect type: {args.architect._architect_type}. Please check your task configuration."
+
+        if link_task_source == False and current_architect in allowed_architects:
+            logger.info(
+                "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: [blue]true[/blue]\n\nin your task's hydra configuration and run \n\n[purple]cd[/purple] webapp [red]&&[/red] [green]npm[/green] run dev:watch\n\nin a separate terminal window. For more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task\n",
+                extra={"markup": True},
+            )

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -251,6 +251,12 @@ class Operator:
                 f"Task is using the default blueprint name {task_name} as a name, "
                 "as no task_name is provided"
             )
+        link_task_source = run_config.blueprint.get("link_task_source")
+        if link_task_source == False:
+            logger.info(
+                "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: [blue]true[/blue]\n\nin your task's hydra configuration and run \n\n[purple]cd[/purple] webapp && [green]npm[/green] run dev:watch\n\nin a separate terminal window. For more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task",
+                extra={"markup": True},
+            )
 
         tasks = self.db.find_tasks(task_name=task_name)
 
@@ -313,7 +319,7 @@ class Operator:
             raise e
 
         live_run.task_launcher.create_assignments()
-        live_run.task_launcher.launch_units(url=task_url, run_config=run_config)
+        live_run.task_launcher.launch_units(url=task_url)
 
         self._task_runs_tracked[task_run.db_id] = live_run
         task_run.update_completion_progress(status=False)

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -313,7 +313,7 @@ class Operator:
             raise e
 
         live_run.task_launcher.create_assignments()
-        live_run.task_launcher.launch_units(task_url)
+        live_run.task_launcher.launch_units(url=task_url, run_config=run_config)
 
         self._task_runs_tracked[task_run.db_id] = live_run
         task_run.update_completion_progress(status=False)

--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -29,7 +29,6 @@ from mephisto.abstractions.blueprints.mixins.onboarding_required import (
 )
 from mephisto.abstractions.database import MephistoDB, EntryDoesNotExistException
 from mephisto.data_model.qualification import QUAL_NOT_EXIST
-from mephisto.tools.data_browser import DataBrowser as MephistoDataBrowser
 from mephisto.utils.qualifications import make_qualification_dict
 from mephisto.operations.task_launcher import TaskLauncher
 from mephisto.operations.client_io_handler import ClientIOHandler
@@ -56,7 +55,7 @@ from omegaconf import DictConfig, OmegaConf
 logger = get_logger(name=__name__)
 
 if TYPE_CHECKING:
-    from mephisto.abstractions.blueprint import Blueprint, TaskRunner
+    from mephisto.abstractions.blueprint import Blueprint
     from mephisto.abstractions.crowd_provider import CrowdProvider
     from mephisto.abstractions.architect import Architect
 
@@ -250,12 +249,6 @@ class Operator:
             logger.warning(
                 f"Task is using the default blueprint name {task_name} as a name, "
                 "as no task_name is provided"
-            )
-        link_task_source = run_config.blueprint.get("link_task_source")
-        if link_task_source == False:
-            logger.info(
-                "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: [blue]true[/blue]\n\nin your task's hydra configuration and run \n\n[purple]cd[/purple] webapp && [green]npm[/green] run dev:watch\n\nin a separate terminal window. For more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task",
-                extra={"markup": True},
             )
 
         tasks = self.db.find_tasks(task_name=task_name)

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -26,7 +26,6 @@ import enum
 if TYPE_CHECKING:
     from mephisto.data_model.task_run import TaskRun
     from mephisto.abstractions.database import MephistoDB
-from omegaconf import DictConfig, OmegaConf
 import threading
 from mephisto.utils.logger_core import get_logger
 import types
@@ -180,7 +179,7 @@ class TaskLauncher:
             if not self.unlaunched_units:
                 break
 
-    def _launch_limited_units(self, url: str, run_config: Optional[DictConfig]) -> None:
+    def _launch_limited_units(self, url: str) -> None:
         """use units' generator to launch limited number of units according to (max_num_concurrent_units)"""
         # Continue launching if we haven't pulled the plug, so long as there are currently
         # units to launch, or more may come in the future.
@@ -191,23 +190,16 @@ class TaskLauncher:
                 if unit is None:
                     break
                 unit.launch(url)
-            if (
-                run_config is not None
-                and run_config.blueprint.link_task_source == False
-            ):
-                logger.info(
-                    "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: true\n\nin your task's hydra configuration and run \n\ncd webapp && npm run dev:watch\n\nin a separate terminal window. For more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task"
-                )
             if self.generator_type == GeneratorType.NONE:
                 break
         self.finished_generators = True
 
-    def launch_units(self, url: str, run_config: Optional[DictConfig]) -> None:
+    def launch_units(self, url: str) -> None:
         """launch any units registered by this TaskLauncher"""
         self.launch_url = url
         self.units_thread = threading.Thread(
             target=self._launch_limited_units,
-            args=(url, run_config),
+            args=(url,),
             name="unit-generator",
         )
         self.units_thread.start()

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -196,7 +196,7 @@ class TaskLauncher:
                 and run_config.blueprint.link_task_source == False
             ):
                 logger.info(
-                    "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: true\n\nin your task's hydra configuration.\n\nFor more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task"
+                    "If you want your server to update on reload whenever you make changes to your webapp, then make sure to set \n\nlink_task_source: true\n\nin your task's hydra configuration and run \n\ncd webapp && npm run dev:watch\n\nin a separate terminal window. For more information check out:\nhttps://mephisto.ai/docs/guides/tutorials/custom_react/#12-launching-the-task"
                 )
             if self.generator_type == GeneratorType.NONE:
                 break


### PR DESCRIPTION
## Overview
For local development using the `link_task_source` property can significantly improve productivity. However, on the docs, there is not much information available on it. 

When searching "link_task_source" on the docs I only get two results, which both come from the blueprint table.

<img  width="598" alt="search-results" src="https://user-images.githubusercontent.com/55665282/183482528-fc51ee46-5e74-4bb3-8e28-908d002bc0c7.png">

Ideally there should be some info on this property in the tutorial.

### Changes:
* Updated tutorial to include information on `link_task_source`
* Added a logging message that prints to the console if you have `link_task_source` set to false.

## Updated documentation section in "working on a custom task" page

![launching_the_task](https://user-images.githubusercontent.com/55665282/183483737-b1f20991-029f-4b3b-8af7-e628ede800c9.png)

## Logging message that shows when `link_task_source` is set to false

<img width="1634" alt="link_task_source_logging" src="https://user-images.githubusercontent.com/55665282/183940321-fa93169f-8969-4870-b274-5e8d410e59d6.png">


