### PR TITLE
Corrected documentation inconsistencies and typos

### DIFF
--- a/docs/web/docs/guides/how_to_use/worker_quality/using_golds.md
+++ b/docs/web/docs/guides/how_to_use/worker_quality/using_golds.md
@@ -13,7 +13,7 @@ Gold labeling is commonly used for ensuring worker quality over the full duratio
 
 There are a few primary configuration parts for using gold units:
 - Hydra args
-  - `blueprint.gold_qualfification_base`: A string representing the base qualification that required qualifications keeping track of success will be built from.
+  - `blueprint.gold_qualification_base`: A string representing the base qualification that required qualifications keeping track of success will be built from.
   - `blueprint.use_golds`: Set to `True` to enable the feature.
   - `min_golds`: An int for the minimum number of golds a worker needs to complete for the first time before receiving real units.
   - `max_incorrect_golds`: An int for the number of golds a worker can get incorrect before being disqualified from this task.

--- a/docs/web/docs/guides/tutorials/custom_react.md
+++ b/docs/web/docs/guides/tutorials/custom_react.md
@@ -208,8 +208,8 @@ function SimpleFrontend({ taskData, isOnboarding, onSubmit, onError }) {
     <div>
       <Directions>
         Directions: Please rate the below sentence as good or bad.
+        <TellTextIsEdited taskData={taskData} />
       </Directions>
-      <TellTextIsEdited taskData={taskData} />
       ...
 ```
 

--- a/docs/web/docs/guides/tutorials/first_task.md
+++ b/docs/web/docs/guides/tutorials/first_task.md
@@ -231,7 +231,7 @@ mephisto:
 
 Save this configuration file, and you're ready to launch again:
 ```bash
-$ python static_test_script conf=my_config
+$ python static_test_script.py conf=my_config
 ```
 You'll note that Mephisto launches the task under your new task name:
 ```


### PR DESCRIPTION
When going through the process of onboarding to `Mephisto`, I noticed a couple of typos or inconsistencies of the documentation with the pictures provided. This PR fixes the ones that I noticed.