### PR TITLE
Add max_assignments_per_hit; MTurk's  MaxAssignments

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -274,10 +274,12 @@ class MTurkUnit(Unit):
     def launch(self, task_url: str) -> None:
         """Create this HIT on MTurk (making it available) and register the ids in the local db"""
         task_run = self.get_assignment().get_task_run()
-        duration = task_run.get_task_args().assignment_duration_in_seconds
+        task_args = task_run.get_task_args()
+        duration = task_args.assignment_duration_in_seconds
+        max_assignments_per_hit = task_args.max_assignments_per_hit
         task_lifetime_in_seconds = (
-            task_run.get_task_args().task_lifetime_in_seconds
-            if task_run.get_task_args().task_lifetime_in_seconds
+           task_args.task_lifetime_in_seconds
+            if task_args.task_lifetime_in_seconds
             else 60 * 60 * 24 * 31
         )
         run_id = task_run.db_id
@@ -292,9 +294,10 @@ class MTurkUnit(Unit):
             task_url,
             hit_type_id,
             lifetime_in_seconds=task_lifetime_in_seconds,
+            num_assignments=max_assignments_per_hit
         )
         # TODO(OWN) get this link to the mephisto frontend
-        print(hit_link)
+        print(f'{hit_link} \tHITId:{hit_id}')
 
         # We create a hit for this unit, but note that this unit may not
         # necessarily match with the same HIT that was launched for it.

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -98,12 +98,22 @@ class TaskRunArgs:
             )
         },
     )
+
     max_num_concurrent_units: int = field(
         default=0,
         metadata={
             "help": (
                 "Maximum units that will be released simultaneously, setting a limit "
                 "on concurrent connections to Mephisto overall. (0 is infinite)"
+            )
+        },
+    )
+    max_assignments_per_hit: int = field(
+        default=1,
+        metadata={
+            "help": (
+                "Maximum assignments per task. The number of times the task"
+                "can be accepted and completed"
             )
         },
     )


### PR DESCRIPTION
The default values set by the current version does not allow multiple workers to work on same HIT.
The proposed pull request adds `task.max_assignments_per_hit` config  (with default=1), and allows configuring the maximum assignments per HIT.


Related: 
* https://github.com/facebookresearch/ParlAI/issues/3932 
* [mturk API  `create_hit_with_hit_type`](https://boto3.amazonaws.com/v1/documentation/api/1.11.9/reference/services/mturk.html#MTurk.Client.create_hit_with_hit_type)