### PR TITLE
Adding more general function with better name

### DIFF
--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -71,9 +71,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -116,9 +116,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -161,9 +161,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -205,9 +205,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: |
@@ -251,9 +251,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -295,9 +295,9 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We actively welcome your pull requests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.
 5. Make sure your code lints.
-    * This can be done by running `pre-commit install`. This will check the if your code is formatted correctly on each commit.
+    * This can be done by running `pip install pre-commit; pre-commit install`. This will check the if your code is formatted correctly on each commit.
     * Make sure that pre-commit is installed by following the steps in [this website](https://pre-commit.com/).
 6. If you haven't already, complete the Contributor License Agreement ("CLA").
 

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -254,7 +254,7 @@ class LocalMephistoDB(MephistoDB):
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = sqlite3.connect(self.db_path, check_same_thread=False)
                 conn.row_factory = StringIDRow
                 self.conn[curr_thread] = conn
             except sqlite3.Error as e:

--- a/mephisto/abstractions/providers/mock/mock_datastore.py
+++ b/mephisto/abstractions/providers/mock/mock_datastore.py
@@ -54,7 +54,7 @@ class MockDatastore:
         """
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
-            conn = sqlite3.connect(self.db_path)
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
             conn.row_factory = sqlite3.Row
             self.conn[curr_thread] = conn
         return self.conn[curr_thread]

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -92,7 +92,7 @@ class MTurkDatastore:
         """
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
-            conn = sqlite3.connect(self.db_path)
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
             conn.row_factory = sqlite3.Row
             self.conn[curr_thread] = conn
         return self.conn[curr_thread]

--- a/mephisto/abstractions/providers/mturk/utils/script_utils.py
+++ b/mephisto/abstractions/providers/mturk/utils/script_utils.py
@@ -11,10 +11,55 @@ from mephisto.abstractions.providers.mturk.mturk_requester import MTurkRequester
 from mephisto.data_model.requester import Requester
 from mephisto.data_model.unit import Unit
 from tqdm import tqdm  # type: ignore
+from mephisto.utils.logger_core import get_logger
+
+logging = get_logger(name=__name__)
 
 if TYPE_CHECKING:
     from mephisto.abstractions.database import MephistoDB
 
+
+def direct_assign_qual_mturk_workers(
+    db: "MephistoDB",
+    worker_list: List[str],
+    qual_name: str,
+    requester_name: Optional[str] = None,
+):
+    """
+    Directly assign MTurk qualification that Mephisto associates with qual_name
+    to all of the MTurk worker ids in worker_list. If requester_name is not provided,
+    it will use the most recently registered mturk requester in the database.
+    """
+    reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
+    requester = reqs[-1]
+
+    assert isinstance(
+        requester, MTurkRequester
+    ), "Can only direct soft block mturk workers from mturk requester"
+
+    mturk_qual_details = requester.datastore.get_qualification_mapping(qual_name)
+    if mturk_qual_details is not None:
+        # Overrule the requester, as this qualification already exists
+        requester = Requester.get(db, mturk_qual_details["requester_id"])
+        qualification_id = mturk_qual_details["mturk_qualification_id"]
+    else:
+        qualification_id = requester._create_new_mturk_qualification(
+            qual_name
+        )
+
+    assert isinstance(
+        requester, MTurkRequester
+    ), "Can only direct assign qualification (soft block) mturk workers from mturk requester"
+    mturk_client = requester._get_client(requester._requester_name)
+    for worker_id in tqdm(worker_list):
+        try:
+            give_worker_qualification(
+                mturk_client, worker_id, qualification_id, value=1
+            )
+        except Exception as e:
+            logger.exception(
+                f'Failed to give worker with ID: "{worker_id}" qualification with error: {e}. Skipping.'
+            )
 
 def direct_soft_block_mturk_workers(
     db: "MephistoDB",
@@ -28,38 +73,10 @@ def direct_soft_block_mturk_workers(
     in worker_list. If requester_name is not provided, it will use the
     most recently registered mturk requester in the database.
     """
-    reqs = db.find_requesters(requester_name=requester_name, provider_type="mturk")
-    requester = reqs[-1]
-
-    assert isinstance(
-        requester, MTurkRequester
-    ), "Can only direct soft block mturk workers from mturk requester"
-
-    mturk_qual_details = requester.datastore.get_qualification_mapping(
-        soft_block_qual_name
-    )
-    if mturk_qual_details is not None:
-        # Overrule the requester, as this qualification already exists
-        requester = Requester.get(db, mturk_qual_details["requester_id"])
-        qualification_id = mturk_qual_details["mturk_qualification_id"]
-    else:
-        qualification_id = requester._create_new_mturk_qualification(
-            soft_block_qual_name
-        )
-
-    assert isinstance(
-        requester, MTurkRequester
-    ), "Can only direct soft block mturk workers from mturk requester"
-    mturk_client = requester._get_client(requester._requester_name)
-    for worker_id in tqdm(worker_list):
-        try:
-            give_worker_qualification(
-                mturk_client, worker_id, qualification_id, value=1
-            )
-        except Exception as e:
-            print(
-                f'Failed to give worker with ID: "{worker_id}" qualification with error: {e}. Skipping.'
-            )
+    direct_assign_qual_mturk_workers(db=db,
+        worker_list=worker_list,
+        qual_name=soft_block_qual_name,
+        requester_name=requester_name)
 
 
 def get_mturk_ids_from_unit_id(db, unit_id: str) -> Dict[str, Optional[str]]:

--- a/mephisto/abstractions/providers/mturk/utils/script_utils.py
+++ b/mephisto/abstractions/providers/mturk/utils/script_utils.py
@@ -43,9 +43,7 @@ def direct_assign_qual_mturk_workers(
         requester = Requester.get(db, mturk_qual_details["requester_id"])
         qualification_id = mturk_qual_details["mturk_qualification_id"]
     else:
-        qualification_id = requester._create_new_mturk_qualification(
-            qual_name
-        )
+        qualification_id = requester._create_new_mturk_qualification(qual_name)
 
     assert isinstance(
         requester, MTurkRequester
@@ -57,9 +55,10 @@ def direct_assign_qual_mturk_workers(
                 mturk_client, worker_id, qualification_id, value=1
             )
         except Exception as e:
-            logger.exception(
+            logging.exception(
                 f'Failed to give worker with ID: "{worker_id}" qualification with error: {e}. Skipping.'
             )
+
 
 def direct_soft_block_mturk_workers(
     db: "MephistoDB",
@@ -73,10 +72,12 @@ def direct_soft_block_mturk_workers(
     in worker_list. If requester_name is not provided, it will use the
     most recently registered mturk requester in the database.
     """
-    direct_assign_qual_mturk_workers(db=db,
+    direct_assign_qual_mturk_workers(
+        db=db,
         worker_list=worker_list,
         qual_name=soft_block_qual_name,
-        requester_name=requester_name)
+        requester_name=requester_name,
+    )
 
 
 def get_mturk_ids_from_unit_id(db, unit_id: str) -> Dict[str, Optional[str]]:


### PR DESCRIPTION
# Description
We have the `direct_soft_block_mturk_workers` function which is great to assign any qualification to workers, including the soft blocking qualification. The convenience of this often tempts people to use it for any general qualification ([example](https://github.com/fairinternal/ParlAI-Internal/blob/765a8b11678c9b900d73d888046b327a557d0c44/crowdsourcing/projects/light_multiparty/refresh_allowlist.py#L54)). This sort of use causes confusion and may end up with logical bugs. This patch renames `direct_soft_block_mturk_workers` to `direct_assign_qual_mturk_workers` (with minimal changes). To keep the backward compatibility, we still have `direct_soft_block_mturk_workers`; but it is just a wrapper around the call to `direct_assign_qual_mturk_workers`.

# Test
Used it with assigning allow list qualification in [this PR](https://github.com/fairinternal/ParlAI-Internal/pull/3646/files), and it worked well. Checking the final results proved that it assigned the qualification correctly.