### PR TITLE
Making MTurk cleanup run daily per requester

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -811,7 +811,7 @@ def try_prerun_cleanup(db: "MephistoDB", requester_name: str) -> None:
     )
 
     hits_to_dispose: Optional[List[Dict[str, Any]]] = []
-    confirm_string = "Enter anything to confirm removal of the following HITs:\n"
+    confirm_string = "Confirm removal of the following HITs? (y)es/(n)o :\n"
     for hit_type in broken_hit_types.keys():
         hit_count = len(broken_hit_types[hit_type])
         cur_title = broken_hit_types[hit_type][0]["Title"]
@@ -835,13 +835,18 @@ def try_prerun_cleanup(db: "MephistoDB", requester_name: str) -> None:
         print("No HITs selected for disposal. Continuing")
         return
 
-    input(confirm_string)
+    should_clear = ""
+    while not (should_clear.startswith("y") or should_clear.startswith("n")):
+        should_clear = input(confirm_string).lower()
+    if not should_clear.startswith("y"):
+        print("Disposal cancelled, continuing with launch")
+        return
 
     print(f"Disposing {len(hits_to_dispose)} HITs.")
     remaining_hits = expire_and_dispose_hits(client, hits_to_dispose)
 
     if len(remaining_hits) == 0:
-        print("Disposed!")
+        print("Disposed! Returning to launch")
     else:
         print(
             f"After disposing, {len(remaining_hits)} could not be disposed.\n"

--- a/mephisto/tools/scripts.py
+++ b/mephisto/tools/scripts.py
@@ -118,7 +118,9 @@ def task_script(
             os.path.join(get_run_file_dir(), config_path)
         )
         hydra_wrapper = hydra.main(
-            config_path=absolute_config_path, config_name="taskconfig"
+            config_path=absolute_config_path,
+            config_name="taskconfig",
+            version_base="1.1",
         )
         return cast(TaskFunction, hydra_wrapper(process_config_and_run_main))
 

--- a/mephisto/tools/scripts.py
+++ b/mephisto/tools/scripts.py
@@ -8,6 +8,7 @@ Utilities that are useful for Mephisto-related scripts.
 """
 
 from mephisto.abstractions.databases.local_database import LocalMephistoDB
+from mephisto.abstractions.providers.mturk.mturk_utils import try_prerun_cleanup
 from mephisto.operations.operator import Operator
 from mephisto.abstractions.databases.local_singleton_database import MephistoSingletonDB
 from mephisto.utils.logger_core import format_loud
@@ -206,6 +207,7 @@ def augment_config_from_db(script_cfg: DictConfig, db: "MephistoDB") -> DictConf
         provider_type = requester_provider_type
 
     if provider_type in ["mturk"]:
+        try_prerun_cleanup(db, cfg.provider.requester_name)
         input(
             f"This task is going to launch live on {provider_type}, press enter to continue: "
         )


### PR DESCRIPTION
# Overview
It very frequently comes up that Mephisto users and workers are left in positions where tasks seem to be broken. Usually this is the result of stale tasks, which surface from hasty shutdowns or strange expiration issues through `botocore`. The `mephisto scripts mturk cleanup` script exists to alleviate this problem, but given how frequently the issue arises I think it makes sense to build this functionality into the Mephisto run script when using an MTurk requester.

# Implementation
- Adds a new `try_prerun_cleanup` script to the `mturk_utils` that queries for presumed active (or broken HITs) and surfaces these if it has been greater than 24 hours since the last time one of these queries has been run for the given requester. It allows the user to select which if any HITs need disposing, then continues. It updates a file in `~/.mephisto/` to keep track of these times.
- Augments the `augment_config_from_db` helper function to run `try_prerun_cleanup` whenever an MTurk requester is being used.
- Adds a new option to the cleanup script to remove old tasks (> 2 weeks).
# Testing
I cleaned up some of my old tasks on one of my requesters using the new `(o)ld` option. 
I tried launching a task using one of my requesters:
**First time**
```
python static_test_script.py mephisto/provider=mturk mephisto.provider.requester_name=MYREQUESTER
...
It's been more than a day since you last ran a job with MYREQUESTER, checking for outstanding tasks...
That took a while! You may want to run `mephisto scripts cleanup mturk` later to clear out some of the older HIT types.

The requester MYREQUESTER has 2 outstanding HIT types, with 100 suspected active or broken HITs.
This may include tasks that are still in-flight, but also tasks have been improperly shut down and need cleanup.
 Please review and dispose HITs below.
HIT TITLE: ONE OF MY TASKS
LAUNCH TIME: 10/12/2022, 17:24:34
HIT COUNT: 20
Should we cleanup this hit type? (y)es or (n)o: 
>> n
HIT TITLE: ANOTHER ONE OF MY TASKS
LAUNCH TIME: 10/12/2022, 17:16:29
HIT COUNT: 80
Should we cleanup this hit type? (y)es or (n)o: 
>> y
Enter anything to confirm removal of the following HITs:
80 hits from 10/12/2022, 17:16:29 for HIT Type: ANOTHER ONE OF MY TASKS
# ctrl C here because I didn't want to remove this
```

**After first run**
```
python static_test_script.py mephisto/provider=mturk mephisto.provider.requester_name=MYREQUESTER
...
This task is going to launch live on mturk, press enter to continue: 
```

# Note

One can disable this functionality until a future date by updating the "last reviewed time" for a given requester to sometime in the future. If it becomes an issue, we will provide an option to `(d)efer` the check, however I think doing this check is important for worker quality.