### PR TITLE
Finding OSTYPE is not exists

### DIFF
--- a/mephisto/scripts/metrics/install_metrics.sh
+++ b/mephisto/scripts/metrics/install_metrics.sh
@@ -1,7 +1,7 @@
 if [ -z "$OSTYPE" ]
 then
-	OSTYPE=$(uname)
-	echo "Checking OS type returned ${OSTYPE}"
+  OSTYPE=$(uname)
+  echo "Checking OS type returned ${OSTYPE}"
 fi
 case "$OSTYPE" in
   darwin* | Darwin*)

--- a/mephisto/scripts/metrics/install_metrics.sh
+++ b/mephisto/scripts/metrics/install_metrics.sh
@@ -1,8 +1,13 @@
+if [ -z "$OSTYPE" ]
+then
+		OSTYPE=$(uname)
+		echo "Checking OS type returned ${OSTYPE}"
+fi
 case "$OSTYPE" in
   darwin*)
     platform='darwin'
     ;;
-  linux*)
+  linux* | Linux*)
     platform='linux'
     ;;
   *)

--- a/mephisto/scripts/metrics/install_metrics.sh
+++ b/mephisto/scripts/metrics/install_metrics.sh
@@ -1,10 +1,10 @@
 if [ -z "$OSTYPE" ]
 then
-		OSTYPE=$(uname)
-		echo "Checking OS type returned ${OSTYPE}"
+	OSTYPE=$(uname)
+	echo "Checking OS type returned ${OSTYPE}"
 fi
 case "$OSTYPE" in
-  darwin*)
+  darwin* | Darwin*)
     platform='darwin'
     ;;
   linux* | Linux*)


### PR DESCRIPTION
While trying to install mephisto metrics, ran into issues with empty `OSTYPE` env variable. This fixes that by checking it exists.