### PR TITLE
Removing threadsafety as we already lock connections behind threads

### DIFF
--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -118,7 +118,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -163,7 +163,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .
@@ -207,7 +207,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: |
@@ -297,7 +297,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: |

--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -116,7 +116,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -161,7 +161,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -205,7 +205,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -251,7 +251,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -295,7 +295,7 @@ jobs:
         uses: actions/setup-python@v2
 
       - name: 🪨 Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/cypress-end-to-end-tests.yml
+++ b/.github/workflows/cypress-end-to-end-tests.yml
@@ -253,7 +253,7 @@ jobs:
       - name: 🪨 Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 16.16.0
 
       - name: 🤖 Install Mephisto
         run: pip install -e .

--- a/mephisto/abstractions/databases/local_database.py
+++ b/mephisto/abstractions/databases/local_database.py
@@ -254,7 +254,7 @@ class LocalMephistoDB(MephistoDB):
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
             try:
-                conn = sqlite3.connect(self.db_path)
+                conn = sqlite3.connect(self.db_path, check_same_thread=False)
                 conn.row_factory = StringIDRow
                 self.conn[curr_thread] = conn
             except sqlite3.Error as e:

--- a/mephisto/abstractions/providers/mock/mock_datastore.py
+++ b/mephisto/abstractions/providers/mock/mock_datastore.py
@@ -54,7 +54,7 @@ class MockDatastore:
         """
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
-            conn = sqlite3.connect(self.db_path)
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
             conn.row_factory = sqlite3.Row
             self.conn[curr_thread] = conn
         return self.conn[curr_thread]

--- a/mephisto/abstractions/providers/mturk/mturk_datastore.py
+++ b/mephisto/abstractions/providers/mturk/mturk_datastore.py
@@ -92,7 +92,7 @@ class MTurkDatastore:
         """
         curr_thread = threading.get_ident()
         if curr_thread not in self.conn or self.conn[curr_thread] is None:
-            conn = sqlite3.connect(self.db_path)
+            conn = sqlite3.connect(self.db_path, check_same_thread=False)
             conn.row_factory = sqlite3.Row
             self.conn[curr_thread] = conn
         return self.conn[curr_thread]


### PR DESCRIPTION
# Overview
Under rare circumstances, sqlite DB access was occurring across threads from where the table was originally created. Mephisto however wraps all DB access with conditions, so rather than having `sqlite` throw for us, we can actually safely process these requests.

# Testing
We had a long running job that had issues before with an access across threads that killed the run. Now that job appears stable with no DB issues.