### PR TITLE
Update heroku_architect.py

### DIFF
--- a/mephisto/abstractions/architects/heroku_architect.py
+++ b/mephisto/abstractions/architects/heroku_architect.py
@@ -421,7 +421,10 @@ class HerokuArchitect(Architect):
         domains = subprocess.check_output(
             shlex.split(f"{heroku_executable_path} domains -a {heroku_app_name}")
         ).decode()
-        self.__heroku_app_url = domains.split("\n")[1]
+        possible_domains = domains.split("\n")[1:]
+        while possible_domains[0].strip() == '':
+            possible_domains.pop(0)
+        self.__heroku_app_url = possible_domains[0]
         return "https://{}".format(self.__heroku_app_url)
 
     def __delete_heroku_server(self):


### PR DESCRIPTION
Addressing #1060.

Uses a linear search rather than direct selection to get the first non-empty app name.

cc @gaotianyu1350