### PR TITLE
[WIP] Add unit scheduling strategies

### DIFF
--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -125,6 +125,26 @@ class TaskRunArgs:
             )
         },
     )
+    unit_scheduling_strategy: str = field(
+        default="FIFO",
+        metadata={
+            "help": (
+                "Strategy that determines the scheduling strategy for units."
+                "Can be 'FIFO', 'LIFO' or 'Random'."
+            )
+        }
+    )
+    scheduler_prefer_assigned_assignments: bool = field(
+        default=True,
+        metadata={
+            "help": (
+                "Determines if units in assignments with at least one already"
+                "assigned unit are preferred over all other units. This is"
+                "usefull for concurrent tasks as this leads to shorter wait"
+                "times."
+            )
+        }
+    )
 
     post_install_script: str = field(
         default="",

--- a/mephisto/operations/unit_scheduler.py
+++ b/mephisto/operations/unit_scheduler.py
@@ -1,23 +1,61 @@
 from abc import ABC, abstractmethod
 from mephisto.data_model.task_run import TaskRun
 from random import shuffle
+from mephisto.data_model.constants.assignment_state import AssignmentState
 
 class UnitScheduler(ABC):
-    def __init__(self, task_run: "TaskRun"):
+    def __init__(self, task_run: "TaskRun", prefer_assigned_assignments: bool):
         self.task_run = task_run
+        self.prefer_assigned_assignments = prefer_assigned_assignments
 
-@abstractmethod
-def reserve_unit(self, available_units):
-    """
-    Implementations of this method should choose one of 'available_units'
-    according to their scheduling strategy, reserve it in the task run and return it.
-    If there are no available_units left or none of them can succesfully be reserved
-    this method returns 'None'.
-    """
-    pass
+    def reserve_unit(self, available_units):
+        """
+        This method wraps the internal strategy.
+
+        If 'prefer_assigned_assignments' is False, this method behaves exactly
+        like the internal strategy.
+
+        If 'prefer_assigned_assignments' is True, the scheduler prefers
+        assignments with assigned units over unassigned assignments. This is
+        usefull when dealing with concurrent assignments.
+        """
+        if( not self.prefer_assigned_assignments):
+            return self.reserve_unit(available_units)
+        else:
+            assignments = self.task_run.get_assignments()
+
+            def hasAssignedUnit(assignment):
+                """
+                Returns if a given assignment has assigned units. Note that this
+                is different from 'assignemt.get_status() == assigned' as the
+                get_status() would return launched if the assignment has any
+                unit that is launched but not assigned.
+                """
+                units = assignment.get_units()
+                statuses = set(unit.get_status() for unit in units)
+                return any([s == AssignmentState.ASSIGNED for s in statuses])
+
+            ids_of_assigned_assignments = [assignment.db_id for assignment in assignments if hasAssignedUnit(assignment)]
+            units_in_assigned_assignments = list(filter(lambda unit: unit.assignment_id in ids_of_assigned_assignments, available_units))
+            other_units = list(filter(lambda unit: (not (unit.assignment_id in ids_of_assigned_assignments)), available_units))
+
+            res = self._reserve_unit(units_in_assigned_assignments)
+            if res != None:
+                return res
+            else:
+                return self._reserve_unit(other_units)
+
+    @abstractmethod
+    def _reserve_unit(self,available_units):
+        """
+        Implementations of this method should choose one of 'available_units'
+        according to their scheduling strategy, reserve it in the task run and return it.
+        If there are no available_units left or none of them can succesfully be reserved
+        this method returns 'None'.
+        """
 
 class FIFOUnitScheduler(UnitScheduler):
-    def reserve_unit(self, available_units):
+    def _reserve_unit(self, available_units):
         reserved_unit = None
 
         while len(available_units) > 0 and reserved_unit is None:
@@ -27,7 +65,7 @@ class FIFOUnitScheduler(UnitScheduler):
         return reserved_unit
 
 class LIFOUnitScheduler(UnitScheduler):
-    def reserve_unit(self, available_units):
+    def _reserve_unit(self, available_units):
         reserved_unit = None
 
         while len(available_units) > 0 and reserved_unit is None:
@@ -38,7 +76,7 @@ class LIFOUnitScheduler(UnitScheduler):
 
 
 class RandomUnitScheduler(UnitScheduler):
-    def reserve_unit(self, available_units):
+    def _reserve_unit(self, available_units):
         reserved_unit = None
         shuffle(available_units)
 

--- a/mephisto/operations/unit_scheduler.py
+++ b/mephisto/operations/unit_scheduler.py
@@ -1,0 +1,49 @@
+from abc import ABC, abstractmethod
+from mephisto.data_model.task_run import TaskRun
+from random import shuffle
+
+class UnitScheduler(ABC):
+    def __init__(self, task_run: "TaskRun"):
+        self.task_run = task_run
+
+@abstractmethod
+def reserve_unit(self, available_units):
+    """
+    Implementations of this method should choose one of 'available_units'
+    according to their scheduling strategy, reserve it in the task run and return it.
+    If there are no available_units left or none of them can succesfully be reserved
+    this method returns 'None'.
+    """
+    pass
+
+class FIFOUnitScheduler(UnitScheduler):
+    def reserve_unit(self, available_units):
+        reserved_unit = None
+
+        while len(available_units) > 0 and reserved_unit is None:
+            unit = available_units.pop(0)
+            reserved_unit = self.task_run.reserve_unit(unit)
+
+        return reserved_unit
+
+class LIFOUnitScheduler(UnitScheduler):
+    def reserve_unit(self, available_units):
+        reserved_unit = None
+
+        while len(available_units) > 0 and reserved_unit is None:
+            unit = available_units.pop()
+            reserved_unit = self.task_run.reserve_unit(unit)
+
+        return reserved_unit
+
+
+class RandomUnitScheduler(UnitScheduler):
+    def reserve_unit(self, available_units):
+        reserved_unit = None
+        shuffle(available_units)
+
+        while len(available_units) > 0 and reserved_unit is None:
+            unit = available_units.pop()
+            reserved_unit = self.task_run.reserve_unit(unit)
+
+        return reserved_unit

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -119,7 +119,7 @@ class WorkerPool:
             self._live_run is None
         ), "Cannot associate more than one live run to a worker pool at a time"
         self._live_run = live_run
-        self.unit_scheduler = FIFOUnitScheduler(live_run.task_run)
+        self.unit_scheduler = FIFOUnitScheduler(live_run.task_run, prefer_assigned_assignments=True)
 
     def get_live_run(self) -> "LiveTaskRun":
         """Get the associated live run for this worker pool, asserting it's set"""

--- a/mephisto/operations/worker_pool.py
+++ b/mephisto/operations/worker_pool.py
@@ -24,7 +24,7 @@ from mephisto.operations.task_launcher import (
     GOLD_UNIT_INDEX,
 )
 from mephisto.operations.datatypes import LiveTaskRun, WorkerFailureReasons
-from mephisto.operations.unit_scheduler import FIFOUnitScheduler
+from mephisto.operations.unit_scheduler import FIFOUnitScheduler, LIFOUnitScheduler, RandomUnitScheduler
 
 from typing import Sequence, Dict, Union, Optional, List, Any, TYPE_CHECKING
 
@@ -119,7 +119,18 @@ class WorkerPool:
             self._live_run is None
         ), "Cannot associate more than one live run to a worker pool at a time"
         self._live_run = live_run
-        self.unit_scheduler = FIFOUnitScheduler(live_run.task_run, prefer_assigned_assignments=True)
+        scheduling_strategy = live_run.task_run.args.task.unit_scheduling_strategy
+        prefer_assigned_assignments = live_run.task_run.args.task.scheduler_prefer_assigned_assignments
+
+        if(scheduling_strategy == "FIFO"):
+            self.unit_scheduler = FIFOUnitScheduler(live_run.task_run, prefer_assigned_assignments)
+        elif(scheduling_strategy == "LIFO"):
+            self.unit_scheduler = LIFOUnitScheduler(live_run.task_run, prefer_assigned_assignments)
+        elif(scheduling_strategy == "Random"):
+            self.unit_scheduler = RandomUnitScheduler(live_run.task_run, prefer_assigned_assignments)
+        else:
+            raise "Unknown scheduling strategy"
+
 
     def get_live_run(self) -> "LiveTaskRun":
         """Get the associated live run for this worker pool, asserting it's set"""


### PR DESCRIPTION
It would be nice to be able to select the unit scheduling strategy. Right now one can only manipulate this by changing the order of the assignments data input. This however has some drawbacks:

* It is not possible to schedule on an unit basis. Only the order of whole assignments can be changed.
* It is not possible to change the order after handing the assignment data to mephisto. This is a problem when using the generator pattern. Here the best you can do to get a more random schedule would be to buffer the assignments for a while and then randomize these batches.

Some scheduling strategies that could make sense:

 1. First in first out: this is the one mephisto is using right now
 2. Last in first out: this could be useful when using the generator pattern and generating new assignments based on previously submitted ones
 3. Random: also nice to have if there is some pattern in the order in which the assignments are generated
 4. Round Robin: this could be useful if one fears that not all units might be completed and prefers to have an even distribution of the completed units over the assignments.

I have implemented strategies 1-3 and it seems to work. However I'm unsure about whether my implementation makes sense and haven't written unit tests for them. 

Would greatly appreciate feedback!