### PR TITLE
Updated error message to manually delete EC2 server

### DIFF
--- a/mephisto/abstractions/architects/ec2/ec2_architect.py
+++ b/mephisto/abstractions/architects/ec2/ec2_architect.py
@@ -182,7 +182,7 @@ class EC2Architect(Architect):
 
         assert cls.check_domain_unused_locally(
             subdomain=subdomain
-        ), "Given subdomain does exist"
+        ), "Given subdomain does exist. Run `python3 -m mephisto.abstractions.architects.ec2.cleanup_ec2_server_by_name`"
 
         # VALID_INSTANCES = []
         # assert args.architect.instance_type in VALID_INSTANCES


### PR DESCRIPTION
Updated error message to manually delete EC2 server rather than just throwing an AssertionError and not saying how to fix it.