### PR TITLE
Resolving static return status bug

### DIFF
--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -298,7 +298,13 @@ class TaskRunner(ABC):
                 agent.update_status(AgentState.STATUS_COMPLETED)
                 agent.mark_done()
 
-            self.shared_state.on_unit_submitted(unit)
+            try:
+                self.shared_state.on_unit_submitted(unit)
+            except Exception as e:
+                logger.exception(
+                    f"Unhandled exception in on_unit_submitted for {unit}",
+                    exc_info=True,
+                )
             del self.running_units[unit.db_id]
 
             self._cleanup_special_units(unit, agent)
@@ -379,7 +385,13 @@ class TaskRunner(ABC):
                     agent.mark_done()
 
             for unit in assignment.get_units():
-                self.shared_state.on_unit_submitted(unit)
+                try:
+                    self.shared_state.on_unit_submitted(unit)
+                except Exception as e:
+                    logger.exception(
+                        f"Unhandled exception in on_unit_submitted for {unit}",
+                        exc_info=True,
+                    )
             del self.running_assignments[assignment.db_id]
 
             # Clear reservations


### PR DESCRIPTION
# Overview
Presenting as the sister problem to #830, in static data collection tasks Mephisto would not properly dissociate a `Unit` from a returned `Agent`, meaning that eventually all of the available units for a task wouldn't be completable by a new worker. This resulted in the same kind of task stall-out we would see in other blueprints caused by #830.

# Fix Details
Ultimately, what was happening is that from the perspective of the `TaskRunner`, these `Unit`s were completing and exiting _cleanly_ on a return. Thus there was no reason to clean up. 

The cause for the issue is that a RETURN disconnect (caused by an `MTurkAgent`'s status sync mechanism) would release an agent's async locked `did_submit` (as it should), however the expectation was that the `Agent` would recognize post-release if it was in an error state to raise. 

This fix updates the `Agent` to meet this expectation properly.

# Testing
Ran a static job on one of my collection efforts that didn't end up stalling out, despite having many `RETURNED` events.