### PR TITLE
Prevent oversampling of study submissions by any single worker

### DIFF
--- a/mephisto/abstractions/providers/mturk/mturk_utils.py
+++ b/mephisto/abstractions/providers/mturk/mturk_utils.py
@@ -439,7 +439,8 @@ def create_hit_type(
                 has_locale_qual = True
         locale_requirements += existing_qualifications
 
-    if not has_locale_qual and not client_is_sandbox(client):
+    is_sandbox = client_is_sandbox(client)
+    if not has_locale_qual and not is_sandbox:
         allowed_locales = get_config_arg("mturk", "allowed_locales")
         if allowed_locales is None:
             allowed_locales = [
@@ -457,6 +458,9 @@ def create_hit_type(
                 "ActionsGuarded": "DiscoverPreviewAndAccept",
             }
         )
+
+    if is_sandbox:
+        hit_reward = 0
 
     # Create the HIT type
     response = client.create_hit_type(

--- a/mephisto/abstractions/providers/prolific/api/base_api_resource.py
+++ b/mephisto/abstractions/providers/prolific/api/base_api_resource.py
@@ -99,8 +99,6 @@ class BaseAPIResource(object):
             else:
                 result = response.json()
 
-            logger.debug(f"{log_prefix} Response: {result}")
-
             return result
 
         except ProlificException:

--- a/mephisto/abstractions/providers/prolific/api/participant_groups.py
+++ b/mephisto/abstractions/providers/prolific/api/participant_groups.py
@@ -112,6 +112,7 @@ class ParticipantGroups(BaseAPIResource):
             Participant-Groups/paths/~1api~1v1~1participant-groups~1%7Bid%7D~1participants~1/delete
         """
         from mephisto.utils.logger_core import get_logger
+
         logger = get_logger(name=__name__)
         endpoint = cls.list_participants_for_group_api_endpoint.format(id=id)
         params = dict(participant_ids=participant_ids)

--- a/mephisto/abstractions/providers/prolific/api/participant_groups.py
+++ b/mephisto/abstractions/providers/prolific/api/participant_groups.py
@@ -111,6 +111,8 @@ class ParticipantGroups(BaseAPIResource):
         https://docs.prolific.co/docs/api-docs/public/#tag/
             Participant-Groups/paths/~1api~1v1~1participant-groups~1%7Bid%7D~1participants~1/delete
         """
+        from mephisto.utils.logger_core import get_logger
+        logger = get_logger(name=__name__)
         endpoint = cls.list_participants_for_group_api_endpoint.format(id=id)
         params = dict(participant_ids=participant_ids)
         response_json = cls.delete(endpoint, params=params)

--- a/mephisto/abstractions/providers/prolific/prolific_provider.py
+++ b/mephisto/abstractions/providers/prolific/prolific_provider.py
@@ -174,6 +174,7 @@ class ProlificProvider(CrowdProvider):
         self,
         qualifications: List[QualificationType],
         bloked_participant_ids: List[str],
+        task_run: "TaskRun",
     ) -> List["Worker"]:
         qualified_workers = []
         workers: List[Worker] = self.db.find_workers(provider_type="prolific")
@@ -181,7 +182,9 @@ class ProlificProvider(CrowdProvider):
         available_workers = [w for w in workers if w.worker_name not in bloked_participant_ids]
 
         for worker in available_workers:
-            if worker_is_qualified(worker, qualifications):
+            if worker.can_send_more_submissions_for_task(task_run) and worker_is_qualified(
+                worker, qualifications
+            ):
                 qualified_workers.append(worker)
 
         return qualified_workers
@@ -305,7 +308,11 @@ class ProlificProvider(CrowdProvider):
             prolific_specific_qualifications = new_prolific_specific_qualifications
 
         if qualifications:
-            qualified_workers = self._get_qualified_workers(qualifications, blocked_participant_ids)
+            qualified_workers = self._get_qualified_workers(
+                qualifications,
+                blocked_participant_ids,
+                task_run,
+            )
 
             if qualified_workers:
                 prolific_workers_ids = [w.worker_name for w in qualified_workers]

--- a/mephisto/abstractions/providers/prolific/prolific_provider.py
+++ b/mephisto/abstractions/providers/prolific/prolific_provider.py
@@ -215,8 +215,7 @@ class ProlificProvider(CrowdProvider):
         return prolific_participant_group
 
     def _get_excluded_participant_ids(self, task_run: "TaskRun") -> List[str]:
-        """ Find participant_ids that exceeded `maximum_units_per_worker` cap within this Task
-        """
+        """Find participant_ids that exceeded `maximum_units_per_worker` cap within this Task"""
         task: "Task" = task_run.get_task()
         task_units: List["Unit"] = self.db.find_units(task_id=task.db_id)
 

--- a/mephisto/abstractions/providers/prolific/prolific_provider.py
+++ b/mephisto/abstractions/providers/prolific/prolific_provider.py
@@ -29,6 +29,7 @@ from mephisto.abstractions.providers.prolific.prolific_requester import Prolific
 from mephisto.abstractions.providers.prolific.prolific_unit import ProlificUnit
 from mephisto.abstractions.providers.prolific.prolific_worker import ProlificWorker
 from mephisto.abstractions.providers.prolific.provider_type import PROVIDER_TYPE
+from mephisto.data_model.worker import Worker
 from mephisto.operations.registry import register_mephisto_abstraction
 from mephisto.utils.logger_core import get_logger
 from mephisto.utils.qualifications import QualificationType
@@ -44,13 +45,12 @@ from .api.eligibility_requirement_classes import ParticipantGroupEligibilityRequ
 from .api.exceptions import ProlificException
 
 if TYPE_CHECKING:
+    from mephisto.data_model.task import Task
     from mephisto.data_model.task_run import TaskRun
     from mephisto.data_model.unit import Unit
-    from mephisto.data_model.worker import Worker
     from mephisto.data_model.requester import Requester
     from mephisto.data_model.agent import Agent
     from mephisto.abstractions.blueprint import SharedTaskState
-
 
 DEFAULT_FRAME_HEIGHT = 0
 DEFAULT_PROLIFIC_GROUP_NAME_ALLOW_LIST = "Allow list"
@@ -173,18 +173,16 @@ class ProlificProvider(CrowdProvider):
     def _get_qualified_workers(
         self,
         qualifications: List[QualificationType],
-        bloked_participant_ids: List[str],
+        blocked_participant_ids: List[str],
         task_run: "TaskRun",
     ) -> List["Worker"]:
         qualified_workers = []
         workers: List[Worker] = self.db.find_workers(provider_type="prolific")
         # `worker_name` is Prolific Participant ID in provider-specific datastore
-        available_workers = [w for w in workers if w.worker_name not in bloked_participant_ids]
+        available_workers = [w for w in workers if w.worker_name not in blocked_participant_ids]
 
         for worker in available_workers:
-            if worker.can_send_more_submissions_for_task(task_run) and worker_is_qualified(
-                worker, qualifications
-            ):
+            if worker_is_qualified(worker, qualifications):
                 qualified_workers.append(worker)
 
         return qualified_workers
@@ -215,6 +213,21 @@ class ProlificProvider(CrowdProvider):
             prolific_participant_group_id=prolific_participant_group.id,
         )
         return prolific_participant_group
+
+    def _get_excluded_participant_ids(self, task_run: "TaskRun") -> List[str]:
+        """ Find participant_ids that exceeded `maximum_units_per_worker` cap within this Task
+        """
+        task: "Task" = task_run.get_task()
+        task_units: List["Unit"] = self.db.find_units(task_id=task.db_id)
+
+        excluded_participant_ids: List[str] = []
+        for unit in task_units:
+            if unit.worker_id:
+                worker: "Worker" = Worker.get(self.db, unit.worker_id)
+                if not worker.can_send_more_submissions_for_task(task_run):
+                    excluded_participant_ids.append(worker.worker_name)
+
+        return list(set(excluded_participant_ids))
 
     def setup_resources_for_task_run(
         self,
@@ -264,11 +277,12 @@ class ProlificProvider(CrowdProvider):
             title=args.provider.prolific_project_name,
         )
 
-        blocked_participant_ids = self.datastore.get_bloked_participant_ids()
-
+        blocked_participant_ids: List[str] = self.datastore.get_blocked_participant_ids()
+        excluded_participant_ids: List[str] = self._get_excluded_participant_ids(task_run)
         # If no Mephisto qualifications found,
         # we need to block Mephisto workers on Prolific as well
-        if blocked_participant_ids:
+        participant_ids_to_add_to_block_list = blocked_participant_ids + excluded_participant_ids
+        if participant_ids_to_add_to_block_list:
             new_prolific_specific_qualifications = []
             # Add empty Blacklist in case if there is not in state or config
             blacklist_qualification = DictConfig(
@@ -288,21 +302,21 @@ class ProlificProvider(CrowdProvider):
                     whitelist_qualification = prolific_specific_qualification
                     prev_value = whitelist_qualification["white_list"]
                     whitelist_qualification["white_list"] = [
-                        p for p in prev_value if p not in blocked_participant_ids
+                        p for p in prev_value if p not in participant_ids_to_add_to_block_list
                     ]
                     new_prolific_specific_qualifications.append(whitelist_qualification)
                 elif name == ParticipantGroupEligibilityRequirement.name:
                     # Remove blocked Participat IDs from Participant Group Eligibility Requirement
                     client.ParticipantGroups.remove_participants_from_group(
                         id=prolific_specific_qualification["id"],
-                        participant_ids=blocked_participant_ids,
+                        participant_ids=participant_ids_to_add_to_block_list,
                     )
                 else:
                     new_prolific_specific_qualifications.append(prolific_specific_qualification)
 
             # Set Blacklist Eligibility Requirement
             blacklist_qualification["black_list"] = list(
-                set(blacklist_qualification["black_list"] + blocked_participant_ids)
+                set(blacklist_qualification["black_list"] + participant_ids_to_add_to_block_list)
             )
             new_prolific_specific_qualifications.append(blacklist_qualification)
             prolific_specific_qualifications = new_prolific_specific_qualifications
@@ -310,7 +324,7 @@ class ProlificProvider(CrowdProvider):
         if qualifications:
             qualified_workers = self._get_qualified_workers(
                 qualifications,
-                blocked_participant_ids,
+                participant_ids_to_add_to_block_list,
                 task_run,
             )
 

--- a/mephisto/abstractions/providers/prolific/prolific_utils.py
+++ b/mephisto/abstractions/providers/prolific/prolific_utils.py
@@ -393,6 +393,15 @@ def create_study(
                     ),
                 ],
             ),
+            dict(
+                code=f"{constants.StudyCodeType.OTHER}_{code_suffix}",
+                code_type=constants.StudyCodeType.OTHER,
+                actions=[
+                    dict(
+                        action=constants.StudyAction.MANUALLY_REVIEW,
+                    ),
+                ],
+            ),
         ]
 
     # Task info

--- a/mephisto/abstractions/providers/prolific/prolific_utils.py
+++ b/mephisto/abstractions/providers/prolific/prolific_utils.py
@@ -578,7 +578,10 @@ def remove_worker_qualification(
     *args,
     **kwargs,
 ) -> None:
-    """Remove a qualification for the given worker (remove a worker from a Participant Group)"""
+    """
+    Remove a qualification for the given worker (remove a worker from a Participant Group).
+    NOTE: If a participant is not a member of the group, they will be ignored (from API Docs)
+    """
     try:
         client.ParticipantGroups.remove_participants_from_group(
             id=qualification_id,
@@ -589,6 +592,14 @@ def remove_worker_qualification(
             f'Could not remove worker {worker_id} from a qualification "{qualification_id}"'
         )
         raise
+
+
+def exclude_worker_from_participant_group(
+    client: ProlificClient,
+    worker_id: str,
+    participant_group_id: str,
+):
+    remove_worker_qualification(client, worker_id, participant_group_id)
 
 
 def pay_bonus(

--- a/mephisto/data_model/agent.py
+++ b/mephisto/data_model/agent.py
@@ -537,8 +537,7 @@ class Agent(_AgentBase, MephistoDataModelComponentMixin, metaclass=MephistoDBBac
         unit.worker_id = worker.db_id
         agent._unit = unit
 
-        # In case provider API wasn't responsive, we ensure this submission
-        # doesn't exceed per-worker cap for this Task. Othewrwise don't process submission.
+        # Prevent sending more units to worker if worker exceeded submission cap within this Task
         task_run: "TaskRun" = agent.get_task_run()
         if not worker.can_send_more_submissions_for_task(task_run):
             try:

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -147,6 +147,16 @@ class TaskRunArgs:
         },
     )
 
+    max_submissions_per_worker: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Maximum submissions that a worker can submit on across all "
+                "tasks that share this task_name. (0 is infinite)"
+            )
+        },
+    )
+
     @classmethod
     def get_mock_params(cls) -> str:
         """Returns a param string with default / mock arguments to use for testing"""

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -264,10 +264,14 @@ class TaskRun(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedMeta):
 
         # Cannot pair with self
         units: List["Unit"] = []
-        for unit_set in unit_assigns.values():
-            is_self_set = map(lambda u: u.worker_id == worker.db_id, unit_set)
-            if not any(is_self_set):
-                units += unit_set
+        for unit_list in unit_assigns.values():
+            self_linked_units = [
+                u
+                for u in unit_list
+                if u.worker_id == worker.db_id and u.db_status == AssignmentState.LAUNCHED
+            ]
+            if not self_linked_units:
+                units += unit_list
 
         # Valid units must be launched and must not be special units (negative indices)
         # Can use db_status directly rather than polling in the critical path, as in

--- a/mephisto/data_model/task_run.py
+++ b/mephisto/data_model/task_run.py
@@ -147,16 +147,6 @@ class TaskRunArgs:
         },
     )
 
-    max_submissions_per_worker: Optional[int] = field(
-        default=None,
-        metadata={
-            "help": (
-                "Maximum submissions that a worker can submit on across all "
-                "tasks that share this task_name. (0 is infinite)"
-            )
-        },
-    )
-
     @classmethod
     def get_mock_params(cls) -> str:
         """Returns a param string with default / mock arguments to use for testing"""

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -12,6 +12,8 @@ from mephisto.data_model._db_backed_meta import (
     MephistoDataModelComponentMixin,
 )
 from typing import Any, List, Optional, Mapping, Tuple, Dict, Type, Tuple, TYPE_CHECKING
+
+from mephisto.data_model.constants.assignment_state import AssignmentState
 from mephisto.utils.logger_core import get_logger
 
 logger = get_logger(name=__name__)
@@ -259,6 +261,17 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
         """unblock a blocked worker for the specified reason"""
         raise NotImplementedError()
 
+    def exclude_worker_from_task(
+        self,
+        task_run: Optional["TaskRun"] = None,
+    ) -> Tuple[bool, str]:
+        """
+        Prevent this worker from further participation in current Task.
+        (Note that scope of exclusion is only within the current Task,
+        whereas block lists or altering worker qualifications would affect future Tasks.)
+        """
+        pass
+
     def is_blocked(self, requester: "Requester") -> bool:
         """Determine if a worker is blocked"""
         raise NotImplementedError()
@@ -266,6 +279,25 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
     def is_eligible(self, task_run: "TaskRun") -> bool:
         """Determine if this worker is eligible for the given task run"""
         raise NotImplementedError()
+
+    def can_send_more_submissions_for_task(self, task_run: "TaskRun") -> bool:
+        """Check whether a worker is allowed to send any more submissions within current Task"""
+        max_submissions_per_worker = task_run.args.max_submissions_per_worker
+
+        # By default, worker can send any amount of submissions
+        if max_submissions_per_worker is None:
+            return True
+
+        # Find all completed units byt this worker for current task
+        task_units = self.db.find_units(task_id=task_run.task_id, worker_id=self.db_id)
+        completed_task_units = [
+            u for u in task_units if u.get_status() in AssignmentState.completed()
+        ]
+
+        if len(completed_task_units) >= max_submissions_per_worker:
+            return False
+
+        return True
 
     def register(self, args: Optional[Dict[str, str]] = None) -> None:
         """Register this worker with the crowdprovider, if necessary"""

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -293,8 +293,7 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
         completed_task_units = [
             u for u in task_units if u.get_status() in AssignmentState.completed()
         ]
-
-        if len(completed_task_units) >= maximum_units_per_worker:
+        if len(completed_task_units) >= maximum_units_per_worker - 1:
             return False
 
         return True

--- a/mephisto/data_model/worker.py
+++ b/mephisto/data_model/worker.py
@@ -282,10 +282,10 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
 
     def can_send_more_submissions_for_task(self, task_run: "TaskRun") -> bool:
         """Check whether a worker is allowed to send any more submissions within current Task"""
-        max_submissions_per_worker = task_run.args.max_submissions_per_worker
+        maximum_units_per_worker = task_run.args.task.maximum_units_per_worker
 
         # By default, worker can send any amount of submissions
-        if max_submissions_per_worker is None:
+        if maximum_units_per_worker == 0:
             return True
 
         # Find all completed units byt this worker for current task
@@ -294,7 +294,7 @@ class Worker(MephistoDataModelComponentMixin, metaclass=MephistoDBBackedABCMeta)
             u for u in task_units if u.get_status() in AssignmentState.completed()
         ]
 
-        if len(completed_task_units) >= max_submissions_per_worker:
+        if len(completed_task_units) >= maximum_units_per_worker:
             return False
 
         return True


### PR DESCRIPTION
For some studies (i.e. Tasks spanning multiple TaskRuns) it may be desired to limit number of submissions received from the same worker (for example, to prevent bias in annotation tasks dataset).

The new TaskRunArgs parameter `max_submissions_per_worker` addresses this need.