### PR TITLE
Experimental functions for resuming a task run

### DIFF
--- a/mephisto/operations/operator.py
+++ b/mephisto/operations/operator.py
@@ -595,3 +595,82 @@ class Operator:
             )
         finally:
             self.shutdown()
+
+    def EXP_launch_from_incomplete_run(
+        self, task_run_id: str, shared_state: Optional[SharedTaskState] = None
+    ) -> str:
+        """
+        Attempt to resume a task run with incomplete assignments/units
+        """
+        task_run = TaskRun.get(db, task_run_id)
+        run_config = task_run.args
+
+        set_mephisto_log_level(level=run_config.get("log_level", "info"))
+
+        requester, provider_type = self._get_requester_and_provider_from_config(
+            run_config
+        )
+
+        # Next get the abstraction classes, and run validation
+        # before anything is actually created in the database
+        blueprint_type = run_config.blueprint._blueprint_type
+        architect_type = run_config.architect._architect_type
+        BlueprintClass = get_blueprint_from_type(blueprint_type)
+        ArchitectClass = get_architect_from_type(architect_type)
+        CrowdProviderClass = get_crowd_provider_from_type(provider_type)
+
+        if shared_state is None:
+            shared_state = BlueprintClass.SharedStateClass()
+
+        BlueprintClass.assert_task_args(run_config, shared_state)
+        ArchitectClass.assert_task_args(run_config, shared_state)
+        CrowdProviderClass.assert_task_args(run_config, shared_state)
+        # TODO special validation that _THIS TASK RUN_ can be resumed
+
+        # Make a new live run
+        live_run = self._create_live_task_run(
+            run_config,
+            shared_state,
+            task_run,
+            ArchitectClass,
+            BlueprintClass,
+            CrowdProviderClass,
+        )
+
+        try:
+            # If anything fails after here, we have to cleanup the architect
+            # Setup and deploy the server
+            built_dir = live_run.architect.prepare()
+            task_url = live_run.architect.deploy()
+
+            # TODO(#102) maybe the cleanup (destruction of the server configuration?) should only
+            # happen after everything has already been reviewed, this way it's possible to
+            # retrieve the exact build directory to review a task for real
+            live_run.architect.cleanup()
+
+            # Register the task with the provider
+            live_run.provider.setup_resources_for_task_run(
+                task_run, run_config, shared_state, task_url
+            )
+
+            live_run.client_io.launch_channels()
+        except (KeyboardInterrupt, Exception) as e:
+            logger.error(
+                "Encountered error while launching run, shutting down", exc_info=True
+            )
+            try:
+                live_run.architect.shutdown()
+            except (KeyboardInterrupt, Exception) as architect_exception:
+                logger.exception(
+                    f"Could not shut down architect: {architect_exception}",
+                    exc_info=True,
+                )
+            raise e
+
+        live_run.task_launcher.EXP_resume_assignments()
+        live_run.task_launcher.launch_units(url=task_url)
+
+        self._task_runs_tracked[task_run.db_id] = live_run
+        task_run.update_completion_progress(status=False)
+
+        return task_run.db_id

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -264,3 +264,30 @@ class TaskLauncher:
             self.assignments_thread.join()
         if self.units_thread is not None:
             self.units_thread.join()
+
+    def EXP_resume_assignments(self) -> None:
+        """
+        Experimental function to go through an resume expired (or incomplete) tasks from a specific
+        task run that may have been left incomplete.
+        """
+        assignments = self.task_run.get_assignments()
+        for assignment in assignments:
+            self.assignments.append(assignment)
+            for unit in assignment.get_units():
+                unit_status = unit.get_status()
+                if unit_status in [AssignmentState.LAUNCHED, AssignmentState.ASSIGNED]:
+                    raise AssertionError(
+                        f"Cannot launch job with units in status {unit_status}. Be sure this task run is properly cleaned up before relaunching"
+                    )
+                if unit.get_status() in [
+                    AssignmentState.EXPIRED,
+                    AssignmentState.REJECTED,
+                    AssignmentState.SOFT_REJECTED,
+                ]:
+                    if unit.get_assigned_agent() != None:
+                        # Dissociate the rejected agent
+                        unit.clear_assigned_agent()
+                    # Update these units to created, then prepare to launch them
+                    unit.set_db_status(AssignmentState.CREATED)
+                    self.units.append(unit)
+        return

--- a/mephisto/operations/task_launcher.py
+++ b/mephisto/operations/task_launcher.py
@@ -290,4 +290,5 @@ class TaskLauncher:
                     # Update these units to created, then prepare to launch them
                     unit.set_db_status(AssignmentState.CREATED)
                     self.units.append(unit)
+        assert len(self.units) > 0, "Cannot relaunch a job with no incomplete units!!"
         return


### PR DESCRIPTION
# Overview
This PR acts as a starting point for implementing the path of resuming incomplete or interrupted `TaskRun`s. It creates two new experimental functions (denoted with an `EXP_` prefix) that power the functionality. The basic flow is to:
1) Query for all assignments of that task run, and find ones with missing `Unit`s.
2) Load up all of the `Assignment`s, then force-reset their incomplete units from `EXPIRED` to `CREATED`, 
3) Clone configuration from the previous `TaskRun`, and use it to initialize a `CrowdProvider`, `Architect`, and `Blueprint`
4) Push the assignments through the `launch_unit`s flow (which would need to be updated to only launch units in a `CREATED` state and ignore all others).

# Implementation
The first portion is a version of `Operator.launch_task_run_or_die`, which instead of creating a new task run from a given config, loads a task run from ID and steals its config.  It then establishes the same type of local state that an operator would have normally and tries to execute the run.
The second part is `TaskLauncher.EXP_resume_assignments`, which replaces the `create_assignments` step and instead looks for existing assignments that have incomplete units. It moves those incomplete units (either by expiration or (+soft) rejection) to the CREATED state, and stores them locally so that the `launch_units` call from the `Operator` only relaunches these particular units.

# Testing
No testing yet

# TODO
- [ ] Do some testing in sandbox/local, discover some bugs, resolve those bugs
- [ ] Commit this to `main`: it's experimental. Some people can use it, but I'd like to standardize pre-releasing functionality that may unblock people (or lead them to contribute the remaining parts to bring to core functionality)

# TODO to move to core
- Add validation that a job _can_ be resumed. Perhaps we need metadata? Any task run with non-standard `SharedTaskState` for instance is going to struggle to resume properly, but it's possible we have a script wrapper that restores screening unit validator, onboarding functions, etc.
- Create tests
  - Create a simple automated test that actually runs this functionality
  - Ensure that nothing is broken with regards to shutting down after the new tasks are compeleted
  - Ensure that there's no weird linking if we go back and re-action other workers
  - Ensure that our review scripts still work on task runs that go through this flow
- Fix anything that was surfaced writing new tests
- Remove experimental prefix