### PR TITLE
InaccessiblePrometheusServer Exception

### DIFF
--- a/mephisto/utils/metrics.py
+++ b/mephisto/utils/metrics.py
@@ -34,6 +34,10 @@ GRAFANA_DIR = os.path.join(METRICS_DIR, "grafana")
 GRAFANA_EXECUTABLE = os.path.join(GRAFANA_DIR, "bin", "grafana-server")
 
 
+class InaccessiblePrometheusServer(Exception):
+    pass
+
+
 def _server_process_running(pid):
     """Check on the existing process id"""
     try:
@@ -148,7 +152,7 @@ def launch_prometheus_server(args: Optional["DictConfig"] = None) -> bool:
                 logger.warning(
                     "Prometheus server appears to be running though! exiting as unsure what to do..."
                 )
-                raise Exception("Prometheus server running but inaccessible")
+                raise InaccessiblePrometheusServer("Prometheus server running but inaccessible")
             else:
                 logger.warning(
                     "Clearing prometheus pid as the server isn't running. "


### PR DESCRIPTION
Defined a new exception to raise when the Prometheus server is inaccessible. This helps with catching this more later for more specific handling and error management. 