### PR TITLE
Extending some 1.1 changes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,11 +21,6 @@ jobs:
           node-version: 16.16.0
           cache: yarn
       - uses: actions/setup-python@v2
-      - name: Install Poetry
-        run: |
-
-      - name: Install dependencies
-        run: poetry install --no-interaction
       - name: 🤖 Install Mephisto
         run: |
           cd ../../

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -188,7 +188,7 @@ class TaskRunner(ABC):
             ):
                 if onboarding_agent.get_status() not in AgentState.complete():
                     # Absent agents at this stage should be disconnected
-                    agent.update_status(AgentState.STATUS_DISCONNECT)
+                    onboarding_agent.update_status(AgentState.STATUS_DISCONNECT)
                 self.cleanup_onboarding(onboarding_agent)
             except Exception as e:
                 logger.exception(

--- a/mephisto/abstractions/_subcomponents/task_runner.py
+++ b/mephisto/abstractions/_subcomponents/task_runner.py
@@ -186,6 +186,9 @@ class TaskRunner(ABC):
                 AgentDisconnectedError,
                 AgentShutdownError,
             ):
+                if onboarding_agent.get_status() not in AgentState.complete():
+                    # Absent agents at this stage should be disconnected
+                    agent.update_status(AgentState.STATUS_DISCONNECT)
                 self.cleanup_onboarding(onboarding_agent)
             except Exception as e:
                 logger.exception(


### PR DESCRIPTION
# Overview
Two changes for the 1.1 release weren't pushed to their full extent. This PR resolves these.

# Details
- Pushes the Poetry installation changes made after switching to 1.2 that were added to the docs test to the actual deploy rule
- Pushes the change for ensuring that returned `Unit`s on MTurk move to the correct disconnected state to `OnboardingAgent`s instead of just regular `Agent`s

# Testing
Automated testing should suffice here.