### PR TITLE
Permissive socket upload

### DIFF
--- a/mephisto/abstractions/architects/ec2/run_scripts/node/init_server.sh
+++ b/mephisto/abstractions/architects/ec2/run_scripts/node/init_server.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 echo "Installing basic requirements..."
-sudo yum update -y >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
+# Following is commented out until the aws linux2 repo is no longer lagging
+# sudo yum update -y >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
 sudo yum install -y httpd >> /home/ec2-user/routing_server/setup/setup_log.txt 2>&1
 
 echo "Downloading Node..."


### PR DESCRIPTION
# Overview
Based on a followup issue caused by the Amazon Linux 2 repo server issues we've had lately (#1023 current bandage), we've found that our `WebsocketChannel` server fails pretty reliably when we run into a handshake failure during initialization. This PR adds retriability for the initial handshake, as the server may still just be warming up.