### PR TITLE
Changes to `get_status` complexity

### DIFF
--- a/mephisto/abstractions/_subcomponents/agent_state.py
+++ b/mephisto/abstractions/_subcomponents/agent_state.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass, replace
 import time
 import weakref
 import os.path
+from mephisto.data_model.constants.assignment_state import AssignmentState
 
 if TYPE_CHECKING:
     from mephisto.data_model.agent import Agent, OnboardingAgent
@@ -93,6 +94,18 @@ class AgentState(ABC):
             return super().__new__(cls)
 
     @staticmethod
+    def immutable() -> List[str]:
+        """Return all agent statuses that cannot be changed under normal operation"""
+        return [
+            AgentState.STATUS_DISCONNECT,
+            AgentState.STATUS_TIMEOUT,
+            AgentState.STATUS_EXPIRED,
+            AgentState.STATUS_RETURNED,
+            AgentState.STATUS_SOFT_REJECTED,
+            AgentState.STATUS_APPROVED,
+        ]
+
+    @staticmethod
     def complete() -> List[str]:
         """Return all final Agent statuses which will not be updated by the WorkerPool"""
         return [
@@ -125,6 +138,30 @@ class AgentState(ABC):
             AgentState.STATUS_APPROVED,
             AgentState.STATUS_REJECTED,
         ]
+
+    @staticmethod
+    def to_assignment_state(agent_state: str) -> str:
+        """Return corresponding AssignmentState for an AgentState"""
+        AGENT_STATE_TO_ASSIGNMENTS_STATE_MAP = {
+            AgentState.STATUS_NONE: AssignmentState.CREATED,
+            AgentState.STATUS_ACCEPTED: AssignmentState.ASSIGNED,
+            AgentState.STATUS_ONBOARDING: AssignmentState.ASSIGNED,
+            AgentState.STATUS_WAITING: AssignmentState.ASSIGNED,
+            AgentState.STATUS_IN_TASK: AssignmentState.ASSIGNED,
+            AgentState.STATUS_COMPLETED: AssignmentState.COMPLETED,
+            AgentState.STATUS_DISCONNECT: AssignmentState.CREATED,
+            AgentState.STATUS_TIMEOUT: AssignmentState.CREATED,
+            AgentState.STATUS_PARTNER_DISCONNECT: AssignmentState.COMPLETED,
+            AgentState.STATUS_EXPIRED: AssignmentState.EXPIRED,
+            AgentState.STATUS_RETURNED: AssignmentState.CREATED,
+            AgentState.STATUS_SOFT_REJECTED: AssignmentState.SOFT_REJECTED,
+            AgentState.STATUS_APPROVED: AssignmentState.ACCEPTED,
+            AgentState.STATUS_REJECTED: AssignmentState.REJECTED,
+        }
+        assert (
+            agent_state in AGENT_STATE_TO_ASSIGNMENTS_STATE_MAP
+        ), f"Invalid agent state {agent_state} provided, valid: {AGENT_STATE_TO_ASSIGNMENTS_STATE_MAP.keys()}"
+        return AGENT_STATE_TO_ASSIGNMENTS_STATE_MAP[agent_state]
 
     # Implementations of an AgentState must implement the following:
 

--- a/mephisto/abstractions/providers/mturk/mturk_unit.py
+++ b/mephisto/abstractions/providers/mturk/mturk_unit.py
@@ -211,7 +211,7 @@ class MTurkUnit(Unit):
         agent = self.get_assigned_agent()
         if agent is None:
             if self.db_status in AssignmentState.completed():
-                logger.warning(f"Agent for unit {self} is None")
+                logger.warning(f"Agent for completed unit {self} is None")
                 return self.db_status
             else:
                 # Note, we _may_ be able to query the overall HIT Type to see


### PR DESCRIPTION
# Overview

The `get_status` function for `MTurkUnit`s and `MTurkAgent`s has, for a while, been way more obtuse than necessary. We remove the strange situation where `MTurkUnit`s request information from MTurk about `MTurkAgent`s indirectly, then push updates downwards to the  `MTurkAgent`. This is instead replaced by the `MTurkAgent` having more autonomy in updating its status based on the provider, allowing the expected state changes upwards to occur cleanly.

# Testing

Not tested yet