### PR TITLE
Laying down basic strokes of standard get_data response

### DIFF
--- a/docs/web/docs/guides/how_to_use/worker_quality/using_screen_units.mdx
+++ b/docs/web/docs/guides/how_to_use/worker_quality/using_screen_units.mdx
@@ -69,7 +69,7 @@ def validate_screening_unit(unit: Unit):
     agent = unit.get_assigned_agent()
     if agent is not None:
         data = agent.state.get_data()
-        annotation = data["final_submission"]["annotations"][0]
+        annotation = data["outputs"]["final_submission"]["annotations"][0]
         if annotation["isCorrect"] and annotation["currentAnnotation"] == 3:
             return True
     return False

--- a/examples/remote_procedure/mnist/webapp/src/components/core_components.jsx
+++ b/examples/remote_procedure/mnist/webapp/src/components/core_components.jsx
@@ -141,7 +141,13 @@ function Instructions({ taskData }) {
   );
 }
 
-function TaskFrontend({ taskData, classifyDigit, handleSubmit }) {
+function TaskFrontend({
+  taskData,
+  finalResults = null,
+  classifyDigit,
+  handleSubmit,
+}) {
+  // TODO Update this file such that, if finalResults contains data we render in review mode with that data
   const NUM_ANNOTATIONS = taskData.isScreeningUnit ? 1 : 3;
   const [annotations, updateAnnotations] = React.useReducer(
     (currentAnnotation, { updateIdx, updatedAnnotation }) => {

--- a/mephisto/abstractions/_subcomponents/agent_state.py
+++ b/mephisto/abstractions/_subcomponents/agent_state.py
@@ -241,6 +241,10 @@ class AgentState(ABC):
     def get_data(self) -> Dict[str, Any]:
         """
         Return the currently stored data for this task
+
+        Data should however always follow the format of having an "inputs" and "outputs"
+        format, wherein "inputs" are whatever data was passed through to initialTaskData
+        and outputs can be whatever the results were.
         """
         raise NotImplementedError()
 

--- a/mephisto/abstractions/blueprints/mock/mock_agent_state.py
+++ b/mephisto/abstractions/blueprints/mock/mock_agent_state.py
@@ -42,7 +42,10 @@ class MockAgentState(AgentState):
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict of this agent's state"""
-        return self.state
+        return {
+            "inputs": self.init_state,
+            "outputs": self.state,
+        }
 
     def _save_data(self) -> None:
         """Mock agents don't save data (yet)"""

--- a/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
+++ b/mephisto/abstractions/blueprints/remote_procedure/remote_procedure_agent_state.py
@@ -64,9 +64,9 @@ class RemoteProcedureAgentState(AgentState):
         agent_file = self._get_expected_data_file()
         if self.agent.db.key_exists(agent_file):
             state = self.agent.db.read_dict(agent_file)
-            self.requests = {x["uuid"]: RemoteRequest(**x) for x in state["requests"]}
-            self.init_data = state["init_data"]
-            self.final_submission = state["final_submission"]
+            self.requests = {x["uuid"]: RemoteRequest(**x) for x in state["outputs"]["requests"]}
+            self.init_data = state["inputs"]
+            self.final_submission = state["outputs"]["final_submission"]
             # Backwards compatibility for times
             if "start_time" in state:
                 self.metadata.task_start = state["start_time"]
@@ -74,10 +74,13 @@ class RemoteProcedureAgentState(AgentState):
 
     def get_data(self) -> Dict[str, Any]:
         """Return dict with the messages of this agent"""
+        # TODO init_data -> inputs, final_submission -> outputs.final_submission, requests -> outputs.requests
         return {
-            "final_submission": self.final_submission,
-            "init_data": self.init_data,
-            "requests": [r.to_dict() for r in self.requests.values()],
+            "inputs": self.init_data,
+            "outputs": {
+                "final_submission": self.final_submission,
+                "requests": [r.to_dict() for r in self.requests.values()],
+            },
             "start_time": self.metadata.task_start,
             "end_time": self.metadata.task_end,
         }


### PR DESCRIPTION
Setting forward the _basic_ idea of what we'll be doing to standardize get_data. In short, we'll always return an `"inputs"` and `"outputs"` field, the former representing the `intialTaskData` value passed to the react `TaskFrontend`, the latter now being the new value we have the review server pass to the `finalResults` field.