### PR TITLE
Adding auth implementation of prolific client

### DIFF
--- a/mephisto/abstractions/providers/prolific/api/__init__.py
+++ b/mephisto/abstractions/providers/prolific/api/__init__.py
@@ -6,6 +6,7 @@
 
 from .bonuses import Bonuses
 from .eligibility_requirements import EligibilityRequirements
+from .invitations import Invitations
 from .messages import Messages
 from .participant_groups import ParticipantGroups
 from .projects import Projects

--- a/mephisto/abstractions/providers/prolific/api/client.py
+++ b/mephisto/abstractions/providers/prolific/api/client.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Type, TypeVar, cast
+
+from .base_api_resource import BaseAPIResource
+from .bonuses import Bonuses as _Bonuses
+from .eligibility_requirements import (
+    EligibilityRequirements as _EligibilityRequirements,
+)
+from .invitations import Invitations as _Invitations
+from .messages import Messages as _Messages
+from .participant_groups import ParticipantGroups as _ParticipantGroups
+from .projects import Projects as _Projects
+from .studies import Studies as _Studies
+from .submissions import Submissions as _Submissions
+from .users import Users as _Users
+from .workspaces import Workspaces as _Workspaces
+
+T = TypeVar("T")
+
+
+def wrap_class(target_cls: Type[T], api_key: str) -> Type[T]:
+    """
+    Create a wrapper around the given BaseAPIResource to have the
+    api_key pre-bound
+    """
+    assert issubclass(target_cls, BaseAPIResource), "Can only wrap BaseAPIResource"
+
+    class Wrapper(target_cls):
+        @classmethod
+        def _base_request(cls, *args, **kwargs):
+            new_args = {k: v for k, v in kwargs.items()}
+            if new_args.get("api_key", None) is None:
+                new_args["api_key"] = api_key
+            return super()._base_request(*args, **new_args)
+
+    return cast(Type[T], Wrapper)
+
+
+class ProlificClient:
+
+    Bonuses: Type[_Bonuses]
+    EligibilityRequirements: Type[_EligibilityRequirements]
+    Invitations: Type[_Invitations]
+    Messages: Type[_Messages]
+    ParticipantGroups: Type[_ParticipantGroups]
+    Projects: Type[_Projects]
+    Studies: Type[_Studies]
+    Submissions: Type[_Submissions]
+    Users: Type[_Users]
+    Workspaces: Type[_Workspaces]
+
+    def __init__(self, api_key: str):
+        """
+        Creates a client that can be used to call all of the
+        prolific data model using the provided key.
+        """
+        self.Bonuses = wrap_class(_Bonuses, api_key)
+        self.EligibilityRequirements = wrap_class(_EligibilityRequirements, api_key)
+        self.Invitations = wrap_class(_Invitations, api_key)
+        self.Messages = wrap_class(_Messages, api_key)
+        self.ParticipantGroups = wrap_class(_ParticipantGroups, api_key)
+        self.Projects = wrap_class(_Projects, api_key)
+        self.Studies = wrap_class(_Studies, api_key)
+        self.Submissions = wrap_class(_Submissions, api_key)
+        self.Users = wrap_class(_Users, api_key)
+        self.Workspaces = wrap_class(_Workspaces, api_key)

--- a/mephisto/abstractions/providers/prolific/api/constants.py
+++ b/mephisto/abstractions/providers/prolific/api/constants.py
@@ -1,102 +1,115 @@
-EMAIL_FORMAT = '^\\S+@\\S+\\.\\S+$'  # Simple email format checking
+EMAIL_FORMAT = "^\\S+@\\S+\\.\\S+$"  # Simple email format checking
 
 
 # --- Studies ---
 
 # HACK: Hardcoded Question IDs (Prolific doesn't have a better way for now)
 # TODO (#1008): Make this dynamic as soon as possible
-ER_AGE_RANGE_QUESTION_ID = '54ac6ea9fdf99b2204feb893'
+ER_AGE_RANGE_QUESTION_ID = "54ac6ea9fdf99b2204feb893"
 
 # https://docs.prolific.co/docs/api-docs/public/#tag/Studies/The-study-object
 # `external_study_url` field
-STUDY_URL_PARTICIPANT_ID_PARAM = 'participant_id'
-STUDY_URL_PARTICIPANT_ID_PARAM_PROLIFIC_VAR = '{{%PROLIFIC_PID%}}'
-STUDY_URL_STUDY_ID_PARAM = 'study_id'
-STUDY_URL_STUDY_ID_PARAM_PROLIFIC_VAR = '{{%STUDY_ID%}}'
-STUDY_URL_SUBMISSION_ID_PARAM = 'submission_id'
-STUDY_URL_SUBMISSION_ID_PARAM_PROLIFIC_VAR = '{{%SESSION_ID%}}'
+STUDY_URL_PARTICIPANT_ID_PARAM = "participant_id"
+STUDY_URL_PARTICIPANT_ID_PARAM_PROLIFIC_VAR = "{{%PROLIFIC_PID%}}"
+STUDY_URL_STUDY_ID_PARAM = "study_id"
+STUDY_URL_STUDY_ID_PARAM_PROLIFIC_VAR = "{{%STUDY_ID%}}"
+STUDY_URL_SUBMISSION_ID_PARAM = "submission_id"
+STUDY_URL_SUBMISSION_ID_PARAM_PROLIFIC_VAR = "{{%SESSION_ID%}}"
 
 
 class ProlificIDOption:
-    NOT_REQUIRED = 'not_required'
-    QUESTION = 'question'
-    URL_PARAMETERS = 'url_parameters'
+    NOT_REQUIRED = "not_required"
+    QUESTION = "question"
+    URL_PARAMETERS = "url_parameters"
 
 
 class StudyAction:
-    AUTOMATICALLY_APPROVE = 'AUTOMATICALLY_APPROVE'
-    MANUALLY_REVIEW = 'MANUALLY_REVIEW'
-    PUBLISH = 'PUBLISH'
-    START = 'START'
-    STOP = 'STOP'
-    UNPUBLISHED = 'UNPUBLISHED'
+    AUTOMATICALLY_APPROVE = "AUTOMATICALLY_APPROVE"
+    MANUALLY_REVIEW = "MANUALLY_REVIEW"
+    PUBLISH = "PUBLISH"
+    START = "START"
+    STOP = "STOP"
+    UNPUBLISHED = "UNPUBLISHED"
 
 
 class StudyStatus:
-    UNPUBLISHED = 'UNPUBLISHED'
-    ACTIVE = 'ACTIVE'
-    SCHEDULED = 'SCHEDULED'
-    PAUSED = 'PAUSED'
-    AWAITING_REVIEW = 'AWAITING REVIEW'
-    COMPLETED = 'COMPLETED'
-    _EXPIRED = 'EXPIRED'  # Pseudo status that we will use in `Study.internal_name` as a hack
+    UNPUBLISHED = "UNPUBLISHED"
+    ACTIVE = "ACTIVE"
+    SCHEDULED = "SCHEDULED"
+    PAUSED = "PAUSED"
+    AWAITING_REVIEW = "AWAITING REVIEW"
+    COMPLETED = "COMPLETED"
+    _EXPIRED = (
+        "EXPIRED"  # Pseudo status that we will use in `Study.internal_name` as a hack
+    )
 
 
 class StudyCompletionOption:
-    CODE = 'code'
-    URL = 'url'
+    CODE = "code"
+    URL = "url"
 
 
 class StudyCodeType:
-    COMPLETED = 'COMPLETED'
-    FAILED_ATTENTION_CHECK = 'FAILED_ATTENTION_CHECK'
-    FOLLOW_UP_STUDY = 'FOLLOW_UP_STUDY'
-    GIVE_BONUS = 'GIVE_BONUS'
-    INCOMPATIBLE_DEVICE = 'INCOMPATIBLE_DEVICE'
-    NO_CONSENT = 'NO_CONSENT'
-    OTHER = 'OTHER'
+    COMPLETED = "COMPLETED"
+    FAILED_ATTENTION_CHECK = "FAILED_ATTENTION_CHECK"
+    FOLLOW_UP_STUDY = "FOLLOW_UP_STUDY"
+    GIVE_BONUS = "GIVE_BONUS"
+    INCOMPATIBLE_DEVICE = "INCOMPATIBLE_DEVICE"
+    NO_CONSENT = "NO_CONSENT"
+    OTHER = "OTHER"
 
 
 # --- Submissions ---
 
 # It must be at least 100 chars long
 DEFAULT_REJECTION_CATEGORY_MESSAGE = (
-    'This is default automatical rejection message '
-    'as Prolific requires some text at least 100 chars long.'
+    "This is default automatical rejection message "
+    "as Prolific requires some text at least 100 chars long."
 )
+
 
 class SubmissionStatus:
     """
     Submission statuses explained
     https://researcher-help.prolific.co/hc/en-gb/articles/360009094114-Submission-statuses-explained
     """
-    RESERVED = 'RESERVED'
-    ACTIVE = 'ACTIVE'
-    TIMED_OUT = 'TIMED-OUT'
-    AWAITING_REVIEW = 'AWAITING REVIEW'
-    APPROVED = 'APPROVED'
-    RETURNED = 'RETURNED'
-    REJECTED = 'REJECTED'
+
+    RESERVED = "RESERVED"
+    ACTIVE = "ACTIVE"
+    TIMED_OUT = "TIMED-OUT"
+    AWAITING_REVIEW = "AWAITING REVIEW"
+    APPROVED = "APPROVED"
+    RETURNED = "RETURNED"
+    REJECTED = "REJECTED"
     # After you approve or reject a submission, it may have the ‘Processing’ status
     # for a short time before showing as ‘Approved’ or ‘Rejected’.
-    PROCESSING = 'PROCESSING'
+    PROCESSING = "PROCESSING"
 
 
 class SubmissionAction:
-    APPROVE = 'APPROVE'
-    REJECT = 'REJECT'
+    APPROVE = "APPROVE"
+    REJECT = "REJECT"
 
 
 class SubmissionRejectionCategory:
-    BAD_CODE = 'BAD_CODE'
-    FAILED_CHECK = 'FAILED_CHECK'
-    FAILED_INSTRUCTIONS = 'FAILED_INSTRUCTIONS'
-    INCOMP_LONGITUDINAL = 'INCOMP_LONGITUDINAL'
-    LOW_EFFORT = 'LOW_EFFORT'
-    MALINGERING = 'MALINGERING'
-    NO_CODE = 'NO_CODE'
-    NO_DATA = 'NO_DATA'
-    OTHER = 'OTHER'
-    TOO_QUICKLY = 'TOO_QUICKLY'
-    TOO_SLOWLY = 'TOO_SLOWLY'
-    UNSUPP_DEVICE = 'UNSUPP_DEVICE'
+    BAD_CODE = "BAD_CODE"
+    FAILED_CHECK = "FAILED_CHECK"
+    FAILED_INSTRUCTIONS = "FAILED_INSTRUCTIONS"
+    INCOMP_LONGITUDINAL = "INCOMP_LONGITUDINAL"
+    LOW_EFFORT = "LOW_EFFORT"
+    MALINGERING = "MALINGERING"
+    NO_CODE = "NO_CODE"
+    NO_DATA = "NO_DATA"
+    OTHER = "OTHER"
+    TOO_QUICKLY = "TOO_QUICKLY"
+    TOO_SLOWLY = "TOO_SLOWLY"
+    UNSUPP_DEVICE = "UNSUPP_DEVICE"
+
+
+# --- Workspaces ---
+
+
+class WorkspaceRole:
+    WORKSPACE_ADMIN = "WORKSPACE_ADMIN"
+    WORKSPACE_COLLABORATOR = "WORKSPACE_COLLABORATOR"
+    PROJECT_EDITOR = "PROJECT_EDITOR"

--- a/mephisto/abstractions/providers/prolific/api/invitations.py
+++ b/mephisto/abstractions/providers/prolific/api/invitations.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from .base_api_resource import BaseAPIResource
+from .constants import WorkspaceRole
+
+from typing import List
+
+
+class Invitations(BaseAPIResource):
+    invitations_api_endpoint = "invitations/"
+
+    @classmethod
+    def create(
+        cls,
+        workspace_id: str,
+        collaborators: List[str],
+        role: str = WorkspaceRole.WORKSPACE_ADMIN,
+    ) -> dict:
+        endpoint = cls.invitations_api_endpoint
+        params = {
+            "association": workspace_id,
+            "emails": collaborators,
+            "role": role,
+        }
+        response_json = cls.post(endpoint, params=params)
+        return response_json

--- a/mephisto/abstractions/providers/prolific/api/workspaces.py
+++ b/mephisto/abstractions/providers/prolific/api/workspaces.py
@@ -12,14 +12,14 @@ from .data_models import WorkspaceBalance
 
 
 class Workspaces(BaseAPIResource):
-    list_api_endpoint = 'workspaces/'
-    retrieve_api_endpoint = 'workspaces/{id}/'
-    get_balance_api_endpoint = 'workspaces/{id}/balance/'
+    list_api_endpoint = "workspaces/"
+    retrieve_api_endpoint = "workspaces/{id}/"
+    get_balance_api_endpoint = "workspaces/{id}/balance/"
 
     @classmethod
     def list(cls) -> List[Workspace]:
         response_json = cls.get(cls.list_api_endpoint)
-        workspaces = [Workspace(**s) for s in response_json['results']]
+        workspaces = [Workspace(**s) for s in response_json["results"]]
         return workspaces
 
     @classmethod
@@ -33,6 +33,18 @@ class Workspaces(BaseAPIResource):
         workspace = Workspace(**data)
         workspace.validate()
         response_json = cls.post(cls.list_api_endpoint, params=workspace.to_dict())
+        return Workspace(**response_json)
+
+    @classmethod
+    def update(cls, new_workspace: Workspace) -> Workspace:
+        endpoint = cls.retrieve_api_endpoint.format(id=new_workspace.id)
+        new_workspace.validate()
+        print(new_workspace.users)
+        params = new_workspace.to_dict()
+        if params["description"] == "":
+            del params["description"]
+        del params["product"]
+        response_json = cls.patch(endpoint, params=new_workspace.to_dict())
         return Workspace(**response_json)
 
     @classmethod

--- a/mephisto/abstractions/providers/prolific/prolific_provider.py
+++ b/mephisto/abstractions/providers/prolific/prolific_provider.py
@@ -18,14 +18,18 @@ from mephisto.abstractions.crowd_provider import ProviderArgs
 from mephisto.abstractions.providers.prolific import prolific_utils
 from mephisto.abstractions.providers.prolific.api.constants import ProlificIDOption
 from mephisto.abstractions.providers.prolific.prolific_agent import ProlificAgent
-from mephisto.abstractions.providers.prolific.prolific_datastore import ProlificDatastore
-from mephisto.abstractions.providers.prolific.prolific_requester import ProlificRequester
+from mephisto.abstractions.providers.prolific.prolific_datastore import (
+    ProlificDatastore,
+)
+from mephisto.abstractions.providers.prolific.prolific_requester import (
+    ProlificRequester,
+)
 from mephisto.abstractions.providers.prolific.prolific_unit import ProlificUnit
 from mephisto.abstractions.providers.prolific.prolific_worker import ProlificWorker
 from mephisto.abstractions.providers.prolific.provider_type import PROVIDER_TYPE
 from mephisto.operations.registry import register_mephisto_abstraction
 from mephisto.utils.logger_core import get_logger
-from . import api as prolific_api
+from .api.client import ProlificClient
 from .api.data_models import Project
 from .api.data_models import Study
 from .api.data_models import Workspace
@@ -42,10 +46,10 @@ if TYPE_CHECKING:
 
 
 DEFAULT_FRAME_HEIGHT = 0
-DEFAULT_PROLIFIC_GROUP_NAME_ALLOW_LIST = 'Allow list'
-DEFAULT_PROLIFIC_GROUP_NAME_BLOCK_LIST = 'Block list'
-DEFAULT_PROLIFIC_PROJECT_NAME = 'Project'
-DEFAULT_PROLIFIC_WORKSPACE_NAME = 'My Workspace'
+DEFAULT_PROLIFIC_GROUP_NAME_ALLOW_LIST = "Allow list"
+DEFAULT_PROLIFIC_GROUP_NAME_BLOCK_LIST = "Block list"
+DEFAULT_PROLIFIC_PROJECT_NAME = "Project"
+DEFAULT_PROLIFIC_WORKSPACE_NAME = "My Workspace"
 
 
 logger = get_logger(name=__name__)
@@ -54,62 +58,63 @@ logger = get_logger(name=__name__)
 @dataclass
 class ProlificProviderArgs(ProviderArgs):
     """Base class for arguments to configure Crowd Providers"""
+
     _provider_type: str = PROVIDER_TYPE
     requester_name: str = PROVIDER_TYPE
     # This link is being collected automatically for EC2 archidect.
     prolific_external_study_url: str = field(
-        default='',
+        default="",
         metadata={
-            'help': (
-                'The external study URL of your study that you want participants to be direct to. '
-                'The URL can be customized to add information to match participants '
-                'in your survey. '
-                'You can add query parameters with the following placeholders. '
-                'Example of a link with params: '
-                'https://example.com?'
-                'participant_id={{%PROLIFIC_PID%}}'
-                '&study_id={{%STUDY_ID%}}'
-                '&submission_id={{%SESSION_ID%}}'
-                'where `prolific_pid`, `study_id`, `submission_id` are params we use on our side, '
-                'and `{{%PROLIFIC_PID%}}`, `{{%STUDY_ID%}}`, `{{%SESSION_ID%}}` are their '
-                'format of template variables they use to replace with their IDs'
+            "help": (
+                "The external study URL of your study that you want participants to be direct to. "
+                "The URL can be customized to add information to match participants "
+                "in your survey. "
+                "You can add query parameters with the following placeholders. "
+                "Example of a link with params: "
+                "https://example.com?"
+                "participant_id={{%PROLIFIC_PID%}}"
+                "&study_id={{%STUDY_ID%}}"
+                "&submission_id={{%SESSION_ID%}}"
+                "where `prolific_pid`, `study_id`, `submission_id` are params we use on our side, "
+                "and `{{%PROLIFIC_PID%}}`, `{{%STUDY_ID%}}`, `{{%SESSION_ID%}}` are their "
+                "format of template variables they use to replace with their IDs"
             ),
         },
     )
     prolific_id_option: str = field(
         default=ProlificIDOption.URL_PARAMETERS,
         metadata={
-            'help': (
+            "help": (
                 'Enum: "question" "url_parameters" "not_required". '
-                'Use \'question\' if you will add a question in your survey or '
-                'experiment asking the participant ID. '
-                'Recommended Use \'url_parameters\' if your survey or experiment can retrieve and '
-                'store those parameters for your analysis.'
-                'Use \'not_required\' if you don\'t need to record them'
+                "Use 'question' if you will add a question in your survey or "
+                "experiment asking the participant ID. "
+                "Recommended Use 'url_parameters' if your survey or experiment can retrieve and "
+                "store those parameters for your analysis."
+                "Use 'not_required' if you don't need to record them"
             ),
         },
     )
     prolific_estimated_completion_time_in_minutes: int = field(
         default=5,
         metadata={
-            'help': (
-                'Estimated duration in minutes of the experiment or survey '
-                '(`estimated_completion_time` in Prolific).'
+            "help": (
+                "Estimated duration in minutes of the experiment or survey "
+                "(`estimated_completion_time` in Prolific)."
             ),
         },
     )
     prolific_total_available_places: int = field(
         default=1,
         metadata={
-            'help': 'How many participants are you looking to recruit.',
+            "help": "How many participants are you looking to recruit.",
         },
     )
     prolific_eligibility_requirements: list = field(
         default=(),
         metadata={
-            'help': (
-                'Eligibility requirements allows you to define '
-                'participants criteria such as age, gender and country. '
+            "help": (
+                "Eligibility requirements allows you to define "
+                "participants criteria such as age, gender and country. "
             ),
         },
     )
@@ -133,6 +138,7 @@ class ProlificProvider(CrowdProvider):
     Prolific implementation of a CrowdProvider that stores everything
     in a local state in the class for use in tests.
     """
+
     UnitClass: ClassVar[Type["Unit"]] = ProlificUnit
 
     RequesterClass: ClassVar[Type["Requester"]] = ProlificRequester
@@ -152,55 +158,65 @@ class ProlificProvider(CrowdProvider):
 
     @property
     def log_prefix(self) -> str:
-        return '[Prolific Provider] '
+        return "[Prolific Provider] "
 
-    def _get_client(self, requester_name: str) -> prolific_api:
+    def _get_client(self, requester_name: str) -> ProlificClient:
         """Get a Prolific client"""
         return self.datastore.get_client_for_requester(requester_name)
 
     def setup_resources_for_task_run(
         self,
-        task_run: 'TaskRun',
-        args: 'DictConfig',
-        shared_state: 'SharedTaskState',
+        task_run: "TaskRun",
+        args: "DictConfig",
+        shared_state: "SharedTaskState",
         server_url: str,
     ) -> None:
-        requester = cast('ProlificRequester', task_run.get_requester())
+        requester = cast("ProlificRequester", task_run.get_requester())
         client = self._get_client(requester.requester_name)
         task_run_id = task_run.db_id
 
         # Set up Task Run config
         config_dir = os.path.join(self.datastore.datastore_root, task_run_id)
 
-        frame_height = task_run.get_blueprint().get_frontend_args().get(
-            'frame_height', DEFAULT_FRAME_HEIGHT,
+        frame_height = (
+            task_run.get_blueprint()
+            .get_frontend_args()
+            .get(
+                "frame_height",
+                DEFAULT_FRAME_HEIGHT,
+            )
         )
 
         # Get Prolific specific data to create a task
-        prolific_workspace: Workspace = prolific_utils.find_or_create_prolific_workspace(
-            client, title=args.provider.prolific_workspace_name,
+        prolific_workspace: Workspace = (
+            prolific_utils.find_or_create_prolific_workspace(
+                client,
+                title=args.provider.prolific_workspace_name,
+            )
         )
         prolific_project: Project = prolific_utils.find_or_create_prolific_project(
-            client, prolific_workspace.id, title=args.provider.prolific_project_name,
+            client,
+            prolific_workspace.id,
+            title=args.provider.prolific_project_name,
         )
 
         # Create Study
-        logger.debug(f'{self.log_prefix}Creating Prolific Study')
+        logger.debug(f"{self.log_prefix}Creating Prolific Study")
         prolific_study: Study = prolific_utils.create_study(
             client,
             task_run_config=args,
             prolific_project_id=prolific_project.id,
         )
         logger.debug(
-            f'{self.log_prefix}'
-            f'Prolific Study has been created successfully with ID: {prolific_study.id}'
+            f"{self.log_prefix}"
+            f"Prolific Study has been created successfully with ID: {prolific_study.id}"
         )
 
         # Publish Prolific Study
-        logger.debug(f'{self.log_prefix}Publishing Prolific Study')
+        logger.debug(f"{self.log_prefix}Publishing Prolific Study")
         prolific_utils.publish_study(client, prolific_study.id)
         logger.debug(
-            f'{self.log_prefix}'
+            f"{self.log_prefix}"
             f'Prolific Study "{prolific_study.id}" has been published successfully with ID'
         )
 
@@ -218,14 +234,17 @@ class ProlificProvider(CrowdProvider):
         self.datastore.new_study(
             prolific_study_id=prolific_study.id,
             study_link=prolific_study.external_study_url,
-            duration_in_seconds=args.provider.prolific_estimated_completion_time_in_minutes * 60,
+            duration_in_seconds=args.provider.prolific_estimated_completion_time_in_minutes
+            * 60,
             run_id=task_run_id,
         )
         logger.debug(
             f'{self.log_prefix}Prolific Study "{prolific_study.id}" has been saved into datastore'
         )
 
-    def cleanup_resources_from_task_run(self, task_run: 'TaskRun', server_url: str) -> None:
+    def cleanup_resources_from_task_run(
+        self, task_run: "TaskRun", server_url: str
+    ) -> None:
         """No cleanup necessary for task type"""
         pass
 
@@ -235,7 +254,7 @@ class ProlificProvider(CrowdProvider):
         Return the path to the `wrap_crowd_source.js` file for this
         provider to be deployed to the server
         """
-        return os.path.join(os.path.dirname(__file__), 'wrap_crowd_source.js')
+        return os.path.join(os.path.dirname(__file__), "wrap_crowd_source.js")
 
     def cleanup_qualification(self, qualification_name: str) -> None:
         """Remove the qualification from Prolific (Participant Group), if it exists"""
@@ -243,12 +262,13 @@ class ProlificProvider(CrowdProvider):
         if mapping is None:
             return None
 
-        requester_id = mapping['requester_id']
+        requester_id = mapping["requester_id"]
         requester = Requester.get(self.db, requester_id)
-        assert isinstance(requester, ProlificRequester), 'Must be an Prolific requester'
+        assert isinstance(requester, ProlificRequester), "Must be an Prolific requester"
         client = requester._get_client(requester.requester_name)
         try:
-            prolific_utils.delete_qualification(client, mapping['prolific_participant_group_id'])
+            prolific_utils.delete_qualification(
+                client, mapping["prolific_participant_group_id"]
+            )
         except ProlificException:
-            logger.exception('Could not delete qualification on Prolific')
-
+            logger.exception("Could not delete qualification on Prolific")


### PR DESCRIPTION
# Overview 
Creates a new `ProlificClient` in the prolific api for two primary purposes:
1. Prevents passing around the `prolific_api` module as if it were a class
2. Allows us to register a client to use with a specific `api_key`, and then make authorized calls directly with `ProlificClient.<>` thereafter.

The implementation is mostly in `prolific/api/client.py`, and involves creating a class that wraps every exposed `BaseAPIResource` such that `_base_request` can be fed the pre-set `api_key` parameter. This also updates `BaseAPIResource._base_request` to take such a parameter in the first place, and edits a number of locations that assume there would only ever be one valid API key stored in a local credential file.

A few other things were changed while I was getting an upcoming script to work.

## Full Changes
Unfortunately `black` kicked in for all the files I've touched, so here are the critical areas:
- Creates `Invitations` API resource for a new endpoint to invite researchers
- Edits `base_api_resource.py`'s `get_prolific_api_key` method to account for multiple stored keys, and `_base_request` to take an api key.
- Creates `ProlificClient` as noted above
- Added `WorkspaceRole` constant for `Invitations` to use
- Adds `update` method for `Workspaces`
- replaces every reference to the `prolific_api` module as a variable or return class with the `ProlificClient` instead. `prolific_api` can still be used in utils, however (as demonstrated by `DEFAULT_CLIENT` considering the API is the same)