### PR TITLE
ec2 architect uninterruptable shutdown

### DIFF
--- a/mephisto/abstractions/architects/ec2/ec2_architect.py
+++ b/mephisto/abstractions/architects/ec2/ec2_architect.py
@@ -7,7 +7,7 @@
 import os
 import sh  # type: ignore
 import shutil
-import time
+import signal
 import requests
 import re
 import json
@@ -360,6 +360,7 @@ class EC2Architect(Architect):
         in the db.
         """
         if self.created:  # only delete the server if it's created by us
+
             def cant_cancel_shutdown(sig, frame):
                 logger.warn(
                     "Ignoring ^C during ec2 cleanup. ^| if you NEED to exit and you will "

--- a/mephisto/abstractions/architects/ec2/ec2_architect.py
+++ b/mephisto/abstractions/architects/ec2/ec2_architect.py
@@ -360,4 +360,12 @@ class EC2Architect(Architect):
         in the db.
         """
         if self.created:  # only delete the server if it's created by us
+            def cant_cancel_shutdown(sig, frame):
+                logger.warn(
+                    "Ignoring ^C during ec2 cleanup. ^| if you NEED to exit and you will "
+                    "have to clean up this server with cleanup_ec2_server_by_name.py after."
+                )
+
+            old_handler = signal.signal(signal.SIGINT, cant_cancel_shutdown)
             self.__delete_ec2_server()
+            signal.signal(signal.SIGINT, old_handler)

--- a/mephisto/abstractions/architects/ec2/ec2_helpers.py
+++ b/mephisto/abstractions/architects/ec2/ec2_helpers.py
@@ -969,7 +969,7 @@ def deploy_fallback_server(
             env=dict(os.environ, SSH_AUTH_SOCK=""),
         )
         detete_instance_address(session, allocation_id, association_id)
-    except Exception as e:
+    except (Exception, KeyboardInterrupt) as e:
         old_handler = signal.signal(signal.SIGINT, cant_cancel_shutdown)
         detete_instance_address(session, allocation_id, association_id)
         signal.signal(signal.SIGINT, old_handler)
@@ -1020,7 +1020,7 @@ def deploy_to_routing_server(
         )
         detete_instance_address(session, allocation_id, association_id)
         print("Server setup complete!")
-    except Exception as e:
+    except (Exception, KeyboardInterrupt) as e:
         old_handler = signal.signal(signal.SIGINT, cant_cancel_shutdown)
         detete_instance_address(session, allocation_id, association_id)
         signal.signal(signal.SIGINT, old_handler)


### PR DESCRIPTION
As titled. Currently the ec2 architect shutdown can be interrupted, which may leave the final state incorrect and leave orphan servers. This interrupt block resolves the issue