### PR TITLE
fix #874: Upgrade pip and create main_data_directory in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,18 @@ FROM $BASE_IMAGE
 COPY . /mephisto
 RUN mkdir ~/.mephisto
 
+# Create the main Mephisto data directory
+RUN mkdir /mephisto/data
+
 # Write the mephisto config file manually for now to avoid prompt.
 # For bash-style string $ expansion for newlines,
 # we need to switch the shell to bash:
 SHELL ["/bin/bash", "-c"]
 RUN echo $'core: \n  main_data_directory: /mephisto/data' >> ~/.mephisto/config.yml
 
+# Upgrade pip so we can use the pyproject.toml configuration
+# without raising an error
+RUN pip install --upgrade pip
 RUN cd /mephisto && pip install -e .
 RUN mephisto check # Run mephisto check so a mock requester gets created
 CMD mephisto check


### PR DESCRIPTION
This PR fixes #874 by updating pip in the Dockerfile. 

Also creates the `/mephisto/data/` directory which is specified as the `main_data_directory` in `config.yml`. This was leading to a silent error when running `mephisto check`. (See #916).