### PR TITLE
Upgrading codecov version

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pytest -v -m "not req_creds" --cov --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ mdutils = "^1.4.0"
 pdoc = "^10.0.3"
 pylint = "^2.4"
 pytest = "^5.0"
-pytest-cov = "^2.10.1"
+pytest-cov = "^4.1.0"
 mypy = "^0.971.0"
 
 


### PR DESCRIPTION
As title, v4 is no longer available, and was leading to our test failures.