### PR TITLE
Fixed Static task to not explicitly check for `objData.file1`

### DIFF
--- a/mephisto/abstractions/blueprints/static_html_task/source/dev/app.jsx
+++ b/mephisto/abstractions/blueprints/static_html_task/source/dev/app.jsx
@@ -52,7 +52,7 @@ function MainApp() {
     } else {
       formData.append("USED_AGENT_ID", agentId);
 
-      objData.file1.size === 0
+      objData?.file1 === undefined
         ? (objData.file1 = {})
         : (objData.file1 = {
             lastModified: objData.file1.lastModified


### PR DESCRIPTION
I was doing some local development on a static task and for some reason the form wasn't submitting properly. Digging into the modified file, there is an implicit assumption that the user's task will have a file upload form input. Instead of explicitly checking, I changed it to see if `objData.file1` exists before accessing any further properties on that object.