### PR TITLE
Adding missing hook registration for MTurk Sandbox `wrap_crowd_source`

### DIFF
--- a/mephisto/abstractions/providers/mturk_sandbox/wrap_crowd_source.js
+++ b/mephisto/abstractions/providers/mturk_sandbox/wrap_crowd_source.js
@@ -15,6 +15,11 @@ Returning None for the assignment_id means that the task is being
 previewed by the given worker.
 \------------------------------------------*/
 
+// The following is the nanoevents npm library (https://github.com/ai/nanoevents/blob/main/index.js) manually processed as such:
+// 1. transpiled to support more browser targets using the Babel transpiler (https://babeljs.io/repl#?browsers=defaults&build=&builtIns=false&corejs=false&spec=false&loose=false), and
+// 2. minified using a JS minifier (https://www.toptal.com/developers/javascript-minifier)
+var eventEmitter=function(){return{events:{},emit:function(f){for(var b=this.events[f]||[],c=arguments.length,e=new Array(c>1?c-1:0),a=1;a<c;a++)e[a-1]=arguments[a];for(var d=0,g=b.length;d<g;d++)b[d].apply(b,e)},on:function(b,c){var a,d=this;return(null===(a=this.events[b])|| void 0===a?void 0:a.push(c))||(this.events[b]=[c]),function(){var a;d.events[b]=null===(a=d.events[b])|| void 0===a?void 0:a.filter(function(a){return c!==a})}}}}
+
 function getWorkerName() {
   // MTurk worker name is passed via url params
   let urlParams = new URLSearchParams(window.location.search);
@@ -63,6 +68,20 @@ function handleSubmitToProvider(task_data) {
   form.action = urlParams.get("turkSubmitTo") + "/mturk/externalSubmit";
   HTMLFormElement.prototype.submit.call(form);
 }
+
+window._MEPHISTO_CONFIG_ = window._MEPHISTO_CONFIG_ || {};
+window._MEPHISTO_CONFIG_.EVENT_EMITTER = events;
+
+window._MEPHISTO_CONFIG_.get = (property) => {
+  if (!(property in window._MEPHISTO_CONFIG_))
+    throw new Error(`${property} does not exist in window.MEPHISTO_CONFIG`);
+  else return window._MEPHISTO_CONFIG_[property];
+};
+
+window._MEPHISTO_CONFIG_.set = (property, value) => {
+  window._MEPHISTO_CONFIG_[property] = value;
+  events.emit(property, value);
+};
 
 /* === UI error handling code ======= */
 window._MEPHISTO_CONFIG_ = window._MEPHISTO_CONFIG_ || {};


### PR DESCRIPTION
# Summary
As titled, there's a bug introduced in #879 where HTML static code would fail to render entirely on MTurk Sandbox, even if it works fine on local and live.

The immediate fix is to port the code from that PR to the mturk sandbox `wrap_crowd_source.js`, but @pringshia I think there's a need for some of this code (error handling, events) to exist in `mephisto-task` rather than in the crowd-source files.